### PR TITLE
feat(tabs): restore split panels across restarts + separate tab/session IDs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -25,6 +25,7 @@
         "@xterm/xterm": "^6.0.0",
         "consola": "^3.4.2",
         "immer": "^11.1.4",
+        "nanoid": "^5.1.6",
         "next-themes": "^0.4.6",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -1342,7 +1343,7 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+    "nanoid": ["nanoid@5.1.6", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
@@ -1783,6 +1784,8 @@
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "pnpm-workspace-yaml/yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
+
+    "postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
 		"@xterm/xterm": "^6.0.0",
 		"consola": "^3.4.2",
 		"immer": "^11.1.4",
+		"nanoid": "^5.1.6",
 		"next-themes": "^0.4.6",
 		"react": "^19.1.0",
 		"react-dom": "^19.1.0",

--- a/src/features/agent/AgentChat.tsx
+++ b/src/features/agent/AgentChat.tsx
@@ -46,8 +46,8 @@ function needsReconnection(sessionId: string): boolean {
 
 /**
  * Suspends until reconnection completes.
- * After resolve, reconnect() has already called replaceTab(),
- * so the parent re-renders with the new sessionId and this component unmounts.
+ * After resolve, reconnect() has updated tab.sessionId in the store,
+ * so the parent re-renders this component with the new sessionId prop.
  */
 function AwaitReconnection({ sessionId }: { sessionId: string }) {
 	use(getReconnectPromise(sessionId));

--- a/src/features/tabs/AgentTabSession.ts
+++ b/src/features/tabs/AgentTabSession.ts
@@ -2,6 +2,7 @@ import type { AgentNotification } from "@agentclientprotocol/sdk";
 import consola from "consola";
 import type { UnlistenFn } from "@tauri-apps/api/event";
 import { listen } from "@tauri-apps/api/event";
+import { nanoid } from "nanoid";
 import {
 	closeAgentSession,
 	createAgentSessionPersistent,
@@ -65,8 +66,7 @@ export class AgentTabSession extends TabSession {
 	/**
 	 * Reconnect a restored session on demand (called when tab is focused).
 	 * Spawns the agent process, transfers events, sets up listeners.
-	 * Returns the new session ID (this session object becomes stale — caller
-	 * must replace it in the registry and tab store).
+	 * The tab nanoid id remains stable — only the backend sessionId changes.
 	 */
 	async reconnect(): Promise<AgentTabSession> {
 		if (this._connected || this._reconnecting) {
@@ -79,7 +79,7 @@ export class AgentTabSession extends TabSession {
 				oldSessionId: this.id,
 			});
 
-			// Create new session object with the new ID
+			// Create new session object with the new backend session ID
 			const newSession = new AgentTabSession(
 				info.id,
 				this.profileId,
@@ -100,10 +100,16 @@ export class AgentTabSession extends TabSession {
 			sessionRegistry.delete(this.id);
 			sessionRegistry.set(newSession.id, newSession);
 
-			// Update tab store: replace old tab with new one
-			useTabStore
-				.getState()
-				.replaceTab(this.profileId, this.id, newSession.toTab());
+			// Update the sessionId on the existing tab (nanoid tab id stays stable)
+			const profile = useTabStore.getState().profiles[this.profileId];
+			const agentTab = profile?.tabs.find(
+				(t): t is AgentTab => t.type === "agent" && t.sessionId === this.id,
+			);
+			if (agentTab) {
+				useTabStore
+					.getState()
+					.updateAgentSessionId(this.profileId, agentTab.id, newSession.id);
+			}
 
 			consola.info(
 				`[agent] reconnected ${this.id} → ${info.id}`,
@@ -162,7 +168,8 @@ export class AgentTabSession extends TabSession {
 	toTab(): AgentTab {
 		return {
 			type: "agent",
-			id: this.id,
+			id: nanoid(),
+			sessionId: this.id,
 			title: this.title,
 			agentType: this.agentType,
 		};

--- a/src/features/tabs/TerminalTabSession.ts
+++ b/src/features/tabs/TerminalTabSession.ts
@@ -1,3 +1,4 @@
+import { nanoid } from "nanoid";
 import {
 	closePtySession,
 	createPtySession,
@@ -33,7 +34,7 @@ export class TerminalTabSession extends TabSession {
 	toTab(): TerminalTab {
 		return {
 			type: "terminal",
-			id: this.id,
+			id: nanoid(),
 			title: this.title,
 			panes: [{ sessionId: this.id, title: this.title }],
 			activePaneId: this.id,

--- a/src/features/tabs/hooks.ts
+++ b/src/features/tabs/hooks.ts
@@ -6,6 +6,7 @@ import { clearPending, markPending } from "./pendingDeletions";
 import { sessionRegistry } from "./sessionRegistry";
 import { useTabStore } from "./store";
 import { TerminalTabSession } from "./TerminalTabSession";
+import type { AgentTab } from "./types";
 
 type CreateTabParams =
 	| { type: "terminal"; profileId: string; cwd: string }
@@ -62,12 +63,13 @@ export function useCloseTab() {
 							}
 						}),
 					);
-				} else {
-					// Agent tabs — single session
-					const session = sessionRegistry.get(tabId);
+				} else if (tab?.type === "agent") {
+					// Agent tabs — look up by sessionId, not nanoid tab id
+					const agentTab = tab as AgentTab;
+					const session = sessionRegistry.get(agentTab.sessionId);
 					if (session) {
 						await session.close();
-						sessionRegistry.delete(tabId);
+						sessionRegistry.delete(agentTab.sessionId);
 					}
 				}
 			} finally {

--- a/src/features/tabs/restore.ts
+++ b/src/features/tabs/restore.ts
@@ -1,5 +1,6 @@
 import { QueryObserver } from "@tanstack/react-query";
 import consola from "consola";
+import { nanoid } from "nanoid";
 import type { ProjectWithProfiles } from "@/generated";
 import {
 	listProjectAgentSessions,
@@ -11,7 +12,12 @@ import { queryKeys } from "@/shared/lib/queryKeys";
 import { AgentTabSession } from "./AgentTabSession";
 import { sessionRegistry } from "./sessionRegistry";
 import { useTabStore } from "./store";
+import type { ProfileTabState } from "./store";
 import { TerminalTabSession } from "./TerminalTabSession";
+import type { AgentTab, ProfileTab, TerminalPane } from "./types";
+
+type PtySession = Awaited<ReturnType<typeof listProjectSessions>>[number];
+type AgentSession = Awaited<ReturnType<typeof listProjectAgentSessions>>[number];
 
 /**
  * Module-level restoration promise.
@@ -31,7 +37,7 @@ function createRestorationPipeline(): Promise<void> {
 		observer.subscribe((result) => {
 			if (!result.data) return;
 
-			// Stale profile cleanup
+			// Stale profile cleanup (runs on every emission)
 			const validIds = new Set(
 				result.data.flatMap((p) => p.profiles.map((pr) => pr.id)),
 			);
@@ -52,7 +58,16 @@ function createRestorationPipeline(): Promise<void> {
 
 /**
  * Populate tab store from already-live sessions (backend restored them at startup).
- * Pure reads — no mutations.
+ *
+ * When a persisted layout exists in localStorage (from the previous session), we
+ * use positional matching to map new backend session IDs to the persisted pane
+ * slots, preserving split-pane groupings across restarts.
+ *
+ * Matching algorithm:
+ *   - `sessionOrder` (persisted) holds the original PTY session IDs in creation order.
+ *   - Backend returns new sessions in `created_at ASC` order — the same relative order.
+ *   - Positional map: sessionOrder[i] → newSessions[i]
+ *   - Agent session IDs are stable across restarts (no mapping needed).
  */
 async function populateTabs(projects: ProjectWithProfiles[]) {
 	consola.info(`[tab-restore] populating tabs for ${projects.length} projects`);
@@ -61,35 +76,161 @@ async function populateTabs(projects: ProjectWithProfiles[]) {
 		projects.map(async (p) => ({
 			project: p,
 			ptySessions: await listProjectSessions({ projectId: p.id }),
-			agentSessions: await listProjectAgentSessions({
-				projectId: p.id,
-			}),
+			agentSessions: await listProjectAgentSessions({ projectId: p.id }),
 		})),
 	);
 
-	// PTY sessions: wrap in session objects, add to tab store
+	// Group sessions by profile_id
+	const ptyByProfile = new Map<string, PtySession[]>();
 	for (const { ptySessions } of projectData) {
 		for (const s of ptySessions) {
-			const ts = new TerminalTabSession(s.id, s.profile_id, s.title);
-			sessionRegistry.set(ts.id, ts);
-			useTabStore.getState().addTab(s.profile_id, ts.toTab());
-			consola.info(`[tab-restore] PTY ${s.id}`);
+			const list = ptyByProfile.get(s.profile_id) ?? [];
+			list.push(s);
+			ptyByProfile.set(s.profile_id, list);
 		}
 	}
 
-	// Agent sessions: only create tab entries (no process spawning).
-	// The actual reconnection (spawn + listener) happens lazily on tab focus.
+	const agentByProfile = new Map<string, AgentSession[]>();
 	for (const { agentSessions } of projectData) {
 		for (const r of agentSessions) {
-			const ts = new AgentTabSession(
-				r.id,
-				r.profile_id,
-				`${r.agent} session`,
-				r.agent,
-			);
+			const list = agentByProfile.get(r.profile_id) ?? [];
+			list.push(r);
+			agentByProfile.set(r.profile_id, list);
+		}
+	}
+
+	// Profiles with a persisted layout: restore using positional session matching
+	const persistedProfiles = useTabStore.getState().profiles;
+	const handledProfiles = new Set<string>();
+
+	for (const [profileId, persistedState] of Object.entries(persistedProfiles)) {
+		handledProfiles.add(profileId);
+
+		const newPtySessions = ptyByProfile.get(profileId) ?? [];
+		const newAgentSessions = agentByProfile.get(profileId) ?? [];
+
+		// Build old→new session ID map: positional match using creation order
+		const oldToNew = new Map<string, string>();
+		const matchCount = Math.min(
+			persistedState.sessionOrder.length,
+			newPtySessions.length,
+		);
+		for (let i = 0; i < matchCount; i++) {
+			oldToNew.set(persistedState.sessionOrder[i], newPtySessions[i].id);
+		}
+
+		// Build agent session lookup by stable ID
+		const agentById = new Map(newAgentSessions.map((a) => [a.id, a]));
+
+		// Patch tabs: replace old session IDs with new ones
+		const patchedTabs: ProfileTab[] = [];
+		const newSessionOrder: string[] = [];
+
+		for (const tab of persistedState.tabs) {
+			if (tab.type === "terminal") {
+				const newPanes: TerminalPane[] = tab.panes
+					.map((pane) => {
+						const newId = oldToNew.get(pane.sessionId);
+						if (!newId) return null;
+						return { ...pane, sessionId: newId };
+					})
+					.filter((p): p is TerminalPane => p !== null);
+
+				if (newPanes.length === 0) continue; // all panes lost, drop tab
+
+				const newActivePaneId =
+					oldToNew.get(tab.activePaneId) ?? newPanes[0].sessionId;
+
+				patchedTabs.push({
+					...tab,
+					panes: newPanes,
+					activePaneId: newActivePaneId,
+				});
+				for (const pane of newPanes) {
+					newSessionOrder.push(pane.sessionId);
+				}
+			} else {
+				// Agent tab: match by stable backend session ID
+				if (agentById.has(tab.sessionId)) {
+					patchedTabs.push(tab); // sessionId and nanoid id both preserved
+					agentById.delete(tab.sessionId);
+				}
+				// else: agent session was deleted, drop the tab
+			}
+		}
+
+		// Extra agent sessions not in persisted layout → new tabs
+		for (const [, r] of agentById) {
+			const newTab: AgentTab = {
+				type: "agent",
+				id: nanoid(),
+				sessionId: r.id,
+				title: `${r.agent} session`,
+				agentType: r.agent,
+			};
+			patchedTabs.push(newTab);
+		}
+
+		// Extra PTY sessions not matched to any persisted pane → new single-pane tabs
+		const matchedNewIds = new Set(oldToNew.values());
+		for (const s of newPtySessions) {
+			if (!matchedNewIds.has(s.id)) {
+				patchedTabs.push({
+					type: "terminal",
+					id: nanoid(),
+					title: s.title,
+					panes: [{ sessionId: s.id, title: s.title }],
+					activePaneId: s.id,
+				});
+				newSessionOrder.push(s.id);
+			}
+		}
+
+		// Register all sessions in the registry
+		for (const s of newPtySessions) {
+			const ts = new TerminalTabSession(s.id, s.profile_id, s.title);
+			sessionRegistry.set(ts.id, ts);
+		}
+		for (const r of newAgentSessions) {
+			const ts = new AgentTabSession(r.id, r.profile_id, `${r.agent} session`, r.agent);
+			sessionRegistry.set(ts.id, ts);
+		}
+
+		// Keep persisted activeTabId if the tab still exists, else fall back to first
+		const activeTabId = patchedTabs.some((t) => t.id === persistedState.activeTabId)
+			? persistedState.activeTabId
+			: (patchedTabs[0]?.id ?? null);
+
+		const restoredState: ProfileTabState = {
+			tabs: patchedTabs,
+			activeTabId,
+			counter: persistedState.counter,
+			sessionOrder: newSessionOrder,
+		};
+		useTabStore.getState().restoreProfile(profileId, restoredState);
+
+		consola.info(
+			`[tab-restore] profile ${profileId}: ${patchedTabs.length} tabs restored`,
+		);
+	}
+
+	// Profiles with no persisted layout: fall back to one tab per session (first run)
+	for (const [profileId, sessions] of ptyByProfile) {
+		if (handledProfiles.has(profileId)) continue;
+		for (const s of sessions) {
+			const ts = new TerminalTabSession(s.id, s.profile_id, s.title);
+			sessionRegistry.set(ts.id, ts);
+			useTabStore.getState().addTab(s.profile_id, ts.toTab());
+			consola.info(`[tab-restore] PTY ${s.id} (no persisted layout)`);
+		}
+	}
+	for (const [profileId, sessions] of agentByProfile) {
+		if (handledProfiles.has(profileId)) continue;
+		for (const r of sessions) {
+			const ts = new AgentTabSession(r.id, r.profile_id, `${r.agent} session`, r.agent);
 			sessionRegistry.set(ts.id, ts);
 			useTabStore.getState().addTab(r.profile_id, ts.toTab());
-			consola.info(`[tab-restore] Agent tab ${r.id} (pending reconnect)`);
+			consola.info(`[tab-restore] Agent ${r.id} (no persisted layout)`);
 		}
 	}
 

--- a/src/features/tabs/store.ts
+++ b/src/features/tabs/store.ts
@@ -2,15 +2,21 @@ import { listen } from "@tauri-apps/api/event";
 import { enableMapSet } from "immer";
 import { create } from "zustand";
 import { immer } from "zustand/middleware/immer";
+import { persist } from "zustand/middleware";
 import { useShallow } from "zustand/react/shallow";
 import type { ProfileTab, TerminalPane } from "./types";
 
 enableMapSet();
 
-interface ProfileTabState {
+export interface ProfileTabState {
 	tabs: ProfileTab[];
 	activeTabId: string | null;
 	counter: number;
+	/**
+	 * Ordered list of terminal pane session IDs in creation order.
+	 * Used to positionally match backend-restored sessions to persisted pane slots.
+	 */
+	sessionOrder: string[];
 }
 
 interface TabStore {
@@ -29,179 +35,229 @@ interface TabStore {
 	closePane: (profileId: string, tabId: string, paneSessionId: string) => void;
 	setActivePane: (profileId: string, tabId: string, paneSessionId: string) => void;
 	updatePaneTitle: (profileId: string, tabId: string, paneSessionId: string, title: string) => void;
+	/** Replace the entire state for a profile — used during restoration. */
+	restoreProfile: (profileId: string, profileState: ProfileTabState) => void;
+	/** Update the backend sessionId on an agent tab without changing its nanoid tab id. */
+	updateAgentSessionId: (profileId: string, tabId: string, newSessionId: string) => void;
 }
 
 export const useTabStore = create<TabStore>()(
-	immer((set) => ({
-		profiles: {},
-		notifiedTabs: new Set<string>(),
+	persist(
+		immer((set) => ({
+			profiles: {},
+			notifiedTabs: new Set<string>(),
 
-		addTab(profileId, tab) {
-			set((state) => {
-				const existing = state.profiles[profileId] ?? {
-					tabs: [],
-					activeTabId: null,
-					counter: 0,
-				};
-				state.profiles[profileId] = {
-					tabs: [...existing.tabs, tab],
-					activeTabId: tab.id,
-					counter: existing.counter + 1,
-				};
-			});
-		},
-
-		closeTab(profileId, tabId) {
-			set((state) => {
-				const profile = state.profiles[profileId];
-				if (!profile) return;
-
-				const tab = profile.tabs.find((t) => t.id === tabId);
-
-				// Clean up notifications for all pane sessions
-				if (tab?.type === "terminal") {
-					for (const pane of tab.panes) {
-						state.notifiedTabs.delete(pane.sessionId);
+			addTab(profileId, tab) {
+				set((state) => {
+					const existing = state.profiles[profileId] ?? {
+						tabs: [],
+						activeTabId: null,
+						counter: 0,
+						sessionOrder: [],
+					};
+					// Track PTY session IDs in creation order for split-pane restoration
+					const newSessionOrder = [...existing.sessionOrder];
+					if (tab.type === "terminal") {
+						for (const pane of tab.panes) {
+							newSessionOrder.push(pane.sessionId);
+						}
 					}
-				}
-				state.notifiedTabs.delete(tabId);
+					state.profiles[profileId] = {
+						tabs: [...existing.tabs, tab],
+						activeTabId: tab.id,
+						counter: existing.counter + 1,
+						sessionOrder: newSessionOrder,
+					};
+				});
+			},
 
-				const idx = profile.tabs.findIndex((t) => t.id === tabId);
-				profile.tabs = profile.tabs.filter((t) => t.id !== tabId);
+			closeTab(profileId, tabId) {
+				set((state) => {
+					const profile = state.profiles[profileId];
+					if (!profile) return;
 
-				if (profile.tabs.length === 0) {
-					delete state.profiles[profileId];
-					return;
-				}
+					const tab = profile.tabs.find((t) => t.id === tabId);
 
-				if (tabId === profile.activeTabId) {
-					const newIdx = Math.min(idx, profile.tabs.length - 1);
-					profile.activeTabId = profile.tabs[newIdx].id;
-				}
-			});
-		},
+					// Clean up notifications and sessionOrder for terminal panes
+					if (tab?.type === "terminal") {
+						const paneIds = new Set(tab.panes.map((p) => p.sessionId));
+						for (const id of paneIds) {
+							state.notifiedTabs.delete(id);
+						}
+						profile.sessionOrder = profile.sessionOrder.filter(
+							(id) => !paneIds.has(id),
+						);
+					}
 
-		setActiveTab(profileId, tabId) {
-			set((state) => {
-				const profile = state.profiles[profileId];
-				if (!profile) return;
-				profile.activeTabId = tabId;
-				state.notifiedTabs.delete(tabId);
-			});
-		},
-
-		removeProfile(profileId) {
-			set((state) => {
-				delete state.profiles[profileId];
-			});
-		},
-
-		updateTabTitle(profileId, tabId, title) {
-			set((state) => {
-				const profile = state.profiles[profileId];
-				if (!profile) return;
-				const tab = profile.tabs.find((t) => t.id === tabId);
-				if (tab && tab.title !== title) tab.title = title;
-			});
-		},
-
-		replaceTab(profileId, oldTabId, newTab) {
-			set((state) => {
-				const profile = state.profiles[profileId];
-				if (!profile) return;
-				const idx = profile.tabs.findIndex((t) => t.id === oldTabId);
-				if (idx === -1) return;
-				profile.tabs[idx] = newTab;
-				if (profile.activeTabId === oldTabId) {
-					profile.activeTabId = newTab.id;
-				}
-			});
-		},
-
-		removeStaleProfiles(validIds) {
-			set((state) => {
-				for (const id of Object.keys(state.profiles)) {
-					if (!validIds.has(id)) delete state.profiles[id];
-				}
-			});
-		},
-
-		markNotified(sessionId) {
-			set((state) => {
-				state.notifiedTabs.add(sessionId);
-			});
-		},
-
-		markRead(sessionId) {
-			set((state) => {
-				state.notifiedTabs.delete(sessionId);
-			});
-		},
-
-		addPane(profileId, tabId, pane) {
-			set((state) => {
-				const profile = state.profiles[profileId];
-				if (!profile) return;
-				const tab = profile.tabs.find((t) => t.id === tabId);
-				if (!tab || tab.type !== "terminal") return;
-				tab.panes.push(pane);
-				tab.activePaneId = pane.sessionId;
-			});
-		},
-
-		closePane(profileId, tabId, paneSessionId) {
-			set((state) => {
-				const profile = state.profiles[profileId];
-				if (!profile) return;
-				const tab = profile.tabs.find((t) => t.id === tabId);
-				if (!tab || tab.type !== "terminal") return;
-
-				const paneIdx = tab.panes.findIndex((p) => p.sessionId === paneSessionId);
-				if (paneIdx === -1) return;
-
-				tab.panes.splice(paneIdx, 1);
-				state.notifiedTabs.delete(paneSessionId);
-
-				if (tab.panes.length === 0) {
-					// Last pane closed — remove the entire tab
-					const tabIdx = profile.tabs.findIndex((t) => t.id === tabId);
-					profile.tabs.splice(tabIdx, 1);
+					const idx = profile.tabs.findIndex((t) => t.id === tabId);
+					profile.tabs = profile.tabs.filter((t) => t.id !== tabId);
 
 					if (profile.tabs.length === 0) {
 						delete state.profiles[profileId];
-					} else if (tabId === profile.activeTabId) {
-						const newIdx = Math.min(tabIdx, profile.tabs.length - 1);
+						return;
+					}
+
+					if (tabId === profile.activeTabId) {
+						const newIdx = Math.min(idx, profile.tabs.length - 1);
 						profile.activeTabId = profile.tabs[newIdx].id;
 					}
-				} else if (paneSessionId === tab.activePaneId) {
-					// Active pane was closed — switch to adjacent
-					const newIdx = Math.min(paneIdx, tab.panes.length - 1);
-					tab.activePaneId = tab.panes[newIdx].sessionId;
-				}
-			});
-		},
+				});
+			},
 
-		setActivePane(profileId, tabId, paneSessionId) {
-			set((state) => {
-				const profile = state.profiles[profileId];
-				if (!profile) return;
-				const tab = profile.tabs.find((t) => t.id === tabId);
-				if (!tab || tab.type !== "terminal") return;
-				tab.activePaneId = paneSessionId;
-			});
-		},
+			setActiveTab(profileId, tabId) {
+				set((state) => {
+					const profile = state.profiles[profileId];
+					if (!profile) return;
+					profile.activeTabId = tabId;
+					// Clear pane notifications for the newly-focused terminal tab
+					const tab = profile.tabs.find((t) => t.id === tabId);
+					if (tab?.type === "terminal") {
+						for (const pane of tab.panes) {
+							state.notifiedTabs.delete(pane.sessionId);
+						}
+					}
+				});
+			},
 
-		updatePaneTitle(profileId, tabId, paneSessionId, title) {
-			set((state) => {
-				const profile = state.profiles[profileId];
-				if (!profile) return;
-				const tab = profile.tabs.find((t) => t.id === tabId);
-				if (!tab || tab.type !== "terminal") return;
-				const pane = tab.panes.find((p) => p.sessionId === paneSessionId);
-				if (pane && pane.title !== title) pane.title = title;
-			});
+			removeProfile(profileId) {
+				set((state) => {
+					delete state.profiles[profileId];
+				});
+			},
+
+			updateTabTitle(profileId, tabId, title) {
+				set((state) => {
+					const profile = state.profiles[profileId];
+					if (!profile) return;
+					const tab = profile.tabs.find((t) => t.id === tabId);
+					if (tab && tab.title !== title) tab.title = title;
+				});
+			},
+
+			replaceTab(profileId, oldTabId, newTab) {
+				set((state) => {
+					const profile = state.profiles[profileId];
+					if (!profile) return;
+					const idx = profile.tabs.findIndex((t) => t.id === oldTabId);
+					if (idx === -1) return;
+					profile.tabs[idx] = newTab;
+					if (profile.activeTabId === oldTabId) {
+						profile.activeTabId = newTab.id;
+					}
+				});
+			},
+
+			removeStaleProfiles(validIds) {
+				set((state) => {
+					for (const id of Object.keys(state.profiles)) {
+						if (!validIds.has(id)) delete state.profiles[id];
+					}
+				});
+			},
+
+			markNotified(sessionId) {
+				set((state) => {
+					state.notifiedTabs.add(sessionId);
+				});
+			},
+
+			markRead(sessionId) {
+				set((state) => {
+					state.notifiedTabs.delete(sessionId);
+				});
+			},
+
+			addPane(profileId, tabId, pane) {
+				set((state) => {
+					const profile = state.profiles[profileId];
+					if (!profile) return;
+					const tab = profile.tabs.find((t) => t.id === tabId);
+					if (!tab || tab.type !== "terminal") return;
+					tab.panes.push(pane);
+					tab.activePaneId = pane.sessionId;
+					profile.sessionOrder.push(pane.sessionId);
+				});
+			},
+
+			closePane(profileId, tabId, paneSessionId) {
+				set((state) => {
+					const profile = state.profiles[profileId];
+					if (!profile) return;
+					const tab = profile.tabs.find((t) => t.id === tabId);
+					if (!tab || tab.type !== "terminal") return;
+
+					const paneIdx = tab.panes.findIndex((p) => p.sessionId === paneSessionId);
+					if (paneIdx === -1) return;
+
+					tab.panes.splice(paneIdx, 1);
+					state.notifiedTabs.delete(paneSessionId);
+					profile.sessionOrder = profile.sessionOrder.filter(
+						(id) => id !== paneSessionId,
+					);
+
+					if (tab.panes.length === 0) {
+						// Last pane closed — remove the entire tab
+						const tabIdx = profile.tabs.findIndex((t) => t.id === tabId);
+						profile.tabs.splice(tabIdx, 1);
+
+						if (profile.tabs.length === 0) {
+							delete state.profiles[profileId];
+						} else if (tabId === profile.activeTabId) {
+							const newIdx = Math.min(tabIdx, profile.tabs.length - 1);
+							profile.activeTabId = profile.tabs[newIdx].id;
+						}
+					} else if (paneSessionId === tab.activePaneId) {
+						// Active pane was closed — switch to adjacent
+						const newIdx = Math.min(paneIdx, tab.panes.length - 1);
+						tab.activePaneId = tab.panes[newIdx].sessionId;
+					}
+				});
+			},
+
+			setActivePane(profileId, tabId, paneSessionId) {
+				set((state) => {
+					const profile = state.profiles[profileId];
+					if (!profile) return;
+					const tab = profile.tabs.find((t) => t.id === tabId);
+					if (!tab || tab.type !== "terminal") return;
+					tab.activePaneId = paneSessionId;
+				});
+			},
+
+			updatePaneTitle(profileId, tabId, paneSessionId, title) {
+				set((state) => {
+					const profile = state.profiles[profileId];
+					if (!profile) return;
+					const tab = profile.tabs.find((t) => t.id === tabId);
+					if (!tab || tab.type !== "terminal") return;
+					const pane = tab.panes.find((p) => p.sessionId === paneSessionId);
+					if (pane && pane.title !== title) pane.title = title;
+				});
+			},
+
+			restoreProfile(profileId, profileState) {
+				set((state) => {
+					state.profiles[profileId] = profileState;
+				});
+			},
+
+			updateAgentSessionId(profileId, tabId, newSessionId) {
+				set((state) => {
+					const profile = state.profiles[profileId];
+					if (!profile) return;
+					const tab = profile.tabs.find((t) => t.id === tabId);
+					if (!tab || tab.type !== "agent") return;
+					tab.sessionId = newSessionId;
+				});
+			},
+		})),
+		{
+			name: "tab-layout",
+			version: 1,
+			// Only persist the tab layout (profiles). notifiedTabs is ephemeral.
+			partialize: (state) => ({ profiles: state.profiles }),
 		},
-	})),
+	),
 );
 
 /** IDs of profiles that currently have tabs open. */
@@ -218,7 +274,8 @@ export function useProfileHasNotification(profileId: string): boolean {
 			if (t.type === "terminal") {
 				return t.panes.some((p) => s.notifiedTabs.has(p.sessionId));
 			}
-			return s.notifiedTabs.has(t.id);
+			// Agent sessions don't emit pty-notify, so never in notifiedTabs
+			return false;
 		});
 	});
 }

--- a/src/features/tabs/types.ts
+++ b/src/features/tabs/types.ts
@@ -13,7 +13,10 @@ export interface TerminalTab {
 
 export interface AgentTab {
 	type: "agent";
+	/** Frontend nanoid — stable across restarts, never used for backend calls. */
 	id: string;
+	/** Backend agent session ID — may change on reconnect. */
+	sessionId: string;
 	title: string;
 	agentType: string;
 }

--- a/src/features/tabs/utils.ts
+++ b/src/features/tabs/utils.ts
@@ -1,5 +1,6 @@
 import { sessionRegistry } from "./sessionRegistry";
 import { useTabStore } from "./store";
+import type { AgentTab } from "./types";
 
 export async function closeAllTabsForProfile(profileId: string): Promise<void> {
 	const tabs = useTabStore.getState().profiles[profileId]?.tabs ?? [];
@@ -20,14 +21,15 @@ export async function closeAllTabsForProfile(profileId: string): Promise<void> {
 				}
 			});
 		}
-		// Agent tabs — single session
-		const session = sessionRegistry.get(tab.id);
+		// Agent tabs — look up by sessionId, not nanoid tab id
+		const agentTab = tab as AgentTab;
+		const session = sessionRegistry.get(agentTab.sessionId);
 		if (!session) return [];
 		return [
 			session
 				.close()
-				.catch((err) => console.error(`Failed to close tab ${tab.id}:`, err))
-				.finally(() => sessionRegistry.delete(tab.id)),
+				.catch((err) => console.error(`Failed to close agent tab ${agentTab.sessionId}:`, err))
+				.finally(() => sessionRegistry.delete(agentTab.sessionId)),
 		];
 	});
 

--- a/src/features/terminal/TerminalTabs.tsx
+++ b/src/features/terminal/TerminalTabs.tsx
@@ -24,12 +24,14 @@ export default function TerminalTabs({ profileId, cwd }: TerminalTabsProps) {
 
 	if (tabs.length === 0) return null;
 
-	const hasTabNotification = (tabId: string) => {
+	const hasTabNotification = (tabId: string): boolean => {
 		const tab = tabs.find((t) => t.id === tabId);
-		if (tab?.type === "terminal") {
-			return tab.panes.some((p) => notifiedTabs.has(p.sessionId));
-		}
-		return notifiedTabs.has(tabId);
+		return match(tab)
+			.with({ type: "terminal" }, (t) =>
+				t.panes.some((p) => notifiedTabs.has(p.sessionId)),
+			)
+			.with({ type: "agent" }, (t) => notifiedTabs.has(t.sessionId))
+			.otherwise(() => false);
 	};
 
 	return (
@@ -87,7 +89,7 @@ export default function TerminalTabs({ profileId, cwd }: TerminalTabsProps) {
 						{match(tab)
 							.with({ type: "agent" }, (t) => (
 								<AgentChat
-									sessionId={t.id}
+									sessionId={t.sessionId}
 									isActive={t.id === activeTabId}
 								/>
 							))


### PR DESCRIPTION
## Summary

- **Split panel restoration**: Tab layout (including multi-pane groupings) is now persisted to localStorage via Zustand `persist` middleware. On app restart, the split panel structure is restored instead of each pane becoming a separate tab.
- **Positional session matching**: Since PTY session IDs change on every restart (backend recreates them), `restore.ts` maps new session IDs to persisted pane slots using `sessionOrder[]` — a per-profile array recording pane session IDs in creation order. The backend restores sessions in the same relative order, making positional matching reliable.
- **ID separation**: `tab.id` is now a `nanoid()` (pure frontend, stable across restarts). `AgentTab` gains a new `sessionId` field for the backend session ID. All session registry lookups and backend calls now use the correct session IDs, not tab IDs.
- **Agent reconnect**: `reconnect()` now calls `updateAgentSessionId()` instead of `replaceTab()`, keeping the nanoid tab id stable while only updating the backend session reference.

## Key files changed

| File | Change |
|---|---|
| `tabs/types.ts` | Add `sessionId` to `AgentTab` |
| `tabs/store.ts` | Add `persist` middleware, `sessionOrder` tracking, `restoreProfile()`, `updateAgentSessionId()` |
| `tabs/restore.ts` | Layout-aware restoration with positional session matching |
| `tabs/AgentTabSession.ts` | `toTab()` uses `nanoid()`, `reconnect()` uses `updateAgentSessionId()` |
| `tabs/TerminalTabSession.ts` | `toTab()` uses `nanoid()` for tab id |
| `tabs/hooks.ts`, `tabs/utils.ts` | Agent lookups via `tab.sessionId` |
| `terminal/TerminalTabs.tsx` | Pass `t.sessionId` to `AgentChat` |

## Test plan

- [ ] Create a terminal tab with 2–3 split panes → restart app → verify pane groupings preserved with scrollback
- [ ] Create multiple tabs (some split, some single) + an agent tab → restart → verify full layout restored
- [ ] Close a pane in a split tab → restart → verify remaining panes correctly grouped
- [ ] Clear localStorage → restart → verify graceful fallback to one-tab-per-session
- [ ] Focus an agent tab after restart → verify reconnection works (tab id stays stable)
- [ ] Verify notification dots still route to correct panes/tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tab and pane state persistence, allowing sessions to be restored after application restart.
  * Improved reconnection handling to preserve tab identity when the backend session updates.

* **Chores**
  * Added a new runtime dependency for generating unique identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->