### PR TITLE
fix(agent): add toast feedback for install/reinstall

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -144,5 +144,7 @@
 	"agentTerminal": "Terminal: {id}",
 	"agentToolOutputAlt": "Tool output",
 	"terminalTabTitle": "Terminal {n}",
-	"agentTabTitle": "{agent} session"
+	"agentTabTitle": "{agent} session",
+	"agentInstallSuccess": "{name} installed successfully",
+	"agentInstallFailed": "Failed to install {name}"
 }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -144,5 +144,7 @@
 	"agentTerminal": "终端：{id}",
 	"agentToolOutputAlt": "工具输出",
 	"terminalTabTitle": "终端 {n}",
-	"agentTabTitle": "{agent} 会话"
+	"agentTabTitle": "{agent} 会话",
+	"agentInstallSuccess": "{name} 安装成功",
+	"agentInstallFailed": "{name} 安装失败"
 }

--- a/src/features/settings/components/AgentCard.tsx
+++ b/src/features/settings/components/AgentCard.tsx
@@ -125,7 +125,12 @@ export function AgentCard({ agent }: AgentCardProps) {
 								size="xs"
 								variant="outline"
 								loading={isPending}
-								onClick={() => install(agent.id)}
+								onClick={() =>
+									install({
+										id: agent.id,
+										displayName: agent.display_name,
+									})
+								}
 							>
 								{agent.acp_installed
 									? m.agentReinstall()

--- a/src/features/settings/hooks/useAgentInstall.ts
+++ b/src/features/settings/hooks/useAgentInstall.ts
@@ -1,18 +1,35 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { installAgent } from "@/generated";
+import * as m from "@/paraglide/messages.js";
 import { queryKeys } from "@/shared/lib/queryKeys";
+import { toaster } from "@/shared/providers/Toaster";
+
+interface InstallAgentParams {
+	id: string;
+	displayName: string;
+}
 
 /**
  * Agent 安装 mutation
- * 安装成功后自动刷新 Agent 状态列表
+ * 安装成功后自动刷新 Agent 状态列表，并显示 toast 反馈
  */
 export function useAgentInstall() {
 	const queryClient = useQueryClient();
 	return useMutation({
-		mutationFn: (agent: string) => installAgent({ agent }),
-		onSuccess: () => {
+		mutationFn: ({ id }: InstallAgentParams) => installAgent({ agent: id }),
+		onSuccess: (_, { displayName }) => {
 			queryClient.invalidateQueries({
 				queryKey: queryKeys.agent.status(),
+			});
+			toaster.success({
+				title: m.agentInstallSuccess({ name: displayName }),
+			});
+		},
+		onError: (error, { displayName }) => {
+			toaster.error({
+				title: m.agentInstallFailed({ name: displayName }),
+				description:
+					error instanceof Error ? error.message : String(error),
 			});
 		},
 	});

--- a/src/shared/providers/Toaster.tsx
+++ b/src/shared/providers/Toaster.tsx
@@ -7,7 +7,7 @@ import {
 	Toast,
 } from "@chakra-ui/react";
 
-const toaster = createToaster({
+export const toaster = createToaster({
 	placement: "bottom-end",
 	pauseOnPageIdle: true,
 });


### PR DESCRIPTION
## Summary
- Export `toaster` from `Toaster.tsx` so mutations can show imperative toasts
- Add `onSuccess` / `onError` toast notifications to `useAgentInstall` with agent display name
- Add i18n messages for both en and zh locales (`agentInstallSuccess`, `agentInstallFailed`)

## Test plan
- [ ] Click "Install" on an agent card → verify success toast with agent name appears
- [ ] Trigger an install failure (e.g. missing native CLI) → verify error toast with description appears
- [ ] Verify button shows loading spinner while install is in progress
- [ ] Switch language to Chinese → verify toast messages render in Chinese

🤖 Generated with [Claude Code](https://claude.com/claude-code)