### PR TITLE
feat(agent): unify agent icons and support dark-mode inversion

### DIFF
--- a/src/features/agent/AgentChat.tsx
+++ b/src/features/agent/AgentChat.tsx
@@ -88,6 +88,11 @@ function ReconnectErrorFallback({ error }: { error: unknown }) {
 export function AgentChat({ sessionId, isActive }: AgentChatProps) {
 	const sendPrompt = useSendAgentPrompt();
 	const setAgentModel = useSetAgentModel();
+	const tabSession = sessionRegistry.get(sessionId) as
+		| AgentTabSession
+		| undefined;
+	const agentIconUrl = tabSession?.iconUrl ?? null;
+	const agentName = tabSession?.title ?? "Agent";
 
 	const { turns, isStreaming, streamingTurn, error, modelState, modelLoading } =
 		useAgentStore(
@@ -198,6 +203,8 @@ export function AgentChat({ sessionId, isActive }: AgentChatProps) {
 				isStreaming={isStreaming ?? false}
 				streamingTurn={streamingTurn}
 				error={error ?? undefined}
+				agentIconUrl={agentIconUrl}
+				agentName={agentName}
 				onSuggestionSelect={handleSend}
 			/>
 

--- a/src/features/agent/components/Message.tsx
+++ b/src/features/agent/components/Message.tsx
@@ -1,12 +1,15 @@
-import { Box, Flex, Icon } from "@chakra-ui/react";
-import { LuUser, LuBot } from "react-icons/lu";
+import { Box, Flex } from "@chakra-ui/react";
+import { LuUser } from "react-icons/lu";
+import { AgentIcon } from "@/shared/components/AgentIcon";
 
 interface MessageProps {
 	role: "user" | "assistant";
+	agentIconUrl?: string | null;
+	agentName?: string;
 	children: React.ReactNode;
 }
 
-export function Message({ role, children }: MessageProps) {
+export function Message({ role, agentIconUrl, agentName, children }: MessageProps) {
 	const isUser = role === "user";
 
 	return (
@@ -23,7 +26,15 @@ export function Message({ role, children }: MessageProps) {
 				border="1px solid"
 				borderColor={"border.subtle"}
 			>
-				<Icon fontSize="md">{isUser ? <LuUser /> : <LuBot />}</Icon>
+				{isUser
+					? <LuUser size={16} />
+					: (
+							<AgentIcon
+								iconUrl={agentIconUrl}
+								size={16}
+								alt={agentName ?? "Agent"}
+							/>
+						)}
 			</Flex>
 			<Box flex="1" minW="0" pt="1">
 				{children}

--- a/src/features/agent/components/MessageList.tsx
+++ b/src/features/agent/components/MessageList.tsx
@@ -1,7 +1,7 @@
 import { Box, Button, EmptyState, Flex, HStack, Text, VStack } from "@chakra-ui/react";
 import { useEffect, useRef } from "react";
-import { RiRobot2Line } from "react-icons/ri";
 import * as m from "@/paraglide/messages.js";
+import { AgentIcon } from "@/shared/components/AgentIcon";
 import type { AgentTurn, StreamingTurn } from "../types";
 import { TurnRenderer } from "./TurnRenderer";
 import { StreamingTurnRenderer } from "./StreamingTurnRenderer";
@@ -29,6 +29,8 @@ interface MessageListProps {
 	isStreaming: boolean;
 	streamingTurn: StreamingTurn | null | undefined;
 	error: string | undefined;
+	agentIconUrl?: string | null;
+	agentName?: string;
 	onSuggestionSelect?: (prompt: string) => void;
 }
 
@@ -37,6 +39,8 @@ export function MessageList({
 	isStreaming,
 	streamingTurn,
 	error,
+	agentIconUrl,
+	agentName,
 	onSuggestionSelect,
 }: MessageListProps) {
 	const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -55,7 +59,11 @@ export function MessageList({
 						<EmptyState.Root>
 							<EmptyState.Content>
 								<EmptyState.Indicator>
-									<RiRobot2Line />
+									<AgentIcon
+										iconUrl={agentIconUrl}
+										size={24}
+										alt={agentName ?? "Agent"}
+									/>
 								</EmptyState.Indicator>
 								<VStack textAlign="center">
 									<EmptyState.Title>
@@ -81,11 +89,20 @@ export function MessageList({
 				)}
 
 				{turns?.map((turn) => (
-					<TurnRenderer key={turn.timestamp} turn={turn} />
+					<TurnRenderer
+						key={turn.timestamp}
+						turn={turn}
+						agentIconUrl={agentIconUrl}
+						agentName={agentName}
+					/>
 				))}
 
 				{isStreaming && streamingTurn && (
-					<StreamingTurnRenderer turn={streamingTurn} />
+					<StreamingTurnRenderer
+						turn={streamingTurn}
+						agentIconUrl={agentIconUrl}
+						agentName={agentName}
+					/>
 				)}
 
 				{error && !isStreaming && (

--- a/src/features/agent/components/StreamingTurnRenderer.tsx
+++ b/src/features/agent/components/StreamingTurnRenderer.tsx
@@ -12,9 +12,15 @@ import { ToolCallBlock } from "./ToolCallBlock";
 
 interface StreamingTurnRendererProps {
 	turn: StreamingTurn;
+	agentIconUrl?: string | null;
+	agentName?: string;
 }
 
-export function StreamingTurnRenderer({ turn }: StreamingTurnRendererProps) {
+export function StreamingTurnRenderer({
+	turn,
+	agentIconUrl,
+	agentName,
+}: StreamingTurnRendererProps) {
 	const { agentContent } = turn;
 
 	// Find the last text entry index to render it as StreamingBubble
@@ -34,7 +40,11 @@ export function StreamingTurnRenderer({ turn }: StreamingTurnRendererProps) {
 				</Message>
 			)}
 
-			<Message role="assistant">
+			<Message
+				role="assistant"
+				agentIconUrl={agentIconUrl}
+				agentName={agentName}
+			>
 				<Flex direction="column" gap="4">
 					{agentContent.length === 0 && (
 						<TextShimmer>{m.agentThinking()}</TextShimmer>

--- a/src/features/agent/components/TurnRenderer.tsx
+++ b/src/features/agent/components/TurnRenderer.tsx
@@ -6,9 +6,11 @@ import { AgentResponseGroup } from "./AgentResponseGroup";
 
 interface TurnRendererProps {
 	turn: AgentTurn;
+	agentIconUrl?: string | null;
+	agentName?: string;
 }
 
-export function TurnRenderer({ turn }: TurnRendererProps) {
+export function TurnRenderer({ turn, agentIconUrl, agentName }: TurnRendererProps) {
 	return (
 		<Flex direction="column">
 			{/* 用户消息 */}
@@ -20,7 +22,11 @@ export function TurnRenderer({ turn }: TurnRendererProps) {
 
 			{/* Agent 响应 */}
 			{turn.agentContent.length > 0 && (
-				<Message role="assistant">
+				<Message
+					role="assistant"
+					agentIconUrl={agentIconUrl}
+					agentName={agentName}
+				>
 					<AgentResponseGroup content={turn.agentContent} />
 				</Message>
 			)}

--- a/src/features/assets/AgentsTab.tsx
+++ b/src/features/assets/AgentsTab.tsx
@@ -17,10 +17,10 @@ import { QueryErrorResetBoundary } from "@tanstack/react-query";
 import * as React from "react";
 import { Suspense, useState } from "react";
 import { LuExternalLink, LuTrash2 } from "react-icons/lu";
-import { RiRobot2Line } from "react-icons/ri";
 import { ErrorBoundary, type FallbackProps } from "react-error-boundary";
 import type { RegistryAgentInfo } from "@/generated/types";
 import * as m from "@/paraglide/messages.js";
+import { AgentIcon } from "@/shared/components/AgentIcon";
 import {
 	useAddMarketplaceAgent,
 	useMarketplaceAgents,
@@ -74,55 +74,18 @@ function MarketplaceQueryBoundary({
 	);
 }
 
-// ─── Shared: agent icon with SVG fallback ───────────────────────────────────
-
-const ICON_SIZE = "40px";
-
-function AgentIcon({
-	icon,
-	name,
-}: {
-	icon?: string | null;
-	name: string;
-}) {
-	const [imgError, setImgError] = useState(false);
-
-	const containerStyle = {
-		width: ICON_SIZE,
-		height: ICON_SIZE,
-		flexShrink: 0,
-		borderRadius: "var(--chakra-radii-md)",
-		border: "1px solid var(--chakra-colors-border)",
-		display: "flex",
-		alignItems: "center",
-		justifyContent: "center",
-		padding: "6px",
-		overflow: "hidden",
-	} satisfies React.CSSProperties;
-
-	if (!icon || imgError) {
-		return (
-			<div style={containerStyle}>
-				<RiRobot2Line size={18} />
-			</div>
-		);
-	}
-
-	return (
-		<div style={containerStyle}>
-			<img
-				src={icon}
-				alt={name}
-				onError={() => setImgError(true)}
-				style={{
-					width: "100%",
-					height: "100%",
-					objectFit: "contain",
-				}}
-			/>
-		</div>
-	);
-}
+const ICON_CONTAINER_STYLE = {
+	width: "40px",
+	height: "40px",
+	flexShrink: 0,
+	borderRadius: "var(--chakra-radii-md)",
+	border: "1px solid var(--chakra-colors-border)",
+	display: "flex",
+	alignItems: "center",
+	justifyContent: "center",
+	padding: "6px",
+	overflow: "hidden",
+} satisfies React.CSSProperties;
 
 // ─── Store mode: browse registry ────────────────────────────────────────────
 
@@ -141,7 +104,13 @@ function RegistryAgentCard({
 		<Card.Root>
 			<Card.Body gap="3">
 				<HStack gap="3" align="flex-start">
-					<AgentIcon icon={agent.icon} name={agent.name} />
+					<div style={ICON_CONTAINER_STYLE}>
+						<AgentIcon
+							iconUrl={agent.icon}
+							size={28}
+							alt={agent.name}
+						/>
+					</div>
 					<Stack gap="0" flex="1" minW="0">
 						<HStack justify="space-between" align="flex-start">
 							<Card.Title fontSize="sm" lineClamp={1}>
@@ -280,7 +249,13 @@ function InstalledAgentCard({
 		<Card.Root>
 			<Card.Body gap="3">
 				<HStack gap="3" align="flex-start">
-					<AgentIcon icon={iconUrl} name={name} />
+					<div style={ICON_CONTAINER_STYLE}>
+						<AgentIcon
+							iconUrl={iconUrl}
+							size={28}
+							alt={name}
+						/>
+					</div>
 					<Stack gap="0" flex="1" minW="0">
 						<HStack justify="space-between" align="flex-start">
 							<Card.Title fontSize="sm" lineClamp={1}>

--- a/src/features/git/AgentMenu.tsx
+++ b/src/features/git/AgentMenu.tsx
@@ -1,28 +1,11 @@
-import { Button, Group, IconButton, Image, Menu, Portal } from "@chakra-ui/react";
-import { useState } from "react";
+import { Button, Group, IconButton, Menu, Portal } from "@chakra-ui/react";
 import type { ReactNode } from "react";
 import { useNavigate } from "react-router";
-import { RiAddLine, RiArrowDownSLine, RiRobot2Line } from "react-icons/ri";
+import { RiAddLine, RiArrowDownSLine } from "react-icons/ri";
 import { useAgentSettingsStore } from "@/features/settings/stores/agentSettingsStore";
 import type { MarketplaceAgent, Profile } from "@/generated";
 import * as m from "@/paraglide/messages.js";
-
-function AgentIcon({ iconUrl, size = 16 }: { iconUrl?: string | null; size?: number }) {
-	const [failed, setFailed] = useState(false);
-	if (iconUrl && !failed) {
-		return (
-			<Image
-				src={iconUrl}
-				width={`${size}px`}
-				height={`${size}px`}
-				objectFit="contain"
-				onError={() => setFailed(true)}
-				alt=""
-			/>
-		);
-	}
-	return <RiRobot2Line size={size} />;
-}
+import { AgentIcon } from "@/shared/components/AgentIcon";
 
 function AgentDropdown({
 	agents,
@@ -95,7 +78,7 @@ export default function AgentMenu({ agents, profile, isPending, onCreateTab }: A
 				aria-label={m.addAgent()}
 				onClick={() => navigate("/assets")}
 			>
-				<RiRobot2Line />
+				<AgentIcon />
 				<RiAddLine />
 			</Button>
 		);

--- a/src/features/terminal/TerminalTabs.tsx
+++ b/src/features/terminal/TerminalTabs.tsx
@@ -1,11 +1,12 @@
 import { Box, Circle, CloseButton, Flex, HStack, Tabs } from "@chakra-ui/react";
-import { RiRobot2Line, RiTerminalBoxLine } from "react-icons/ri";
+import { RiTerminalBoxLine } from "react-icons/ri";
 import { match } from "ts-pattern";
 import { useShallow } from "zustand/react/shallow";
 import { AgentChat } from "@/features/agent/AgentChat";
 import { useCloseTab } from "@/features/tabs/hooks";
 import { isPending } from "@/features/tabs/pendingDeletions";
 import { useTabStore } from "@/features/tabs/store";
+import { AgentIcon } from "@/shared/components/AgentIcon";
 import { SplitTerminal } from "./SplitTerminal";
 
 interface TerminalTabsProps {
@@ -43,7 +44,9 @@ export default function TerminalTabs({ profileId, cwd }: TerminalTabsProps) {
 					{tabs.map((tab) => (
 						<Tabs.Trigger key={tab.id} value={tab.id}>
 							{match(tab)
-								.with({ type: "agent" }, () => <RiRobot2Line />)
+								.with({ type: "agent" }, (t) => (
+									<AgentIcon iconUrl={t.iconUrl} alt={t.title} />
+								))
 								.with({ type: "terminal" }, () => (
 									<RiTerminalBoxLine />
 								))

--- a/src/shared/components/AgentIcon.tsx
+++ b/src/shared/components/AgentIcon.tsx
@@ -1,0 +1,40 @@
+import { Image } from "@chakra-ui/react";
+import { use, useEffect, useState } from "react";
+import { RiRobot2Line } from "react-icons/ri";
+import { ThemeContext } from "@/shared/providers/themeContext";
+
+interface AgentIconProps {
+	iconUrl?: string | null;
+	size?: number | string;
+	alt?: string;
+}
+
+export function AgentIcon({
+	iconUrl,
+	size = 16,
+	alt = "",
+}: AgentIconProps) {
+	const { isDark } = use(ThemeContext);
+	const [failed, setFailed] = useState(false);
+	const imageSize = typeof size === "number" ? `${size}px` : size;
+
+	useEffect(() => {
+		setFailed(false);
+	}, [iconUrl]);
+
+	if (!iconUrl || failed) {
+		return <RiRobot2Line size={size} />;
+	}
+
+	return (
+		<Image
+			src={iconUrl}
+			width={imageSize}
+			height={imageSize}
+			objectFit="contain"
+			filter={isDark ? "invert(1)" : "none"}
+			onError={() => setFailed(true)}
+			alt={alt}
+		/>
+	);
+}


### PR DESCRIPTION
## Summary
- add a shared AgentIcon component to centralize agent icon rendering
- apply dark-mode invert styling for image-based agent icons with robot fallback
- replace robot icon in profile tab list with the current tab agent icon
- replace robot icon/avatar usage in agent chat with the same tab agent icon
- migrate existing agent icon usage in agent menu and assets list to shared component

## Testing
- not run (environment currently missing local frontend deps for typecheck)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent icons are now displayed throughout the application (chat messages, tabs, menus, and cards).
  * Agents can have custom icons; a default robot icon appears as a fallback when unavailable.
  * Dark mode support for agent icon display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->