### PR TITLE
feat(agent): add split button with default agent setting

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -146,5 +146,8 @@
 	"terminalTabTitle": "Terminal {n}",
 	"agentTabTitle": "{agent} session",
 	"agentInstallSuccess": "{name} installed successfully",
-	"agentInstallFailed": "Failed to install {name}"
+	"agentInstallFailed": "Failed to install {name}",
+	"defaultAgent": "Default Agent",
+	"defaultAgentDescription": "Agent used when clicking the quick-create button in the top bar",
+	"defaultAgentNone": "None"
 }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -146,5 +146,8 @@
 	"terminalTabTitle": "终端 {n}",
 	"agentTabTitle": "{agent} 会话",
 	"agentInstallSuccess": "{name} 安装成功",
-	"agentInstallFailed": "{name} 安装失败"
+	"agentInstallFailed": "{name} 安装失败",
+	"defaultAgent": "默认代理",
+	"defaultAgentDescription": "点击顶栏快速创建按钮时使用的代理",
+	"defaultAgentNone": "无"
 }

--- a/src/features/git/AgentMenu.tsx
+++ b/src/features/git/AgentMenu.tsx
@@ -1,8 +1,9 @@
-import { Button, Menu, Portal } from "@chakra-ui/react";
+import { Button, Group, IconButton, Menu, Portal } from "@chakra-ui/react";
 import { SiClaude, SiCursor } from "@icons-pack/react-simple-icons";
 import type { ComponentType } from "react";
-import { RiAddLine, RiRobot2Line } from "react-icons/ri";
+import { RiAddLine, RiArrowDownSLine, RiRobot2Line } from "react-icons/ri";
 import { SiOpenai } from "react-icons/si";
+import { useAgentSettingsStore } from "@/features/settings/stores/agentSettingsStore";
 import type { AgentStatusInfo, Profile } from "@/generated";
 
 const AGENT_ICONS: Record<string, ComponentType<{ size?: number }>> = {
@@ -33,42 +34,100 @@ export default function AgentMenu({
 	isPending,
 	onCreateTab,
 }: AgentMenuProps) {
+	const defaultAgentId = useAgentSettingsStore((s) => s.defaultAgent);
+
 	if (agents.length === 0) return null;
 
+	const defaultAgent = agents.find((a) => a.id === defaultAgentId);
+
+	const createWith = (agentId: string) =>
+		onCreateTab({
+			type: "agent",
+			profileId: profile.id,
+			cwd: profile.worktree_path,
+			agent: agentId,
+		});
+
+	// If no default agent is ready, fall back to dropdown-only
+	if (!defaultAgent) {
+		return (
+			<Menu.Root>
+				<Menu.Trigger asChild>
+					<Button size="xs" variant="subtle" disabled={isPending}>
+						<RiRobot2Line />
+						<RiAddLine />
+					</Button>
+				</Menu.Trigger>
+				<Portal>
+					<Menu.Positioner>
+						<Menu.Content>
+							{agents.map((agent) => {
+								const Icon = getAgentIcon(agent.id);
+								return (
+									<Menu.Item
+										key={agent.id}
+										value={agent.id}
+										onClick={() => createWith(agent.id)}
+									>
+										<Icon size={16} />
+										{agent.display_name}
+									</Menu.Item>
+								);
+							})}
+						</Menu.Content>
+					</Menu.Positioner>
+				</Portal>
+			</Menu.Root>
+		);
+	}
+
+	const DefaultIcon = getAgentIcon(defaultAgent.id);
+	const otherAgents = agents.filter((a) => a.id !== defaultAgentId);
+
 	return (
-		<Menu.Root>
-			<Menu.Trigger asChild>
-				<Button size="xs" variant="subtle" disabled={isPending}>
-					<RiRobot2Line />
-					<RiAddLine />
-				</Button>
-			</Menu.Trigger>
-			<Portal>
-				<Menu.Positioner>
-					<Menu.Content>
-						{agents.map((agent) => {
-							const Icon = getAgentIcon(agent.id);
-							return (
-								<Menu.Item
-									key={agent.id}
-									value={agent.id}
-									onClick={() =>
-										onCreateTab({
-											type: "agent",
-											profileId: profile.id,
-											cwd: profile.worktree_path,
-											agent: agent.id,
-										})
-									}
-								>
-									<Icon size={16} />
-									{agent.display_name}
-								</Menu.Item>
-							);
-						})}
-					</Menu.Content>
-				</Menu.Positioner>
-			</Portal>
-		</Menu.Root>
+		<Group attached>
+			<Button
+				size="xs"
+				variant="subtle"
+				disabled={isPending}
+				onClick={() => createWith(defaultAgent.id)}
+			>
+				<DefaultIcon size={14} />
+				<RiAddLine />
+			</Button>
+			{otherAgents.length > 0 && (
+				<Menu.Root>
+					<Menu.Trigger asChild>
+						<IconButton
+							size="xs"
+							variant="subtle"
+							disabled={isPending}
+							aria-label="Select agent"
+						>
+							<RiArrowDownSLine />
+						</IconButton>
+					</Menu.Trigger>
+					<Portal>
+						<Menu.Positioner>
+							<Menu.Content>
+								{otherAgents.map((agent) => {
+									const Icon = getAgentIcon(agent.id);
+									return (
+										<Menu.Item
+											key={agent.id}
+											value={agent.id}
+											onClick={() => createWith(agent.id)}
+										>
+											<Icon size={16} />
+											{agent.display_name}
+										</Menu.Item>
+									);
+								})}
+							</Menu.Content>
+						</Menu.Positioner>
+					</Portal>
+				</Menu.Root>
+			)}
+		</Group>
 	);
 }

--- a/src/features/settings/AgentSettings.tsx
+++ b/src/features/settings/AgentSettings.tsx
@@ -1,17 +1,35 @@
-import { Stack, Text } from "@chakra-ui/react";
+import {
+	Portal,
+	Select,
+	Stack,
+	Text,
+	createListCollection,
+} from "@chakra-ui/react";
+import { useMemo } from "react";
 import * as m from "@/paraglide/messages.js";
 import { AgentCard } from "./components/AgentCard";
 import { AgentSummaryBar } from "./components/AgentSummaryBar";
 import { CredentialSection } from "./components/CredentialSection";
 import { useAgentStatus, useCredentials } from "./hooks/useAgentData";
+import { useAgentSettingsStore } from "./stores/agentSettingsStore";
 
-/**
- * Agent 设置页面
- * 显示 Agent 状态、凭证检测和安装管理
- */
 export function AgentSettings() {
 	const { data: agents } = useAgentStatus();
 	const { data: credentials } = useCredentials();
+	const defaultAgent = useAgentSettingsStore((s) => s.defaultAgent);
+	const setDefaultAgent = useAgentSettingsStore((s) => s.setDefaultAgent);
+
+	const collection = useMemo(
+		() =>
+			createListCollection({
+				items: agents.map((agent) => ({
+					label: agent.display_name,
+					value: agent.id,
+					disabled: !agent.ready,
+				})),
+			}),
+		[agents],
+	);
 
 	return (
 		<Stack gap="6" maxW="2xl">
@@ -20,6 +38,44 @@ export function AgentSettings() {
 				anthropic={credentials.anthropic}
 				openai={credentials.openai}
 			/>
+
+			<Stack gap="2">
+				<Text fontWeight="semibold" fontSize="sm">
+					{m.defaultAgent()}
+				</Text>
+				<Text fontSize="xs" color="fg.muted">
+					{m.defaultAgentDescription()}
+				</Text>
+				<Select.Root
+					collection={collection}
+					size="sm"
+					maxW="xs"
+					value={[defaultAgent]}
+					onValueChange={(e) => setDefaultAgent(e.value[0])}
+				>
+					<Select.HiddenSelect />
+					<Select.Control>
+						<Select.Trigger>
+							<Select.ValueText placeholder={m.defaultAgentNone()} />
+						</Select.Trigger>
+						<Select.IndicatorGroup>
+							<Select.Indicator />
+						</Select.IndicatorGroup>
+					</Select.Control>
+					<Portal>
+						<Select.Positioner>
+							<Select.Content>
+								{collection.items.map((item) => (
+									<Select.Item item={item} key={item.value}>
+										{item.label}
+										<Select.ItemIndicator />
+									</Select.Item>
+								))}
+							</Select.Content>
+						</Select.Positioner>
+					</Portal>
+				</Select.Root>
+			</Stack>
 
 			<CredentialSection
 				anthropic={credentials.anthropic}

--- a/src/features/settings/stores/agentSettingsStore.ts
+++ b/src/features/settings/stores/agentSettingsStore.ts
@@ -1,0 +1,17 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+interface AgentSettingsStore {
+	defaultAgent: string;
+	setDefaultAgent: (agentId: string) => void;
+}
+
+export const useAgentSettingsStore = create<AgentSettingsStore>()(
+	persist(
+		(set) => ({
+			defaultAgent: "claude",
+			setDefaultAgent: (agentId) => set({ defaultAgent: agentId }),
+		}),
+		{ name: "agent-settings", version: 1 },
+	),
+);


### PR DESCRIPTION
## Summary

- Add a **split button** in the Project Top Bar for quick agent session creation: left side instantly creates a session with the configured default agent, right side dropdown lists other ready agents
- Add a **Default Agent** picker in Settings → Agents tab (persisted via Zustand + localStorage)
- New Zustand store `agentSettingsStore` with `defaultAgent` field (defaults to `claude`)
- Falls back to the original dropdown-only menu if the default agent is not ready/installed

## Test plan

- [ ] Navigate to a project with ready agents — verify split button appears (default agent icon + add icon on left, chevron dropdown on right)
- [ ] Click the left button — should create an agent session with the default agent
- [ ] Click the right dropdown — should list other ready agents
- [ ] Go to Settings → Agents → verify "Default Agent" selector at top
- [ ] Change default agent in settings → verify top bar button updates
- [ ] If default agent is not installed, verify fallback to dropdown-only behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can set a default agent in Settings; selection persists across sessions.
  * Agent menu now shows the default agent as the primary action with a dropdown for other agents.

* **Documentation**
  * Added new localized strings for default agent labels and descriptions (English and Chinese).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->