### PR TITLE
feat: add full keyboard navigation to git diff dialog

### DIFF
--- a/src/features/git/GitDiffDialog.tsx
+++ b/src/features/git/GitDiffDialog.tsx
@@ -12,10 +12,13 @@ import {
 import type { FileDiffOptions } from "@pierre/diffs";
 import {
 	Activity,
+	type MutableRefObject,
 	Suspense,
 	startTransition,
 	useCallback,
+	useEffect,
 	useMemo,
+	useRef,
 	useState,
 } from "react";
 import { RiGitBranchLine } from "react-icons/ri";
@@ -40,6 +43,10 @@ const shikiThemeMap: Record<TerminalThemeId, string> = {
 	"one-dark": "one-dark-pro",
 	"one-light": "one-light",
 };
+
+function clamp(value: number, min: number, max: number): number {
+	return Math.max(min, Math.min(max, value));
+}
 
 interface GitDiffDialogProps {
 	isOpen: boolean;
@@ -114,6 +121,14 @@ function GitDiffContent({ profileId }: { profileId: string }) {
 		null,
 	);
 	const [selectedCommitFileIndex, setSelectedCommitFileIndex] = useState(0);
+	const [selectedCommitIndex, setSelectedCommitIndex] = useState(0);
+
+	// Refs for item counts — children sync these so the keydown handler can clamp
+	const sidebarRef = useRef<HTMLDivElement>(null);
+	const changesFileCountRef = useRef(0);
+	const commitCountRef = useRef(0);
+	const commitFileCountRef = useRef(0);
+	const commitsRef = useRef<GitCommit[]>([]);
 
 	const options: FileDiffOptions<unknown> = useMemo(
 		() => ({
@@ -132,29 +147,134 @@ function GitDiffContent({ profileId }: { profileId: string }) {
 			setActiveTab(value);
 			setSelectedCommit(null);
 			setSelectedCommitFileIndex(0);
+			setSelectedCommitIndex(0);
 		});
 	}, []);
 
-	const handleCommitSelect = useCallback((commit: GitCommit) => {
-		startTransition(() => {
-			setSelectedCommit(commit);
-			setSelectedCommitFileIndex(0);
-		});
-	}, []);
+	const handleCommitSelect = useCallback(
+		(commit: GitCommit, index: number) => {
+			startTransition(() => {
+				setSelectedCommit(commit);
+				setSelectedCommitFileIndex(0);
+				setSelectedCommitIndex(index);
+			});
+		},
+		[],
+	);
 
 	const handleCommitBack = useCallback(() => {
 		startTransition(() => {
 			setSelectedCommit(null);
 			setSelectedCommitFileIndex(0);
+			// selectedCommitIndex intentionally preserved
 		});
 	}, []);
+
+	// Keyboard navigation
+	const handleSidebarKeyDown = useCallback(
+		(e: React.KeyboardEvent<HTMLDivElement>) => {
+			const key = e.key;
+
+			if (key === "ArrowDown" || key === "ArrowUp") {
+				e.preventDefault();
+				const delta = key === "ArrowDown" ? 1 : -1;
+
+				if (activeTab === "changes") {
+					setSelectedFileIndex((prev) =>
+						clamp(
+							prev + delta,
+							0,
+							changesFileCountRef.current - 1,
+						),
+					);
+				} else if (selectedCommit) {
+					setSelectedCommitFileIndex((prev) =>
+						clamp(
+							prev + delta,
+							0,
+							commitFileCountRef.current - 1,
+						),
+					);
+				} else {
+					setSelectedCommitIndex((prev) =>
+						clamp(prev + delta, 0, commitCountRef.current - 1),
+					);
+				}
+				return;
+			}
+
+			if (
+				key === "Enter" &&
+				activeTab === "history" &&
+				!selectedCommit
+			) {
+				e.preventDefault();
+				const commits = commitsRef.current;
+				if (
+					commits.length > 0 &&
+					selectedCommitIndex < commits.length
+				) {
+					handleCommitSelect(
+						commits[selectedCommitIndex],
+						selectedCommitIndex,
+					);
+				}
+				return;
+			}
+
+			if (activeTab === "history" && selectedCommit) {
+				if (key === "Backspace") {
+					e.preventDefault();
+					handleCommitBack();
+					return;
+				}
+				if (key === "Escape") {
+					e.preventDefault();
+					e.stopPropagation();
+					handleCommitBack();
+					return;
+				}
+			}
+		},
+		[
+			activeTab,
+			selectedCommit,
+			selectedCommitIndex,
+			handleCommitSelect,
+			handleCommitBack,
+		],
+	);
+
+	// Auto-focus sidebar on tab change (also covers initial dialog open)
+	useEffect(() => {
+		const timer = setTimeout(() => {
+			sidebarRef.current?.focus();
+		}, 50);
+		return () => clearTimeout(timer);
+	}, [activeTab]);
+
+	// Re-focus sidebar when returning from commit files to commit list
+	useEffect(() => {
+		if (!selectedCommit) {
+			sidebarRef.current?.focus();
+		}
+	}, [selectedCommit]);
 
 	const isChanges = activeTab === "changes";
 
 	return (
 		<Flex flex="1" overflow="hidden">
 			{/* Sidebar column */}
-			<Flex direction="column" w="320px" flexShrink={0} overflow="hidden">
+			<Flex
+				ref={sidebarRef}
+				direction="column"
+				w="320px"
+				flexShrink={0}
+				overflow="hidden"
+				tabIndex={0}
+				onKeyDown={handleSidebarKeyDown}
+				outline="none"
+			>
 				<Tabs.Root
 					value={activeTab}
 					onValueChange={(e) => handleTabChange(e.value)}
@@ -187,6 +307,7 @@ function GitDiffContent({ profileId }: { profileId: string }) {
 									profileId={profileId}
 									selectedFileIndex={selectedFileIndex}
 									onFileSelect={setSelectedFileIndex}
+									countRef={changesFileCountRef}
 								/>
 							</Suspense>
 						</Box>
@@ -204,6 +325,7 @@ function GitDiffContent({ profileId }: { profileId: string }) {
 								<HistorySidebar
 									profileId={profileId}
 									selectedCommit={selectedCommit}
+									selectedCommitIndex={selectedCommitIndex}
 									selectedCommitFileIndex={
 										selectedCommitFileIndex
 									}
@@ -212,6 +334,9 @@ function GitDiffContent({ profileId }: { profileId: string }) {
 										setSelectedCommitFileIndex
 									}
 									onCommitBack={handleCommitBack}
+									commitCountRef={commitCountRef}
+									commitFileCountRef={commitFileCountRef}
+									commitsRef={commitsRef}
 								/>
 							</Suspense>
 						</Box>
@@ -254,12 +379,15 @@ function ChangesSidebar({
 	profileId,
 	selectedFileIndex,
 	onFileSelect,
+	countRef,
 }: {
 	profileId: string;
 	selectedFileIndex: number;
 	onFileSelect: (index: number) => void;
+	countRef: MutableRefObject<number>;
 }) {
 	const files = useGitDiffFiles(profileId);
+	countRef.current = files.length;
 
 	if (files.length === 0) {
 		return (
@@ -321,19 +449,30 @@ function ChangesDiffPane({
 function HistorySidebar({
 	profileId,
 	selectedCommit,
+	selectedCommitIndex,
 	selectedCommitFileIndex,
 	onCommitSelect,
 	onCommitFileSelect,
 	onCommitBack,
+	commitCountRef,
+	commitFileCountRef,
+	commitsRef,
 }: {
 	profileId: string;
 	selectedCommit: GitCommit | null;
+	selectedCommitIndex: number;
 	selectedCommitFileIndex: number;
-	onCommitSelect: (commit: GitCommit) => void;
+	onCommitSelect: (commit: GitCommit, index: number) => void;
 	onCommitFileSelect: (index: number) => void;
 	onCommitBack: () => void;
+	commitCountRef: MutableRefObject<number>;
+	commitFileCountRef: MutableRefObject<number>;
+	commitsRef: MutableRefObject<GitCommit[]>;
 }) {
 	const { data: logData } = useGitLog(profileId);
+	const commits = logData ?? [];
+	commitsRef.current = commits;
+	commitCountRef.current = commits.length;
 
 	if (selectedCommit) {
 		return (
@@ -350,12 +489,13 @@ function HistorySidebar({
 					selectedCommitFileIndex={selectedCommitFileIndex}
 					onCommitFileSelect={onCommitFileSelect}
 					onCommitBack={onCommitBack}
+					countRef={commitFileCountRef}
 				/>
 			</Box>
 		);
 	}
 
-	if ((logData?.length ?? 0) === 0) {
+	if (commits.length === 0) {
 		return (
 			<Flex align="center" justify="center" flex="1" p="8">
 				<Box color="fg.muted" fontSize="sm">
@@ -366,7 +506,11 @@ function HistorySidebar({
 	}
 
 	return (
-		<CommitList commits={logData ?? []} onCommitSelect={onCommitSelect} />
+		<CommitList
+			commits={commits}
+			selectedIndex={selectedCommitIndex}
+			onCommitSelect={onCommitSelect}
+		/>
 	);
 }
 
@@ -376,14 +520,17 @@ function CommitFileSidebar({
 	selectedCommitFileIndex,
 	onCommitFileSelect,
 	onCommitBack,
+	countRef,
 }: {
 	profileId: string;
 	commit: GitCommit;
 	selectedCommitFileIndex: number;
 	onCommitFileSelect: (index: number) => void;
 	onCommitBack: () => void;
+	countRef: MutableRefObject<number>;
 }) {
 	const files = useCommitDiffFiles(profileId, commit.full_hash);
+	countRef.current = files.length;
 
 	return (
 		<HistoryFileList

--- a/src/features/git/components/ChangesFileList.tsx
+++ b/src/features/git/components/ChangesFileList.tsx
@@ -1,6 +1,6 @@
 import { Badge, HStack, Text } from "@chakra-ui/react";
 import type { FileDiffMetadata } from "@pierre/diffs";
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import * as m from "@/paraglide/messages.js";
 import { changeBadge, getLineStats } from "../utils";
 
@@ -59,20 +59,30 @@ export default function ChangesFileList({
 	selectedIndex,
 	onSelect,
 }: ChangesFileListProps) {
+	const containerRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		const el = containerRef.current?.querySelector(
+			`[data-index="${selectedIndex}"]`,
+		);
+		el?.scrollIntoView({ block: "nearest" });
+	}, [selectedIndex]);
+
 	return (
-		<>
+		<div ref={containerRef}>
 			<Text px="3" py="1" fontSize="xs" color="fg.muted">
 				{m.changedFiles({ count: files.length })}
 			</Text>
 			{files.map((file, i) => (
-				<FileListItem
-					key={file.name + i}
-					file={file}
-					isActive={selectedIndex === i}
-					onClick={() => onSelect(i)}
-				/>
+				<div key={file.name + i} data-index={i}>
+					<FileListItem
+						file={file}
+						isActive={selectedIndex === i}
+						onClick={() => onSelect(i)}
+					/>
+				</div>
 			))}
-		</>
+		</div>
 	);
 }
 

--- a/src/features/git/components/CommitList.tsx
+++ b/src/features/git/components/CommitList.tsx
@@ -1,4 +1,5 @@
 import { Box, HStack, Icon, Text, VStack } from "@chakra-ui/react";
+import { useEffect, useRef } from "react";
 import { RiGitCommitLine } from "react-icons/ri";
 import type { GitCommit } from "@/generated";
 
@@ -22,24 +23,46 @@ function formatRelativeTime(isoDate: string): string {
 
 interface CommitListProps {
 	commits: GitCommit[];
-	onCommitSelect: (commit: GitCommit) => void;
+	selectedIndex: number;
+	onCommitSelect: (commit: GitCommit, index: number) => void;
 }
 
 export default function CommitList({
 	commits,
+	selectedIndex,
 	onCommitSelect,
 }: CommitListProps) {
+	const containerRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		const el = containerRef.current?.querySelector(
+			`[data-index="${selectedIndex}"]`,
+		);
+		el?.scrollIntoView({ block: "nearest" });
+	}, [selectedIndex]);
+
 	return (
-		<Box flex="1" overflowY="auto" minH="0">
-			{commits.map((commit) => (
+		<Box ref={containerRef} flex="1" overflowY="auto" minH="0">
+			{commits.map((commit, index) => (
 				<VStack
 					key={commit.full_hash}
+					data-index={index}
 					align="stretch"
 					px="3"
 					py="1.5"
 					cursor="pointer"
-					_hover={{ bg: "bg.muted" }}
-					onClick={() => onCommitSelect(commit)}
+					bg={
+						selectedIndex === index
+							? "bg.emphasized"
+							: "transparent"
+					}
+					_hover={{
+						bg:
+							selectedIndex === index
+								? "bg.emphasized"
+								: "bg.muted",
+					}}
+					onClick={() => onCommitSelect(commit, index)}
 					gap="0.5"
 					userSelect="none"
 				>

--- a/src/features/git/components/HistoryFileList.tsx
+++ b/src/features/git/components/HistoryFileList.tsx
@@ -1,5 +1,6 @@
 import { Box, Flex, HStack, IconButton, Text, VStack } from "@chakra-ui/react";
 import type { FileDiffMetadata } from "@pierre/diffs";
+import { useEffect, useRef } from "react";
 import { RiArrowLeftLine } from "react-icons/ri";
 import type { GitCommit } from "@/generated";
 import * as m from "@/paraglide/messages.js";
@@ -49,6 +50,15 @@ export default function HistoryFileList({
 	onFileSelect,
 	onBack,
 }: HistoryFileListProps) {
+	const listRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		const el = listRef.current?.querySelector(
+			`[data-index="${selectedIndex}"]`,
+		);
+		el?.scrollIntoView({ block: "nearest" });
+	}, [selectedIndex]);
+
 	return (
 		<Flex direction="column" flex="1" minH="0" overflow="hidden">
 			<CommitHeader commit={commit} onBack={onBack} />
@@ -69,14 +79,15 @@ export default function HistoryFileList({
 					>
 						{m.changedFiles({ count: files.length })}
 					</Text>
-					<Box flex="1" overflowY="auto" minH="0">
+					<Box ref={listRef} flex="1" overflowY="auto" minH="0">
 						{files.map((file, i) => (
-							<FileListItem
-								key={file.name + i}
-								file={file}
-								isActive={selectedIndex === i}
-								onClick={() => onFileSelect(i)}
-							/>
+							<div key={file.name + i} data-index={i}>
+								<FileListItem
+									file={file}
+									isActive={selectedIndex === i}
+									onClick={() => onFileSelect(i)}
+								/>
+							</div>
 						))}
 					</Box>
 				</>


### PR DESCRIPTION
## Summary

- Add Arrow Up/Down navigation for file lists (Changes tab) and commit list (History tab)
- Add Enter key to drill into a selected commit from the commit list
- Add Escape/Backspace to return from commit file view to commit list
- Auto-scroll selected items into view with `scrollIntoView({ block: "nearest" })`
- Auto-focus sidebar on dialog open, tab switch, and when returning from commit files

## Implementation

Single `onKeyDown` handler on the sidebar container (`tabIndex={0}`). Child components sync their item counts into parent refs so the handler can clamp indices without restructuring data flow. Uses `data-index` attributes + `querySelector` for scroll targeting.

| Context | Arrow Up/Down | Enter | Escape | Backspace |
|---|---|---|---|---|
| Changes tab | Move file selection | — | Close dialog | — |
| History → commit list | Move commit highlight | Drill into commit | Close dialog | — |
| History → commit files | Move file selection | — | Back to commits | Back to commits |

## Test plan

- [ ] Open git diff dialog, verify sidebar auto-focuses
- [ ] Changes tab: Arrow Up/Down moves file selection, diff pane updates live
- [ ] History tab: Arrow Up/Down highlights commits, Enter drills in
- [ ] History → commit files: Arrow Up/Down moves file selection, Backspace/Escape returns to commit list
- [ ] Escape on commit list (no commit selected) closes the dialog
- [ ] Tab switching re-focuses sidebar, arrow keys work immediately
- [ ] Mouse clicks still work as before
- [ ] Long lists: selected item scrolls into view

🤖 Generated with [Claude Code](https://claude.com/claude-code)