### PR TITLE
fix(git): make commit view header sticky in history tab

### DIFF
--- a/src/features/git/components/GitDiffSidebar.tsx
+++ b/src/features/git/components/GitDiffSidebar.tsx
@@ -88,7 +88,7 @@ export default function GitDiffSidebar({
 					overflow="hidden"
 				>
 					{selectedCommit ? (
-						<Box flex="1" overflowY="auto">
+						<Box flex="1" display="flex" flexDirection="column" minH="0" overflow="hidden">
 							<HistoryFileList
 								commit={selectedCommit}
 								files={commitFiles}

--- a/src/features/git/components/HistoryFileList.tsx
+++ b/src/features/git/components/HistoryFileList.tsx
@@ -1,4 +1,5 @@
 import {
+	Box,
 	Flex,
 	HStack,
 	IconButton,
@@ -61,7 +62,7 @@ export default function HistoryFileList({
 	if (!commit) return null;
 
 	return (
-		<>
+		<Flex direction="column" flex="1" minH="0" overflow="hidden">
 			<CommitHeader commit={commit} onBack={onBack} />
 			{isLoading ? (
 				<Flex align="center" justify="center" flex="1">
@@ -75,19 +76,21 @@ export default function HistoryFileList({
 				</Flex>
 			) : (
 				<>
-					<Text px="3" py="1" fontSize="xs" color="fg.muted">
+					<Text px="3" py="1" fontSize="xs" color="fg.muted" flexShrink={0}>
 						{m.changedFiles({ count: files.length })}
 					</Text>
-					{files.map((file, i) => (
-						<FileListItem
-							key={file.name + i}
-							file={file}
-							isActive={selectedIndex === i}
-							onClick={() => onFileSelect(i)}
-						/>
-					))}
+					<Box flex="1" overflowY="auto" minH="0">
+						{files.map((file, i) => (
+							<FileListItem
+								key={file.name + i}
+								file={file}
+								isActive={selectedIndex === i}
+								onClick={() => onFileSelect(i)}
+							/>
+						))}
+					</Box>
 				</>
 			)}
-		</>
+		</Flex>
 	);
 }


### PR DESCRIPTION
## Summary
- Made the CommitHeader (back button + commit info) and file count text sticky at the top of the commit view in the History tab
- Only the file change list scrolls now, keeping navigation and context always visible
- Restructured flex layout in `HistoryFileList` and its parent wrapper to separate fixed header from scrollable content

## Test plan
- [ ] Open Git Diff Dialog → History tab
- [ ] Click a commit with many file changes
- [ ] Verify header (back button + commit message/hash) and file count stay pinned at top
- [ ] Verify file list scrolls independently
- [ ] Verify back button still works
- [ ] Verify loading spinner and empty state still center correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved layout and scrolling behavior of the Git history sidebar to provide better organization and visual hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->