### PR TITLE
refactor(agent): remove TurnIndexMap and EVENT_ID_COUNTER global state

### DIFF
--- a/src-tauri/crates/repo/src/agent.rs
+++ b/src-tauri/crates/repo/src/agent.rs
@@ -124,6 +124,23 @@ pub fn next_event_index(
 	Ok(max_index.map(|idx| idx + 1).unwrap_or(0))
 }
 
+/// Get the maximum turn_index for a session.
+/// Returns 0 if no events exist.
+pub fn get_max_turn_index(
+	conn: &mut SqliteConnection,
+	session_id: &str,
+) -> Result<i32, AppError> {
+	use diesel::dsl::max;
+
+	let max_turn: Option<i32> = agent_session_events::table
+		.filter(agent_session_events::session_id.eq(session_id))
+		.select(max(agent_session_events::turn_index))
+		.first(conn)
+		.map_err(|e| AppError::DbError(e.to_string()))?;
+
+	Ok(max_turn.unwrap_or(0))
+}
+
 /// Get a single session by ID.
 pub fn get_session(
 	conn: &mut SqliteConnection,
@@ -430,6 +447,63 @@ mod tests {
 		// Both sessions should still appear (for restoration)
 		let sessions = list_by_project(&mut conn, "proj1").unwrap();
 		assert_eq!(sessions.len(), 2);
+	}
+
+	#[test]
+	fn test_get_max_turn_index_empty() {
+		let mut conn = setup_db();
+		insert_test_project(&mut conn, "proj1");
+		insert_test_profile(&mut conn, "prof1", "proj1");
+
+		let session = NewAgentSession {
+			id: "sess1",
+			agent: "claude",
+			acp_session_id: "acp123",
+			profile_id: "prof1",
+			session_init_json: None,
+		};
+		insert_session(&mut conn, &session).unwrap();
+
+		let max_turn = get_max_turn_index(&mut conn, "sess1").unwrap();
+		assert_eq!(max_turn, 0);
+	}
+
+	#[test]
+	fn test_get_max_turn_index_with_events() {
+		let mut conn = setup_db();
+		insert_test_project(&mut conn, "proj1");
+		insert_test_profile(&mut conn, "prof1", "proj1");
+
+		let session = NewAgentSession {
+			id: "sess1",
+			agent: "claude",
+			acp_session_id: "acp123",
+			profile_id: "prof1",
+			session_init_json: None,
+		};
+		insert_session(&mut conn, &session).unwrap();
+
+		let e1 = NewAgentSessionEvent {
+			id: "evt1",
+			event_index: 0,
+			session_id: "sess1",
+			sender: "user",
+			payload_json: r#"{"text":"hello"}"#,
+			turn_index: 1,
+		};
+		let e2 = NewAgentSessionEvent {
+			id: "evt2",
+			event_index: 1,
+			session_id: "sess1",
+			sender: "agent",
+			payload_json: r#"{"text":"hi"}"#,
+			turn_index: 3,
+		};
+		append_event(&mut conn, &e1).unwrap();
+		append_event(&mut conn, &e2).unwrap();
+
+		let max_turn = get_max_turn_index(&mut conn, "sess1").unwrap();
+		assert_eq!(max_turn, 3);
 	}
 
 	#[test]

--- a/src-tauri/crates/service/src/agent.rs
+++ b/src-tauri/crates/service/src/agent.rs
@@ -1,11 +1,6 @@
 use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-
-/// Global monotonic counter to guarantee unique event IDs even when
-/// multiple events are persisted within the same millisecond.
-static EVENT_ID_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 use agent::{
 	AgentManagerWrapper, AgentProcessLaunchSpec, AgentSessionMap,
@@ -301,10 +296,7 @@ pub fn persist_event(
 ) -> Result<(), AppError> {
 	let mut conn = db.lock().map_err(|_| AppError::LockError)?;
 
-	// Use monotonic counter to guarantee uniqueness even when multiple
-	// events are persisted within the same millisecond (common during streaming).
-	let seq = EVENT_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
-	let event_id = format!("{session_id}-evt-{seq}");
+	let event_id = format!("{session_id}-{event_index}");
 
 	let record = NewAgentSessionEvent {
 		id: &event_id,

--- a/src-tauri/src/handler/agent.rs
+++ b/src-tauri/src/handler/agent.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -14,9 +13,6 @@ use model::agent::{AgentSessionEventRecord, AgentSessionMeta, AgentSessionRecord
 use tauri::{AppHandle, Emitter, State};
 use tokio::time::timeout;
 
-/// Maps session_id to current turn_index counter
-pub type TurnIndexMap = Arc<tokio::sync::Mutex<HashMap<String, Arc<AtomicI32>>>>;
-
 /// Spawn a notification listener task for an agent session.
 /// This reads ACP notifications from the agent process, persists them to DB,
 /// and emits Tauri events to the frontend.
@@ -27,7 +23,6 @@ pub fn spawn_notification_listener(
 	session: Arc<ManagedAgentSession>,
 	app: AppHandle,
 	db: DbPool,
-	turn_index_map: TurnIndexMap,
 	notification_tasks: NotificationTaskMap,
 ) {
 	let notif_id = session_id.clone();
@@ -64,12 +59,14 @@ pub fn spawn_notification_listener(
 				);
 			}
 
-			// Get current turn index
+			// Get current turn index from database
 			let turn_idx = {
-				let map = turn_index_map.lock().await;
-				map.get(&notif_id)
-					.map(|counter| counter.load(Ordering::SeqCst))
-					.unwrap_or(0)
+				if let Ok(mut conn) = db.lock() {
+					repo::agent::get_max_turn_index(&mut conn, &notif_id)
+						.unwrap_or(0)
+				} else {
+					0
+				}
 			};
 
 			// Persist event to database
@@ -146,7 +143,6 @@ pub async fn send_agent_prompt(
 	content: String,
 	app: AppHandle,
 	sessions: State<'_, AgentSessionMap>,
-	turn_index_map: State<'_, TurnIndexMap>,
 	db: State<'_, DbPool>,
 ) -> Result<(), String> {
 	let session = {
@@ -156,22 +152,16 @@ pub async fn send_agent_prompt(
 			.ok_or_else(|| format!("session not found: {session_id}"))?
 	};
 
-	// Increment turn index for this session
-	let turn_idx = {
-		let mut map = turn_index_map.lock().await;
-		let counter = map
-			.entry(session_id.clone())
-			.or_insert_with(|| Arc::new(AtomicI32::new(0)));
-		counter.fetch_add(1, Ordering::SeqCst) + 1
-	};
-
-	// Get next event index
-	let event_idx = {
+	// Get next turn index and event index from database in one lock scope
+	let (turn_idx, event_idx) = {
 		let mut conn = db
 			.lock()
 			.map_err(|_| "Failed to acquire DB lock".to_string())?;
-		repo::agent::next_event_index(&mut conn, &session_id)
-			.map_err(|e| format!("{e}"))?
+		let turn = repo::agent::get_max_turn_index(&mut conn, &session_id)
+			.map_err(|e| format!("{e}"))? + 1;
+		let idx = repo::agent::next_event_index(&mut conn, &session_id)
+			.map_err(|e| format!("{e}"))?;
+		(turn, idx)
 	};
 
 	// Persist user message with turn_index
@@ -240,7 +230,6 @@ pub async fn close_agent_session(
 	session_id: String,
 	sessions: State<'_, AgentSessionMap>,
 	tasks: State<'_, NotificationTaskMap>,
-	turn_index_map: State<'_, TurnIndexMap>,
 	db: State<'_, DbPool>,
 ) -> Result<(), String> {
 	// Abort notification task first — this interrupts stream.next().await
@@ -254,9 +243,8 @@ pub async fn close_agent_session(
 		);
 	}
 
-	// Remove session from runtime map and clean up turn index
+	// Remove session from runtime map
 	let session = sessions.lock().await.remove(&session_id);
-	turn_index_map.lock().await.remove(&session_id);
 
 	// Mark session as destroyed in database (the service call's map-remove
 	// is a no-op here since we already removed the session above)
@@ -311,7 +299,6 @@ pub async fn create_agent_session_persistent(
 	manager: State<'_, Arc<AgentManagerWrapper>>,
 	sessions: State<'_, AgentSessionMap>,
 	tasks: State<'_, NotificationTaskMap>,
-	turn_index_map: State<'_, TurnIndexMap>,
 ) -> Result<AgentSessionInfo, String> {
 	let manager_clone = manager.inner().clone();
 	let db_pool = db.inner().clone();
@@ -348,19 +335,12 @@ pub async fn create_agent_session_persistent(
 	};
 	let info = session.info();
 
-	// Initialize turn index counter for this session
-	{
-		let mut map = turn_index_map.lock().await;
-		map.insert(session_id.clone(), Arc::new(AtomicI32::new(0)));
-	}
-
 	// Spawn notification stream listener (reuses extracted helper)
 	spawn_notification_listener(
 		session_id,
 		session,
 		app,
 		db_pool,
-		turn_index_map.inner().clone(),
 		tasks.inner().clone(),
 	);
 
@@ -380,7 +360,6 @@ pub async fn reconnect_agent_session(
 	manager: State<'_, Arc<AgentManagerWrapper>>,
 	sessions: State<'_, AgentSessionMap>,
 	tasks: State<'_, NotificationTaskMap>,
-	turn_index_map: State<'_, TurnIndexMap>,
 ) -> Result<AgentSessionInfo, String> {
 	let manager_clone = manager.inner().clone();
 	let db_pool = db.inner().clone();
@@ -405,26 +384,12 @@ pub async fn reconnect_agent_session(
 	};
 	let info = session.info();
 
-	// Initialize turn index from existing events
-	{
-		let max_turn = {
-			let mut conn = db.lock().map_err(|_| "Failed to acquire DB lock".to_string())?;
-			repo::agent::get_session_events(&mut conn, &new_session_id)
-				.ok()
-				.and_then(|events| events.iter().map(|e| e.turn_index).max())
-				.unwrap_or(0)
-		};
-		let mut map = turn_index_map.lock().await;
-		map.insert(new_session_id.clone(), Arc::new(AtomicI32::new(max_turn)));
-	}
-
 	// Spawn notification listener
 	spawn_notification_listener(
 		new_session_id,
 		session,
 		app,
 		db_pool,
-		turn_index_map.inner().clone(),
 		tasks.inner().clone(),
 	);
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -34,10 +34,6 @@ pub fn run() {
 		std::sync::Arc::new(tokio::sync::Mutex::new(
 			std::collections::HashMap::new(),
 		));
-	let turn_index_map: handler::agent::TurnIndexMap =
-		std::sync::Arc::new(tokio::sync::Mutex::new(
-			std::collections::HashMap::new(),
-		));
 	let read_threads = infra::pty::create_thread_tracker();
 	let flush_senders = service::pty::create_flush_senders();
 	let shutdown_flag = infra::watcher::create_shutdown_flag();
@@ -63,7 +59,6 @@ pub fn run() {
 		.manage(agent_manager)
 		.manage(agent_sessions)
 		.manage(notification_tasks)
-		.manage(turn_index_map)
 		.setup(|app| {
 			use tauri::Manager;
 			let app_data_dir = app


### PR DESCRIPTION
## Summary
- Remove `TurnIndexMap` (`Arc<Mutex<HashMap<String, Arc<AtomicI32>>>>`) — turn index now derived on-demand via `SELECT MAX(turn_index)` from `agent_session_events`
- Remove `EVENT_ID_COUNTER` (`static AtomicU64`) — event IDs now use deterministic `{session_id}-{event_index}` format instead of a counter that resets on restart
- Add `repo::agent::get_max_turn_index()` query function with unit tests
- Combine turn index + event index queries into a single DB lock scope in `send_agent_prompt`

## Test plan
- [x] `cargo check -p service -p repo -p agent` — compiles with no warnings
- [x] `cargo test -p repo -p service -p infra -p model -p agent` — 196 tests pass
- [x] `cargo test --test integration_agent_db` — 23 integration tests pass
- [ ] Manual: `bun tauri dev` → create agent session → send prompts → verify turn indexing → close → reconnect → verify turns continue

🤖 Generated with [Claude Code](https://claude.com/claude-code)