### PR TITLE
feat(sidebar): add 2Code branding title

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@emotion/react": "^11.14.0",
+        "@fontsource-variable/bricolage-grotesque": "^5.2.10",
         "@icons-pack/react-simple-icons": "^13.11.2",
         "@pierre/diffs": "^1.0.10",
         "@tanstack/react-query": "^5.90.20",
@@ -278,6 +279,8 @@
     "@floating-ui/dom": ["@floating-ui/dom@1.7.5", "", { "dependencies": { "@floating-ui/core": "^1.7.4", "@floating-ui/utils": "^0.2.10" } }, "sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg=="],
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.10", "", {}, "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="],
+
+    "@fontsource-variable/bricolage-grotesque": ["@fontsource-variable/bricolage-grotesque@5.2.10", "", {}, "sha512-5EDsCqgGpKVcJWE4sg9ydli+t5WM97mISYw5lla/Ev4z71FwXh1oN0YUU8xjkRW9+wBCGD9R+ntAvI8G4bUFJg=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"@dnd-kit/sortable": "^10.0.0",
 		"@dnd-kit/utilities": "^3.2.2",
 		"@emotion/react": "^11.14.0",
+		"@fontsource-variable/bricolage-grotesque": "^5.2.10",
 		"@icons-pack/react-simple-icons": "^13.11.2",
 		"@pierre/diffs": "^1.0.10",
 		"@tanstack/react-query": "^5.90.20",

--- a/src/layout/AppSidebar.tsx
+++ b/src/layout/AppSidebar.tsx
@@ -1,3 +1,4 @@
+import "@fontsource-variable/bricolage-grotesque";
 import { Box, Flex, HStack, IconButton, Text } from "@chakra-ui/react";
 import { useCallback, useRef } from "react";
 import { RiAddLine, RiHome4Line, RiSettings3Line } from "react-icons/ri";
@@ -56,7 +57,26 @@ export default function AppSidebar() {
 			>
 				<Flex direction="column" h="full" pb="3">
 					{/* macOS traffic light area + drag region */}
-					<Box data-tauri-drag-region h="48px" flexShrink={0} />
+					<Flex
+						data-tauri-drag-region
+						h="48px"
+						flexShrink={0}
+						align="center"
+						justify="end"
+						pe="4"
+					>
+						<Text
+							fontFamily="'Bricolage Grotesque Variable', sans-serif"
+							fontSize="sm"
+							fontWeight="700"
+							color="fg.muted"
+							letterSpacing="tight"
+							userSelect="none"
+							pointerEvents="none"
+						>
+							2Code
+						</Text>
+					</Flex>
 					<SidebarLink to="/" icon={<RiHome4Line />}>
 						{m.home()}
 					</SidebarLink>


### PR DESCRIPTION
## Summary
- Add "2Code" branding title at the top of the sidebar using Bricolage Grotesque variable font from fontsource
- Title is right-aligned in the drag region to coexist with macOS traffic lights
- Uses bold weight (700), muted color, and tight letter spacing for a subtle branded look

## Test plan
- [ ] Verify "2Code" title appears at the top-right of the sidebar
- [ ] Verify it doesn't overlap with macOS traffic lights
- [ ] Verify the drag region still works for window dragging
- [ ] Verify Bricolage Grotesque font renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "2Code" branding label to the application header with custom typography styling using the Bricolage Grotesque font.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->