### PR TITLE
fix: remove unused type exports GitDiffAction and GitDiffContextValue

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -597,7 +597,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "code"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "axum",
  "core-text",

--- a/src/features/git/gitDiffReducer.ts
+++ b/src/features/git/gitDiffReducer.ts
@@ -14,7 +14,7 @@ export interface GitDiffState {
 	commitFileCount: number;
 }
 
-export type GitDiffAction =
+type GitDiffAction =
 	| { type: "switchTab"; tab: Tab }
 	| { type: "selectFile"; index: number }
 	| { type: "selectCommit"; commit: GitCommit; index: number }
@@ -90,7 +90,7 @@ export const gitDiffReducer = produce(
 	},
 );
 
-export interface GitDiffContextValue {
+interface GitDiffContextValue {
 	state: GitDiffState;
 	dispatch: React.Dispatch<GitDiffAction>;
 	profileId: string;


### PR DESCRIPTION
## Summary
Remove unused type exports `GitDiffAction` and `GitDiffContextValue` from `src/features/git/gitDiffReducer.ts`.

## Context
These types are only used internally in `gitDiffReducer.ts`:
- `GitDiffAction` is only used in the reducer function and `GitDiffContextValue.dispatch` type
- `GitDiffContextValue` is only used to type the `GitDiffContext`

They don't need to be exported since they're not used in any other files.

## Changes
- Changed `export type GitDiffAction` to `type GitDiffAction` in `src/features/git/gitDiffReducer.ts:17`
- Changed `export interface GitDiffContextValue` to `interface GitDiffContextValue` in `src/features/git/gitDiffReducer.ts:93`

## Testing
```bash
# Run knip to verify no unused exports
bun run knip

# Run type check
npx tsc --noEmit
```