### PR TITLE
refactor(agent): move model selector into input footer action row

### DIFF
--- a/src/features/agent/AgentChat.tsx
+++ b/src/features/agent/AgentChat.tsx
@@ -140,6 +140,50 @@ export function AgentChat({ sessionId, isActive }: AgentChatProps) {
 		},
 		[selectedModel, sessionId, setAgentModel],
 	);
+	const modelSelector = showModelSelector
+		? (
+			<Select.Root
+				collection={modelCollection}
+				value={selectedModel ? [selectedModel] : []}
+				onValueChange={handleModelChange}
+				size="xs"
+				width={{ base: "120px", md: "150px" }}
+				disabled={modelBusy || (isStreaming ?? false)}
+				aria-label={m.agentModel()}
+			>
+				<Select.HiddenSelect />
+				<Select.Control>
+					<Select.Trigger
+						variant="ghost"
+						h="6"
+						minH="6"
+						px="1"
+						bg="transparent"
+						borderWidth="0"
+						color="fg.muted"
+						_hover={{ bg: "transparent", color: "fg" }}
+					>
+						<Select.ValueText fontSize="xs" truncate />
+					</Select.Trigger>
+					<Select.IndicatorGroup>
+						{modelBusy ? <Spinner size="xs" /> : <Select.Indicator />}
+					</Select.IndicatorGroup>
+				</Select.Control>
+				<Portal>
+					<Select.Positioner>
+						<Select.Content>
+							{modelCollection.items.map((item) => (
+								<Select.Item item={item} key={item.value}>
+									{item.label}
+									<Select.ItemIndicator />
+								</Select.Item>
+							))}
+						</Select.Content>
+					</Select.Positioner>
+				</Portal>
+			</Select.Root>
+		)
+		: null;
 
 	if (isActive && needsReconnection(sessionId)) {
 		return (
@@ -153,46 +197,6 @@ export function AgentChat({ sessionId, isActive }: AgentChatProps) {
 
 	return (
 		<Flex direction="column" h="full" w="full" bg="bg" position="relative">
-			{showModelSelector && (
-				<Flex px="3" pt="2" pb="1" justify="flex-end">
-					<HStack gap="2">
-						<Text fontSize="xs" color="fg.muted">
-							{m.agentModel()}
-						</Text>
-						<Select.Root
-							collection={modelCollection}
-							value={selectedModel ? [selectedModel] : []}
-							onValueChange={handleModelChange}
-							size="xs"
-							width="240px"
-							disabled={modelBusy || (isStreaming ?? false)}
-						>
-							<Select.HiddenSelect />
-							<Select.Control>
-								<Select.Trigger>
-									<Select.ValueText />
-								</Select.Trigger>
-								<Select.IndicatorGroup>
-									{modelBusy ? <Spinner size="xs" /> : <Select.Indicator />}
-								</Select.IndicatorGroup>
-							</Select.Control>
-							<Portal>
-								<Select.Positioner>
-									<Select.Content>
-										{modelCollection.items.map((item) => (
-											<Select.Item item={item} key={item.value}>
-												{item.label}
-												<Select.ItemIndicator />
-											</Select.Item>
-										))}
-									</Select.Content>
-								</Select.Positioner>
-							</Portal>
-						</Select.Root>
-					</HStack>
-				</Flex>
-			)}
-
 			<MessageList
 				turns={turns}
 				isStreaming={isStreaming ?? false}
@@ -211,6 +215,7 @@ export function AgentChat({ sessionId, isActive }: AgentChatProps) {
 								onSend={handleSend}
 								disabled={isStreaming ?? false}
 								onToggleExpand={() => setExpanded(true)}
+								modelSelector={modelSelector}
 							/>
 						</Box>
 					</Box>
@@ -245,6 +250,7 @@ export function AgentChat({ sessionId, isActive }: AgentChatProps) {
 							onSend={handleSend}
 							disabled={isStreaming ?? false}
 							expanded={true}
+							modelSelector={modelSelector}
 						/>
 					</Box>
 				</Flex>

--- a/src/features/agent/components/ChatInput.tsx
+++ b/src/features/agent/components/ChatInput.tsx
@@ -54,9 +54,10 @@ interface ChatInputProps {
 	disabled?: boolean;
 	expanded?: boolean;
 	onToggleExpand?: () => void;
+	modelSelector?: React.ReactNode;
 }
 
-export const ChatInput = ({ ref, onSend, disabled = false, expanded = false, onToggleExpand }: ChatInputProps & { ref?: React.RefObject<Editor | null | null> }) => {
+export const ChatInput = ({ ref, onSend, disabled = false, expanded = false, onToggleExpand, modelSelector }: ChatInputProps & { ref?: React.RefObject<Editor | null | null> }) => {
 	const { data: snippets } = useSuspenseQuery({
 		queryKey: queryKeys.snippets.all,
 		queryFn: listSnippets,
@@ -237,41 +238,53 @@ export const ChatInput = ({ ref, onSend, disabled = false, expanded = false, onT
 					<Box flex="1" overflowY="auto">
 						<RichTextEditor.Content />
 					</Box>
-					<HStack px="3" py="2" justify="flex-end">
-						<IconButton
-							size="sm"
-							onClick={handleSend}
-							disabled={isEmpty || disabled}
-							aria-label="Send"
-						>
-							<RiSendPlaneLine />
-						</IconButton>
+					<HStack px="3" py="2" gap="2" borderTopWidth="1px">
+						<Box flex="1" minW="0">
+							{modelSelector}
+						</Box>
+						<HStack gap="1" ml="auto">
+							<IconButton
+								size="sm"
+								onClick={handleSend}
+								disabled={isEmpty || disabled}
+								aria-label="Send"
+							>
+								<RiSendPlaneLine />
+							</IconButton>
+						</HStack>
 					</HStack>
 				</Flex>
 			) : (
-				<RichTextEditor.Footer borderTopWidth="0">
-					<Box flex="1">
+				<Flex direction="column">
+					<Box>
 						<RichTextEditor.Content />
 					</Box>
-					{onToggleExpand && (
-						<IconButton
-							size="sm"
-							variant="ghost"
-							onClick={onToggleExpand}
-							aria-label="Expand"
-						>
-							<LuExpand />
-						</IconButton>
-					)}
-					<IconButton
-						size="sm"
-						onClick={handleSend}
-						disabled={isEmpty || disabled}
-						aria-label="Send"
-					>
-						<RiSendPlaneLine />
-					</IconButton>
-				</RichTextEditor.Footer>
+					<HStack px="3" py="2" gap="2">
+						<Box flex="1" minW="0">
+							{modelSelector}
+						</Box>
+						<HStack gap="1" ml="auto">
+							{onToggleExpand && (
+								<IconButton
+									size="sm"
+									variant="ghost"
+									onClick={onToggleExpand}
+									aria-label="Expand"
+								>
+									<LuExpand />
+								</IconButton>
+							)}
+							<IconButton
+								size="sm"
+								onClick={handleSend}
+								disabled={isEmpty || disabled}
+								aria-label="Send"
+							>
+								<RiSendPlaneLine />
+							</IconButton>
+						</HStack>
+					</HStack>
+				</Flex>
 			)}
 
 			{isSnippetMenuOpen && (


### PR DESCRIPTION
## Summary\n- move model selector from top-right header area into the chat input footer\n- refactor chat input layout to a dedicated bottom action bar\n- place model selector at bottom-left and send/expand actions at bottom-right\n- switch model select trigger to a text-like ghost style without label\n\n## Testing\n- not run (workspace dependency install is currently missing, so TypeScript checks cannot complete)