### PR TITLE
feat(topbar): show git diff +/- stats in git diff button

### DIFF
--- a/src/features/git/hooks.ts
+++ b/src/features/git/hooks.ts
@@ -1,5 +1,5 @@
 import { parsePatchFiles } from "@pierre/diffs";
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { getCommitDiff, getGitDiff, getGitLog } from "@/generated";
 import { queryKeys } from "@/shared/lib/queryKeys";
@@ -23,6 +23,24 @@ function useCommitDiff(profileId: string, commitHash: string) {
 		queryKey: queryKeys.git.commitDiff(profileId, commitHash),
 		queryFn: () => getCommitDiff({ profileId, commitHash }),
 	});
+}
+
+export function useGitDiffStats(profileId: string) {
+	const { data: diff } = useQuery({
+		queryKey: queryKeys.git.diff(profileId),
+		queryFn: () => getGitDiff({ profileId }),
+	});
+	return useMemo(() => {
+		if (!diff) return null;
+		let additions = 0;
+		let deletions = 0;
+		for (const line of diff.split("\n")) {
+			if (line.startsWith("+") && !line.startsWith("+++")) additions++;
+			else if (line.startsWith("-") && !line.startsWith("---")) deletions++;
+		}
+		if (additions === 0 && deletions === 0) return null;
+		return { additions, deletions };
+	}, [diff]);
 }
 
 export function useGitDiffFiles(profileId: string) {

--- a/src/features/topbar/controls.tsx
+++ b/src/features/topbar/controls.tsx
@@ -1,4 +1,4 @@
-import { IconButton, Portal, Tooltip } from "@chakra-ui/react";
+import { Button, IconButton, Portal, Text, Tooltip } from "@chakra-ui/react";
 import {
 	SiCursor,
 	SiGit,
@@ -10,6 +10,7 @@ import { Command } from "@tauri-apps/plugin-shell";
 import type { ComponentType } from "react";
 import { Suspense } from "react";
 import GitDiffDialog from "@/features/git/GitDiffDialog";
+import { useGitDiffStats } from "@/features/git/hooks";
 import { useGitBranch } from "@/features/projects/hooks";
 import * as m from "@/paraglide/messages.js";
 import { useDialogState } from "@/shared/hooks/useDialogState";
@@ -116,19 +117,30 @@ function GitDiffBranchDialog({
 
 export function GitDiffControl({ profile }: ControlProps) {
 	const dialog = useDialogState();
+	const stats = useGitDiffStats(profile.id);
 
 	return (
 		<>
 			<Tooltip.Root>
 				<Tooltip.Trigger asChild>
-					<IconButton
+					<Button
 						aria-label={m.topbarGitDiff()}
 						size="xs"
 						variant="subtle"
 						onClick={dialog.onOpen}
 					>
 						<SiGit size={14} />
-					</IconButton>
+						{stats && (
+							<>
+								<Text as="span" color="green.400" fontSize="xs">
+									+{stats.additions}
+								</Text>
+								<Text as="span" color="red.400" fontSize="xs">
+									-{stats.deletions}
+								</Text>
+							</>
+						)}
+					</Button>
 				</Tooltip.Trigger>
 				<Portal>
 					<Tooltip.Positioner>


### PR DESCRIPTION
## Summary

- Added `useGitDiffStats` hook in `features/git/hooks.ts` that shares the same `queryKeys.git.diff(profileId)` cache key as the diff dialog, so stats stay in sync when the dialog refreshes
- Changed `GitDiffControl` from `IconButton` to `Button` to accommodate inline text
- Renders `+N` (green) and `-M` (red) line counts next to the git icon; hidden when there are no changes or data is loading

## Test plan

- [ ] Open a project profile with staged/unstaged changes — button should show `+N -M` counts
- [ ] Open the GitDiff dialog and verify stats match the actual diff
- [ ] Close dialog; counts should remain correct (shared cache)
- [ ] On a clean repo with no changes, button shows only the git icon (no stats)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Git diff statistics now display in the topbar control, showing additions (green) and deletions (red) for quick reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->