### PR TITLE
feat(sidebar): expand all project profiles by default

### DIFF
--- a/src/layout/sidebar/ProjectMenuItem.tsx
+++ b/src/layout/sidebar/ProjectMenuItem.tsx
@@ -45,9 +45,9 @@ export function ProjectMenuItem({ project }: { project: ProjectWithProfiles }) {
 	const renameDialog = useDialogState();
 	const deleteDialog = useDialogState();
 
-	// 三态逻辑:用户未操作时跟随激活状态,操作后尊重用户选择
+	// 默认展开,用户手动折叠后尊重用户选择
 	const [userExpanded, setUserExpanded] = useState<boolean | null>(null);
-	const expanded = userExpanded !== null ? userExpanded : isAnyActive;
+	const expanded = userExpanded !== null ? userExpanded : true;
 
 	return (
 		<>


### PR DESCRIPTION
## Summary
- All project profiles/branches in the sidebar are now expanded by default on load
- Users can still manually collapse projects with the chevron button, and that choice is respected
- Clicking a project name continues to navigate directly to its default profile

## Test plan
- [ ] Open the app — all projects in sidebar should show their profiles expanded
- [ ] Manually collapse a project — it stays collapsed
- [ ] Navigate to a profile and reload — profiles should still all be expanded by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Project menu items in the sidebar now default to the expanded state when a user has not previously set a preference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->