### PR TITLE
feat(pty): persist terminal output on exit and add quit confirmation dialog

### DIFF
--- a/src-tauri/src/infra/pty.rs
+++ b/src-tauri/src/infra/pty.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::io::Write;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
 
 use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtySize};
 
@@ -14,9 +15,29 @@ pub struct PtySession {
 }
 
 pub type PtySessionMap = Arc<Mutex<HashMap<String, PtySession>>>;
+/// Tracks background PTY read thread handles so they can be joined on exit,
+/// ensuring persistence threads flush their output buffers before the process terminates.
+pub type PtyReadThreads = Arc<Mutex<Vec<JoinHandle<()>>>>;
 
 pub fn create_session_map() -> PtySessionMap {
 	Arc::new(Mutex::new(HashMap::new()))
+}
+
+pub fn create_thread_tracker() -> PtyReadThreads {
+	Arc::new(Mutex::new(Vec::new()))
+}
+
+/// Join all tracked read threads, blocking until they complete.
+/// This ensures each read thread's persistence sub-thread flushes its output buffer.
+pub fn join_all_read_threads(threads: &PtyReadThreads) {
+	let handles: Vec<JoinHandle<()>> = {
+		let Ok(mut guard) = threads.lock() else { return };
+		guard.drain(..).collect()
+	};
+
+	for handle in handles {
+		let _ = handle.join();
+	}
 }
 
 pub fn create_session(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -25,6 +25,8 @@ pub fn run() {
 
 	let sessions = infra::pty::create_session_map();
 	let sessions_for_exit = sessions.clone();
+	let read_threads = infra::pty::create_thread_tracker();
+	let read_threads_for_exit = read_threads.clone();
 	let shutdown_flag = infra::watcher::create_shutdown_flag();
 	let shutdown_for_exit = shutdown_flag.clone();
 
@@ -34,6 +36,7 @@ pub fn run() {
 		.plugin(tauri_plugin_notification::init())
 		.plugin(tauri_plugin_store::Builder::default().build())
 		.manage(sessions)
+		.manage(read_threads)
 		.manage(shutdown_flag)
 		.manage(layer_handle)
 		.setup(|app| {
@@ -85,18 +88,99 @@ pub fn run() {
 		.build(tauri::generate_context!())
 		.expect("error while building tauri application");
 
-	app.run(move |app_handle, event| {
-		use tauri::Manager;
-		if let tauri::RunEvent::Exit = event {
-			// Signal watcher thread to stop
-			shutdown_for_exit.store(true, std::sync::atomic::Ordering::Relaxed);
+	let closing =
+		std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
 
-			// Mark all open sessions as closed in DB
-			if let Some(db) = app_handle.try_state::<infra::db::DbPool>() {
-				service::pty::mark_all_closed(&db);
+	app.run(move |app_handle, event| {
+		use std::sync::atomic::Ordering;
+		use tauri::Manager;
+		use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
+
+		match event {
+			tauri::RunEvent::WindowEvent {
+				event: tauri::WindowEvent::CloseRequested { api, .. },
+				..
+			} => {
+				api.prevent_close();
+
+				// Guard: only show dialog once
+				if closing.swap(true, Ordering::SeqCst) {
+					return;
+				}
+
+				// Start sync NOW: kill PTYs → read threads get EOF → start flushing
+				shutdown_for_exit.store(true, Ordering::Relaxed);
+				infra::pty::close_all_sessions(&sessions_for_exit);
+
+				// Show native confirmation dialog (non-blocking)
+				let handle = app_handle.clone();
+				let closing_cb = closing.clone();
+				app_handle
+					.dialog()
+					.message(
+						"Do you want to quit? Terminal sessions will be saved.",
+					)
+					.title("Quit")
+					.kind(MessageDialogKind::Warning)
+					.buttons(MessageDialogButtons::OkCancelCustom(
+						"Quit".into(),
+						"Cancel".into(),
+					))
+					.show(move |confirmed| {
+						if confirmed {
+							handle.exit(0);
+						} else {
+							closing_cb.store(false, Ordering::SeqCst);
+						}
+					});
 			}
 
-			infra::pty::close_all_sessions(&sessions_for_exit);
+			tauri::RunEvent::ExitRequested { api, .. } => {
+				// If closing=true, this is from our dialog callback's exit(0) → let it through
+				if closing.load(Ordering::SeqCst) {
+					return;
+				}
+
+				api.prevent_exit();
+				closing.store(true, Ordering::SeqCst);
+
+				shutdown_for_exit.store(true, Ordering::Relaxed);
+				infra::pty::close_all_sessions(&sessions_for_exit);
+
+				let handle = app_handle.clone();
+				let closing_cb = closing.clone();
+				app_handle
+					.dialog()
+					.message(
+						"Do you want to quit? Terminal sessions will be saved.",
+					)
+					.title("Quit")
+					.kind(MessageDialogKind::Warning)
+					.buttons(MessageDialogButtons::OkCancelCustom(
+						"Quit".into(),
+						"Cancel".into(),
+					))
+					.show(move |confirmed| {
+						if confirmed {
+							handle.exit(0);
+						} else {
+							closing_cb.store(false, Ordering::SeqCst);
+						}
+					});
+			}
+
+			tauri::RunEvent::Exit => {
+				// Safety net: ensure everything is flushed
+				shutdown_for_exit.store(true, Ordering::Relaxed);
+				infra::pty::close_all_sessions(&sessions_for_exit);
+				infra::pty::join_all_read_threads(&read_threads_for_exit);
+
+				if let Some(db) = app_handle.try_state::<infra::db::DbPool>() {
+					service::pty::mark_all_closed(&db);
+				}
+			}
+
+			_ => {}
 		}
 	});
 }

--- a/src-tauri/src/service/pty.rs
+++ b/src-tauri/src/service/pty.rs
@@ -90,9 +90,19 @@ pub fn create_session(
 	// Spawn a background thread to read PTY output and emit events
 	let id = session_id.clone();
 	let app_handle = app.clone();
-	std::thread::spawn(move || {
+	let handle = std::thread::spawn(move || {
 		read_pty_output(app_handle, id, reader, db);
 	});
+
+	// Track the thread handle so it can be joined on app exit,
+	// ensuring the persistence sub-thread flushes its buffer.
+	if let Some(threads) =
+		app.try_state::<crate::infra::pty::PtyReadThreads>()
+	{
+		if let Ok(mut guard) = threads.lock() {
+			guard.push(handle);
+		}
+	}
 
 	Ok(session_id)
 }


### PR DESCRIPTION
## Summary

- **Fix terminal content restoration**: PTY output was buffered (32KB) but never flushed to SQLite on exit because background threads were killed before they could complete. Now track read thread `JoinHandle`s and join them on exit to ensure persistence buffers are flushed.
- **Add quit confirmation dialog**: Intercept both close button and Cmd+Q with a native system dialog. PTY sessions are killed immediately when the dialog appears, giving background threads time to flush while the user reads the prompt. `RunEvent::Exit` performs a final join as safety net.
- **Re-entrancy guard**: `AtomicBool` flag prevents double-dialog when `exit(0)` re-triggers `ExitRequested`.

## Test plan

- [ ] `cargo test` passes (127 tests)
- [ ] Click close button → native "Quit / Cancel" dialog appears
- [ ] Click "Cancel" → window stays open
- [ ] Click close again → dialog reappears → click "Quit" → app exits
- [ ] Cmd+Q → same dialog behavior
- [ ] Reopen app → terminal tabs restore with previous session content (prompt + command output)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added exit confirmation dialog when closing the app or window.

* **Bug Fixes**
  * Improved cleanup of terminal sessions on app shutdown to prevent data loss.

* **Chores**
  * Enhanced app lifecycle management for more graceful shutdowns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->