### PR TITLE
[codex] Add Tauri smoke workflow

### DIFF
--- a/.github/workflows/tauri-smoke.yml
+++ b/.github/workflows/tauri-smoke.yml
@@ -57,3 +57,11 @@ jobs:
 
       - name: Run Tauri smoke test
         run: xvfb-run -a bun run test:tauri-smoke
+
+      - name: Upload smoke artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tauri-smoke-artifacts
+          path: e2e-tests/artifacts/
+          if-no-files-found: ignore

--- a/.github/workflows/tauri-smoke.yml
+++ b/.github/workflows/tauri-smoke.yml
@@ -26,8 +26,9 @@ jobs:
             build-essential \
             curl \
             wget \
-            file \
-            libxdo-dev \
+          file \
+          just \
+          libxdo-dev \
             libssl-dev \
             libayatana-appindicator3-dev \
             librsvg2-dev \

--- a/.github/workflows/tauri-smoke.yml
+++ b/.github/workflows/tauri-smoke.yml
@@ -1,0 +1,59 @@
+name: Tauri Smoke
+
+on:
+  push:
+    branches:
+      - dev
+      - "codex/**"
+  pull_request:
+    branches:
+      - dev
+
+jobs:
+  smoke:
+    name: Linux Smoke
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Linux dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y \
+            libwebkit2gtk-4.1-dev \
+            build-essential \
+            curl \
+            wget \
+            file \
+            libxdo-dev \
+            libssl-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            webkit2gtk-driver \
+            xvfb
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            src-tauri -> target
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install app dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Install smoke-test dependencies
+        run: bun install --cwd e2e-tests --frozen-lockfile
+
+      - name: Install tauri-driver
+        run: cargo install tauri-driver --locked
+
+      - name: Run Tauri smoke test
+        run: xvfb-run -a bun run test:tauri-smoke

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ dist-ssr
 # Coverage reports
 src-tauri/coverage/
 /coverage
+e2e-tests/artifacts/

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -1,0 +1,23 @@
+# Tauri Smoke Test
+
+This directory contains a CI-oriented desktop smoke test for the Tauri app.
+
+It uses Tauri's WebDriver support via `tauri-driver` plus Selenium to verify that:
+
+- the desktop shell launches
+- the main layout renders
+- the frontend is not blank
+
+## Run
+
+```bash
+bun --cwd e2e-tests install
+bun run test:tauri-smoke
+```
+
+## CI Notes
+
+- Install `tauri-driver` with Cargo before running the suite.
+- On Linux CI, run the suite under a virtual display such as `xvfb-run`.
+- The suite skips on macOS because Tauri does not provide a desktop WebDriver client there.
+- If your runner needs an explicit native WebDriver binary, set `TAURI_SMOKE_NATIVE_DRIVER=/path/to/driver`.

--- a/e2e-tests/bun.lock
+++ b/e2e-tests/bun.lock
@@ -1,0 +1,223 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "2code-e2e-tests",
+      "dependencies": {
+        "chai": "^5.2.1",
+        "mocha": "^11.7.1",
+        "selenium-webdriver": "^4.34.0",
+      },
+    },
+  },
+  "packages": {
+    "@bazel/runfiles": ["@bazel/runfiles@6.5.0", "", {}, "sha512-RzahvqTkfpY2jsDxo8YItPX+/iZ6hbiikw1YhE0bA9EKBR5Og8Pa6FHn9PO9M0zaXRVsr0GFQLKbB/0rzy9SzA=="],
+
+    "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
+
+    "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
+
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "brace-expansion": ["brace-expansion@2.0.3", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA=="],
+
+    "browser-stdout": ["browser-stdout@1.3.1", "", {}, "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="],
+
+    "camelcase": ["camelcase@6.3.0", "", {}, "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="],
+
+    "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
+
+    "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
+
+    "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
+
+    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "core-util-is": ["core-util-is@1.0.3", "", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decamelize": ["decamelize@4.0.0", "", {}, "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ=="],
+
+    "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
+
+    "diff": ["diff@7.0.0", "", {}, "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw=="],
+
+    "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
+
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
+    "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
+
+    "flat": ["flat@5.0.2", "", { "bin": { "flat": "cli.js" } }, "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ=="],
+
+    "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
+
+    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
+    "glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
+
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "he": ["he@1.2.0", "", { "bin": { "he": "bin/he" } }, "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="],
+
+    "immediate": ["immediate@3.0.6", "", {}, "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "is-path-inside": ["is-path-inside@3.0.3", "", {}, "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ=="],
+
+    "is-plain-obj": ["is-plain-obj@2.1.0", "", {}, "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="],
+
+    "is-unicode-supported": ["is-unicode-supported@0.1.0", "", {}, "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw=="],
+
+    "isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
+
+    "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
+    "jszip": ["jszip@3.10.1", "", { "dependencies": { "lie": "~3.3.0", "pako": "~1.0.2", "readable-stream": "~2.3.6", "setimmediate": "^1.0.5" } }, "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g=="],
+
+    "lie": ["lie@3.3.0", "", { "dependencies": { "immediate": "~3.0.5" } }, "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ=="],
+
+    "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
+    "log-symbols": ["log-symbols@4.1.0", "", { "dependencies": { "chalk": "^4.1.0", "is-unicode-supported": "^0.1.0" } }, "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg=="],
+
+    "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
+
+    "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
+
+    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
+    "mocha": ["mocha@11.7.5", "", { "dependencies": { "browser-stdout": "^1.3.1", "chokidar": "^4.0.1", "debug": "^4.3.5", "diff": "^7.0.0", "escape-string-regexp": "^4.0.0", "find-up": "^5.0.0", "glob": "^10.4.5", "he": "^1.2.0", "is-path-inside": "^3.0.3", "js-yaml": "^4.1.0", "log-symbols": "^4.1.0", "minimatch": "^9.0.5", "ms": "^2.1.3", "picocolors": "^1.1.1", "serialize-javascript": "^6.0.2", "strip-json-comments": "^3.1.1", "supports-color": "^8.1.1", "workerpool": "^9.2.0", "yargs": "^17.7.2", "yargs-parser": "^21.1.1", "yargs-unparser": "^2.0.0" }, "bin": { "mocha": "bin/mocha.js", "_mocha": "bin/_mocha" } }, "sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
+
+    "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
+
+    "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
+
+    "pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
+
+    "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
+
+    "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
+
+    "randombytes": ["randombytes@2.1.0", "", { "dependencies": { "safe-buffer": "^5.1.0" } }, "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ=="],
+
+    "readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
+
+    "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
+
+    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
+
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "selenium-webdriver": ["selenium-webdriver@4.43.0", "", { "dependencies": { "@bazel/runfiles": "^6.5.0", "jszip": "^3.10.1", "tmp": "^0.2.5", "ws": "^8.20.0" } }, "sha512-dV4zBTT37or3Z3/8uD6rS8zvd4ZxPuG4EJVlqYIbZCGZCYttZm7xb9rlFLSk4rrsQHAeDYvudl7cquo0vWpHjg=="],
+
+    "serialize-javascript": ["serialize-javascript@6.0.2", "", { "dependencies": { "randombytes": "^2.1.0" } }, "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g=="],
+
+    "setimmediate": ["setimmediate@1.0.5", "", {}, "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
+
+    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
+
+    "supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
+
+    "tmp": ["tmp@0.2.5", "", {}, "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow=="],
+
+    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "workerpool": ["workerpool@9.3.4", "", {}, "sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg=="],
+
+    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
+
+    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
+    "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
+
+    "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+
+    "yargs-unparser": ["yargs-unparser@2.0.0", "", { "dependencies": { "camelcase": "^6.0.0", "decamelize": "^4.0.0", "flat": "^5.0.2", "is-plain-obj": "^2.1.0" } }, "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA=="],
+
+    "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+
+    "@isaacs/cliui/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+
+    "chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+
+    "string_decoder/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+
+    "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+
+    "@isaacs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+  }
+}

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "2code-e2e-tests",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "mocha \"test/**/*.test.mjs\""
+  },
+  "dependencies": {
+    "chai": "^5.2.1",
+    "mocha": "^11.7.1",
+    "selenium-webdriver": "^4.34.0"
+  }
+}

--- a/e2e-tests/test/smoke.test.mjs
+++ b/e2e-tests/test/smoke.test.mjs
@@ -75,15 +75,19 @@ describe("Tauri smoke", function () {
 			return;
 		}
 
-		const filename = path.join(
-			artifactsDir,
-			`${sanitize(this.currentTest.title)}.png`,
-		);
+		const basename = sanitize(this.currentTest.title);
+		const screenshotPath = path.join(artifactsDir, `${basename}.png`);
+		const pageSourcePath = path.join(artifactsDir, `${basename}.html`);
 
 		try {
+			const pageSource = await driver.getPageSource();
+			await fsp.writeFile(pageSourcePath, pageSource, "utf8");
+
 			const screenshot = await driver.takeScreenshot();
-			await fsp.writeFile(filename, screenshot, "base64");
-			console.error(`Saved smoke-test failure screenshot to ${filename}`);
+			await fsp.writeFile(screenshotPath, screenshot, "base64");
+			console.error(
+				`Saved smoke-test failure diagnostics to ${screenshotPath} and ${pageSourcePath}`,
+			);
 		} catch (error) {
 			console.error("Failed to capture smoke-test screenshot:", error);
 		}
@@ -112,37 +116,7 @@ describe("Tauri smoke", function () {
 });
 
 function buildAppForSmoke() {
-	const targetTriple = runCommand("rustc", ["--print", "host-tuple"]).trim();
-	const helperBinary = path.join(
-		repoRoot,
-		"src-tauri",
-		"target",
-		"debug",
-		process.platform === "win32" ? "2code-helper.exe" : "2code-helper",
-	);
-	const helperDest = path.join(
-		repoRoot,
-		"src-tauri",
-		"binaries",
-		`2code-helper-${targetTriple}`,
-	);
-
-	runOrThrow("cargo", [
-		"build",
-		"--manifest-path",
-		"src-tauri/Cargo.toml",
-		"-p",
-		"twocode-helper",
-	]);
-
-	fs.mkdirSync(path.dirname(helperDest), { recursive: true });
-	fs.copyFileSync(helperBinary, helperDest);
-	if (process.platform !== "win32") {
-		fs.chmodSync(helperDest, 0o755);
-	}
-
-	runOrThrow("bun", ["run", "build"]);
-	runOrThrow("cargo", ["build", "--manifest-path", "src-tauri/Cargo.toml"]);
+	runOrThrow("bun", ["tauri", "build", "--debug", "--no-bundle"]);
 }
 
 function startTauriDriver() {
@@ -287,21 +261,6 @@ function runOrThrow(command, args) {
 	if (result.status !== 0) {
 		throw new Error(`Command failed: ${command} ${args.join(" ")}`);
 	}
-}
-
-function runCommand(command, args) {
-	const result = spawnSync(command, args, {
-		cwd: repoRoot,
-		encoding: "utf8",
-		shell: process.platform === "win32",
-		env: process.env,
-	});
-
-	if (result.status !== 0) {
-		throw new Error(result.stderr || `Command failed: ${command}`);
-	}
-
-	return result.stdout;
 }
 
 function assertExecutableExists(filepath, hint) {

--- a/e2e-tests/test/smoke.test.mjs
+++ b/e2e-tests/test/smoke.test.mjs
@@ -1,0 +1,264 @@
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { spawn, spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+import { expect } from "chai";
+import { Builder, By, Capabilities, until } from "selenium-webdriver";
+
+const testDir = fileURLToPath(new URL(".", import.meta.url));
+const e2eRoot = path.resolve(testDir, "..");
+const repoRoot = path.resolve(e2eRoot, "..");
+const artifactsDir = path.join(e2eRoot, "artifacts");
+const cargoHome =
+	process.env.CARGO_HOME ?? path.join(os.homedir(), ".cargo");
+const tauriDriverBinary = path.join(
+	cargoHome,
+	"bin",
+	process.platform === "win32" ? "tauri-driver.exe" : "tauri-driver",
+);
+const appBinary = path.join(
+	repoRoot,
+	"src-tauri",
+	"target",
+	"debug",
+	process.platform === "win32" ? "code.exe" : "code",
+);
+
+let driver;
+let tauriDriver;
+let tauriDriverClosed = false;
+
+describe("Tauri smoke", function () {
+	before(async function () {
+		if (process.platform === "darwin") {
+			console.warn(
+				"Skipping desktop smoke test on macOS: Tauri does not expose a desktop WebDriver client there.",
+			);
+			this.skip();
+			return;
+		}
+
+		this.timeout(15 * 60 * 1000);
+
+		await fsp.mkdir(artifactsDir, { recursive: true });
+		assertExecutableExists(
+			tauriDriverBinary,
+			"Install it first with `cargo install tauri-driver`.",
+		);
+
+		buildAppForSmoke();
+		assertExecutableExists(
+			appBinary,
+			`Expected built app binary at ${appBinary}.`,
+		);
+
+		startTauriDriver();
+		await waitForWebDriverServer();
+
+		const capabilities = new Capabilities();
+		capabilities.setBrowserName("wry");
+		capabilities.set("tauri:options", { application: appBinary });
+
+		driver = await new Builder()
+			.usingServer("http://127.0.0.1:4444/")
+			.withCapabilities(capabilities)
+			.build();
+
+		await driver.wait(until.elementLocated(By.css("body")), 60_000);
+	});
+
+	afterEach(async function () {
+		if (!driver || this.currentTest?.state !== "failed") {
+			return;
+		}
+
+		const filename = path.join(
+			artifactsDir,
+			`${sanitize(this.currentTest.title)}.png`,
+		);
+
+		try {
+			const screenshot = await driver.takeScreenshot();
+			await fsp.writeFile(filename, screenshot, "base64");
+			console.error(`Saved smoke-test failure screenshot to ${filename}`);
+		} catch (error) {
+			console.error("Failed to capture smoke-test screenshot:", error);
+		}
+	});
+
+	after(async function () {
+		await closeResources();
+	});
+
+	it("launches the desktop shell and renders a non-empty main layout", async function () {
+		this.timeout(60_000);
+
+		await driver.wait(until.elementLocated(By.css("nav[aria-label]")), 60_000);
+		await driver.wait(until.elementLocated(By.css("main")), 60_000);
+		await driver.wait(
+			until.elementLocated(By.css("#add-project-button")),
+			60_000,
+		);
+
+		await driver.wait(async () => {
+			const text = await readBodyText();
+			return text.trim().length > 20;
+		}, 60_000);
+
+		const nav = await driver.findElement(By.css("nav[aria-label]"));
+		const main = await driver.findElement(By.css("main"));
+		const addProjectButton = await driver.findElement(
+			By.css("#add-project-button"),
+		);
+		const bodyText = await readBodyText();
+
+		expect(await nav.isDisplayed()).to.equal(true);
+		expect(await main.isDisplayed()).to.equal(true);
+		expect(await addProjectButton.isDisplayed()).to.equal(true);
+		expect(bodyText).to.match(
+			/No projects yet|暂无项目|Create your first project|从侧边栏创建|Projects|项目|Settings|设置/,
+		);
+	});
+});
+
+function buildAppForSmoke() {
+	const targetTriple = runCommand("rustc", ["--print", "host-tuple"]).trim();
+	const helperBinary = path.join(
+		repoRoot,
+		"src-tauri",
+		"target",
+		"debug",
+		process.platform === "win32" ? "2code-helper.exe" : "2code-helper",
+	);
+	const helperDest = path.join(
+		repoRoot,
+		"src-tauri",
+		"binaries",
+		`2code-helper-${targetTriple}`,
+	);
+
+	runOrThrow("cargo", [
+		"build",
+		"--manifest-path",
+		"src-tauri/Cargo.toml",
+		"-p",
+		"twocode-helper",
+	]);
+
+	fs.mkdirSync(path.dirname(helperDest), { recursive: true });
+	fs.copyFileSync(helperBinary, helperDest);
+	if (process.platform !== "win32") {
+		fs.chmodSync(helperDest, 0o755);
+	}
+
+	runOrThrow("bun", ["run", "build"]);
+	runOrThrow("cargo", ["build", "--manifest-path", "src-tauri/Cargo.toml"]);
+}
+
+function startTauriDriver() {
+	const args = [];
+	if (process.env.TAURI_SMOKE_NATIVE_DRIVER) {
+		args.push("--native-driver", process.env.TAURI_SMOKE_NATIVE_DRIVER);
+	}
+
+	tauriDriver = spawn(tauriDriverBinary, args, {
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+
+	tauriDriver.stdout.on("data", (chunk) => {
+		process.stdout.write(chunk);
+	});
+	tauriDriver.stderr.on("data", (chunk) => {
+		process.stderr.write(chunk);
+	});
+	tauriDriver.on("error", (error) => {
+		throw new Error(`tauri-driver failed to start: ${error.message}`);
+	});
+	tauriDriver.on("exit", (code) => {
+		if (!tauriDriverClosed && code !== 0) {
+			throw new Error(`tauri-driver exited unexpectedly with code ${code}`);
+		}
+	});
+}
+
+async function waitForWebDriverServer() {
+	for (let attempt = 0; attempt < 60; attempt += 1) {
+		try {
+			const response = await fetch("http://127.0.0.1:4444/status");
+			if (response.ok) {
+				return;
+			}
+		} catch {}
+
+		await sleep(500);
+	}
+
+	throw new Error("Timed out waiting for tauri-driver to accept connections.");
+}
+
+async function readBodyText() {
+	return driver.findElement(By.css("body")).getText();
+}
+
+function runOrThrow(command, args) {
+	const result = spawnSync(command, args, {
+		cwd: repoRoot,
+		stdio: "inherit",
+		shell: process.platform === "win32",
+		env: {
+			...process.env,
+			CI: process.env.CI ?? "1",
+		},
+	});
+
+	if (result.status !== 0) {
+		throw new Error(`Command failed: ${command} ${args.join(" ")}`);
+	}
+}
+
+function runCommand(command, args) {
+	const result = spawnSync(command, args, {
+		cwd: repoRoot,
+		encoding: "utf8",
+		shell: process.platform === "win32",
+		env: process.env,
+	});
+
+	if (result.status !== 0) {
+		throw new Error(result.stderr || `Command failed: ${command}`);
+	}
+
+	return result.stdout;
+}
+
+function assertExecutableExists(filepath, hint) {
+	if (!fs.existsSync(filepath)) {
+		throw new Error(`Missing required binary: ${filepath}\n${hint}`);
+	}
+}
+
+function sanitize(value) {
+	return value.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+}
+
+function sleep(ms) {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function closeResources() {
+	if (driver) {
+		try {
+			await driver.quit();
+		} catch {}
+		driver = undefined;
+	}
+
+	if (tauriDriver) {
+		tauriDriverClosed = true;
+		tauriDriver.kill();
+		tauriDriver = undefined;
+	}
+}

--- a/e2e-tests/test/smoke.test.mjs
+++ b/e2e-tests/test/smoke.test.mjs
@@ -6,7 +6,7 @@ import { spawn, spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 import { expect } from "chai";
-import { Builder, By, Capabilities, until } from "selenium-webdriver";
+import { Builder, By, Capabilities } from "selenium-webdriver";
 
 const testDir = fileURLToPath(new URL(".", import.meta.url));
 const e2eRoot = path.resolve(testDir, "..");
@@ -67,7 +67,7 @@ describe("Tauri smoke", function () {
 			.withCapabilities(capabilities)
 			.build();
 
-		await driver.wait(until.elementLocated(By.css("body")), 60_000);
+		await waitForPageReady();
 	});
 
 	afterEach(async function () {
@@ -96,24 +96,11 @@ describe("Tauri smoke", function () {
 	it("launches the desktop shell and renders a non-empty main layout", async function () {
 		this.timeout(60_000);
 
-		await driver.wait(until.elementLocated(By.css("nav[aria-label]")), 60_000);
-		await driver.wait(until.elementLocated(By.css("main")), 60_000);
-		await driver.wait(
-			until.elementLocated(By.css("#add-project-button")),
-			60_000,
-		);
+		const nav = await waitForElement("nav[aria-label]");
+		const main = await waitForElement("main");
+		const addProjectButton = await waitForElement("#add-project-button");
 
-		await driver.wait(async () => {
-			const text = await readBodyText();
-			return text.trim().length > 20;
-		}, 60_000);
-
-		const nav = await driver.findElement(By.css("nav[aria-label]"));
-		const main = await driver.findElement(By.css("main"));
-		const addProjectButton = await driver.findElement(
-			By.css("#add-project-button"),
-		);
-		const bodyText = await readBodyText();
+		const bodyText = await waitForBodyText((text) => text.trim().length > 20);
 
 		expect(await nav.isDisplayed()).to.equal(true);
 		expect(await main.isDisplayed()).to.equal(true);
@@ -200,7 +187,90 @@ async function waitForWebDriverServer() {
 }
 
 async function readBodyText() {
-	return driver.findElement(By.css("body")).getText();
+	const body = await waitForElement("body");
+	return body.getText();
+}
+
+async function waitForPageReady(timeoutMs = 60_000) {
+	const deadline = Date.now() + timeoutMs;
+	let lastError;
+
+	while (Date.now() < deadline) {
+		try {
+			const readyState = await driver.executeScript(
+				"return document.readyState",
+			);
+			if (readyState === "complete") {
+				await waitForElement("body", 5_000);
+				return;
+			}
+		} catch (error) {
+			if (!isTransientNavigationError(error)) {
+				throw error;
+			}
+			lastError = error;
+		}
+
+		await sleep(500);
+	}
+
+	throw lastError ?? new Error("Timed out waiting for the Tauri page to load.");
+}
+
+async function waitForElement(selector, timeoutMs = 60_000) {
+	const deadline = Date.now() + timeoutMs;
+	let lastError;
+
+	while (Date.now() < deadline) {
+		try {
+			const elements = await driver.findElements(By.css(selector));
+			if (elements.length > 0) {
+				return elements[0];
+			}
+		} catch (error) {
+			if (!isTransientNavigationError(error)) {
+				throw error;
+			}
+			lastError = error;
+		}
+
+		await sleep(500);
+	}
+
+	throw (
+		lastError ?? new Error(`Timed out waiting for element matching ${selector}.`)
+	);
+}
+
+async function waitForBodyText(predicate, timeoutMs = 60_000) {
+	const deadline = Date.now() + timeoutMs;
+	let lastError;
+
+	while (Date.now() < deadline) {
+		try {
+			const text = await readBodyText();
+			if (predicate(text)) {
+				return text;
+			}
+		} catch (error) {
+			if (!isTransientNavigationError(error)) {
+				throw error;
+			}
+			lastError = error;
+		}
+
+		await sleep(500);
+	}
+
+	throw lastError ?? new Error("Timed out waiting for non-empty body text.");
+}
+
+function isTransientNavigationError(error) {
+	const name = error?.name ?? "";
+	const message = error?.message ?? "";
+
+	return /NoSuchFrameError|StaleElementReferenceError/i.test(name)
+		|| /unload event|stale element/i.test(message);
 }
 
 function runOrThrow(command, args) {

--- a/justfile
+++ b/justfile
@@ -31,5 +31,8 @@ coverage:
 coverage-summary:
     cd src-tauri && cargo llvm-cov --lib --tests
 
+tauri-smoke:
+    cd e2e-tests && bun run test
+
 cloc:
     cloc --include-lang="TypeScript,Rust,JavaScript,CSS" . --exclude-dir=node_modules,dist,target --fullpath --not-match-d='(src-tauri/target|src/generated|src/paraglide)'

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "start": "tauri dev",
     "lint": "eslint --fix",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:tauri-smoke": "cd e2e-tests && bun run test"
   },
   "dependencies": {
     "@chakra-ui/react": "^3.34.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -37,12 +37,14 @@ tauri-plugin-shell = "2.3.5"
 # App-layer only dependencies
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
-core-text = "20"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = [ "env-filter" ] }
 axum = "0.8"
 tokio = { version = "1", features = [ "net" ] }
 fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs" }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+core-text = "20"
 
 [dev-dependencies]
 diesel = { version = "2", features = ["sqlite"] }

--- a/src-tauri/src/handler/font.rs
+++ b/src-tauri/src/handler/font.rs
@@ -1,8 +1,4 @@
-use core_text::font::*;
-use core_text::font_collection::create_for_all_families;
-use core_text::font_descriptor::kCTFontMonoSpaceTrait;
 use serde::Serialize;
-use std::collections::BTreeMap;
 
 #[derive(Debug, Serialize, Clone)]
 pub struct SystemFont {
@@ -10,7 +6,13 @@ pub struct SystemFont {
 	pub is_mono: bool,
 }
 
+#[cfg(target_os = "macos")]
 fn load_system_fonts() -> Vec<SystemFont> {
+	use core_text::font::*;
+	use core_text::font_collection::create_for_all_families;
+	use core_text::font_descriptor::kCTFontMonoSpaceTrait;
+	use std::collections::BTreeMap;
+
 	let collection = create_for_all_families();
 	let descriptors = collection.get_descriptors();
 
@@ -39,6 +41,11 @@ fn load_system_fonts() -> Vec<SystemFont> {
 		.into_iter()
 		.map(|(family, is_mono)| SystemFont { family, is_mono })
 		.collect()
+}
+
+#[cfg(not(target_os = "macos"))]
+fn load_system_fonts() -> Vec<SystemFont> {
+	Vec::new()
 }
 
 #[tauri::command]

--- a/src-tauri/src/handler/sound.rs
+++ b/src-tauri/src/handler/sound.rs
@@ -1,42 +1,63 @@
-use std::fs;
-use std::path::Path;
-use std::process::Command;
-
+#[cfg(target_os = "macos")]
 const SOUNDS_DIR: &str = "/System/Library/Sounds";
 
 #[tauri::command]
 pub fn list_system_sounds() -> Vec<String> {
-	let sounds_path = Path::new(SOUNDS_DIR);
-	let mut sounds: Vec<String> = fs::read_dir(sounds_path)
-		.into_iter()
-		.flatten()
-		.filter_map(|entry| {
-			let entry = entry.ok()?;
-			let name = entry.file_name().into_string().ok()?;
-			name.strip_suffix(".aiff").map(|s| s.to_string())
-		})
-		.collect();
-	sounds.sort();
-	sounds
+	#[cfg(target_os = "macos")]
+	{
+		use std::fs;
+		use std::path::Path;
+
+		let sounds_path = Path::new(SOUNDS_DIR);
+		let mut sounds: Vec<String> = fs::read_dir(sounds_path)
+			.into_iter()
+			.flatten()
+			.filter_map(|entry| {
+				let entry = entry.ok()?;
+				let name = entry.file_name().into_string().ok()?;
+				name.strip_suffix(".aiff").map(|s| s.to_string())
+			})
+			.collect();
+		sounds.sort();
+		return sounds;
+	}
+
+	#[cfg(not(target_os = "macos"))]
+	{
+		Vec::new()
+	}
 }
 
 #[tauri::command]
 pub fn play_system_sound(name: String) -> Result<(), String> {
-	let path = Path::new(SOUNDS_DIR).join(format!("{name}.aiff"));
-	if !path.exists() {
-		return Err(format!("Sound not found: {name}"));
+	#[cfg(target_os = "macos")]
+	{
+		use std::path::Path;
+		use std::process::Command;
+
+		let path = Path::new(SOUNDS_DIR).join(format!("{name}.aiff"));
+		if !path.exists() {
+			return Err(format!("Sound not found: {name}"));
+		}
+		Command::new("afplay")
+			.arg(&path)
+			.spawn()
+			.map_err(|e| format!("Failed to play sound: {e}"))?;
+		return Ok(());
 	}
-	Command::new("afplay")
-		.arg(&path)
-		.spawn()
-		.map_err(|e| format!("Failed to play sound: {e}"))?;
-	Ok(())
+
+	#[cfg(not(target_os = "macos"))]
+	{
+		let _ = name;
+		Ok(())
+	}
 }
 
 #[cfg(test)]
 mod tests {
 	use super::*;
 
+	#[cfg(target_os = "macos")]
 	#[test]
 	fn play_nonexistent_sound_returns_error() {
 		let result = play_system_sound("definitely_not_a_real_sound".into());
@@ -45,6 +66,7 @@ mod tests {
 		assert!(err.contains("Sound not found"));
 	}
 
+	#[cfg(target_os = "macos")]
 	#[test]
 	fn list_system_sounds_is_sorted() {
 		let sounds = list_system_sounds();
@@ -60,6 +82,7 @@ mod tests {
 		}
 	}
 
+	#[cfg(target_os = "macos")]
 	#[test]
 	fn list_system_sounds_no_aiff_extension() {
 		let sounds = list_system_sounds();
@@ -69,5 +92,12 @@ mod tests {
 				"sound name should not have .aiff extension: {name}"
 			);
 		}
+	}
+
+	#[cfg(not(target_os = "macos"))]
+	#[test]
+	fn non_macos_sound_commands_are_noops() {
+		assert!(list_system_sounds().is_empty());
+		assert!(play_system_sound("anything".into()).is_ok());
 	}
 }

--- a/src-tauri/src/helper.rs
+++ b/src-tauri/src/helper.rs
@@ -7,6 +7,7 @@ use axum::extract::{Query, State};
 use axum::routing::get;
 use axum::Json;
 use tauri::{AppHandle, Emitter};
+#[cfg(target_os = "macos")]
 use tauri_plugin_store::StoreExt;
 
 pub struct HelperState {

--- a/src-tauri/src/helper.rs
+++ b/src-tauri/src/helper.rs
@@ -1,6 +1,5 @@
 use std::net::TcpListener;
 use std::path::PathBuf;
-use std::process::Command;
 
 use std::collections::HashMap;
 
@@ -53,34 +52,45 @@ async fn notify_handler(
 }
 
 fn try_play_notification(app: &AppHandle) -> bool {
-	let store = match app.store("settings.json") {
-		Ok(s) => s,
-		Err(_) => return false,
-	};
+	#[cfg(not(target_os = "macos"))]
+	{
+		let _ = app;
+		return false;
+	}
 
-	let val = match store.get("notification-settings") {
-		Some(v) => v,
-		None => return false,
-	};
+	#[cfg(target_os = "macos")]
+	{
+		use std::process::Command;
 
-	let entry: model::notification::NotificationEntry =
-		match serde_json::from_value(val) {
-			Ok(e) => e,
+		let store = match app.store("settings.json") {
+			Ok(s) => s,
 			Err(_) => return false,
 		};
 
-	if !entry.state.enabled {
-		return false;
+		let val = match store.get("notification-settings") {
+			Some(v) => v,
+			None => return false,
+		};
+
+		let entry: model::notification::NotificationEntry =
+			match serde_json::from_value(val) {
+				Ok(e) => e,
+				Err(_) => return false,
+			};
+
+		if !entry.state.enabled {
+			return false;
+		}
+
+		let sound_path =
+			format!("/System/Library/Sounds/{}.aiff", entry.state.sound);
+
+		if !std::path::Path::new(&sound_path).exists() {
+			return false;
+		}
+
+		Command::new("afplay").arg(&sound_path).spawn().is_ok()
 	}
-
-	let sound_path =
-		format!("/System/Library/Sounds/{}.aiff", entry.state.sound);
-
-	if !std::path::Path::new(&sound_path).exists() {
-		return false;
-	}
-
-	Command::new("afplay").arg(&sound_path).spawn().is_ok()
 }
 
 async fn health_handler() -> &'static str {

--- a/src/features/git/utils.test.ts
+++ b/src/features/git/utils.test.ts
@@ -44,7 +44,7 @@ function makeFile(
 	hunks: Array<{
 		hunkContent: Array<
 			| { type: "context" }
-			| { type: "change"; additions: string[]; deletions: string[] }
+			| { type: "change"; additions: number; deletions: number }
 		>;
 	}>,
 ): FileDiffMetadata {
@@ -70,8 +70,8 @@ describe("getLineStats", () => {
 				hunkContent: [
 					{
 						type: "change",
-						additions: ["a", "b"],
-						deletions: ["c"],
+						additions: 2,
+						deletions: 1,
 					},
 				],
 			},
@@ -85,13 +85,13 @@ describe("getLineStats", () => {
 				hunkContent: [
 					{
 						type: "change",
-						additions: ["a"],
-						deletions: ["b", "c"],
+						additions: 1,
+						deletions: 2,
 					},
 					{
 						type: "change",
-						additions: ["d", "e", "f"],
-						deletions: [],
+						additions: 3,
+						deletions: 0,
 					},
 				],
 			},
@@ -103,15 +103,15 @@ describe("getLineStats", () => {
 		const file = makeFile([
 			{
 				hunkContent: [
-					{ type: "change", additions: ["a"], deletions: ["b"] },
+					{ type: "change", additions: 1, deletions: 1 },
 				],
 			},
 			{
 				hunkContent: [
 					{
 						type: "change",
-						additions: ["c", "d"],
-						deletions: ["e"],
+						additions: 2,
+						deletions: 1,
 					},
 				],
 			},
@@ -124,7 +124,7 @@ describe("getLineStats", () => {
 			{
 				hunkContent: [
 					{ type: "context" },
-					{ type: "change", additions: ["a"], deletions: [] },
+					{ type: "change", additions: 1, deletions: 0 },
 					{ type: "context" },
 				],
 			},
@@ -136,7 +136,7 @@ describe("getLineStats", () => {
 		const file = makeFile([
 			{
 				hunkContent: [
-					{ type: "change", additions: [], deletions: ["x"] },
+					{ type: "change", additions: 0, deletions: 1 },
 				],
 			},
 		]);
@@ -147,7 +147,7 @@ describe("getLineStats", () => {
 		const file = makeFile([
 			{
 				hunkContent: [
-					{ type: "change", additions: [], deletions: [] },
+					{ type: "change", additions: 0, deletions: 0 },
 				],
 			},
 		]);
@@ -164,8 +164,8 @@ describe("getLineStats", () => {
 			hunkContent: [
 				{
 					type: "change" as const,
-					additions: ["a"],
-					deletions: ["b", "c"],
+					additions: 1,
+					deletions: 2,
 				},
 			],
 		}));
@@ -179,12 +179,12 @@ describe("getLineStats", () => {
 		const file = makeFile([
 			{
 				hunkContent: [
-					{ type: "change", additions: ["a", "b", "c"], deletions: [] },
+					{ type: "change", additions: 3, deletions: 0 },
 				],
 			},
 			{
 				hunkContent: [
-					{ type: "change", additions: ["d"], deletions: [] },
+					{ type: "change", additions: 1, deletions: 0 },
 				],
 			},
 		]);
@@ -195,7 +195,7 @@ describe("getLineStats", () => {
 		const file = makeFile([
 			{
 				hunkContent: [
-					{ type: "change", additions: [], deletions: ["a", "b"] },
+					{ type: "change", additions: 0, deletions: 2 },
 				],
 			},
 		]);
@@ -207,7 +207,7 @@ describe("getLineStats", () => {
 			{
 				hunkContent: [
 					{ type: "unknown-type" } as never,
-					{ type: "change", additions: ["a"], deletions: [] },
+					{ type: "change", additions: 1, deletions: 0 },
 				],
 			},
 		]);

--- a/src/features/topbar/store.test.ts
+++ b/src/features/topbar/store.test.ts
@@ -22,6 +22,7 @@ describe("useTopBarStore", () => {
 				"github-desktop",
 				"vscode",
 				"git-diff",
+				"reveal-in-finder",
 			]);
 		});
 

--- a/src/shared/lib/queryKeys.test.ts
+++ b/src/shared/lib/queryKeys.test.ts
@@ -5,8 +5,10 @@ describe("queryNamespaces", () => {
 	it("contains all expected namespace strings", () => {
 		expect(queryNamespaces).toEqual({
 			project: "project",
+			"project-config": "project-config",
 			"git-branch": "git-branch",
 			"git-diff": "git-diff",
+			"git-diff-stats": "git-diff-stats",
 			"git-log": "git-log",
 			"git-commit-diff": "git-commit-diff",
 		});
@@ -24,6 +26,15 @@ describe("queryKeys", () => {
 		});
 	});
 
+	describe("projectConfig", () => {
+		it("includes projectId in key", () => {
+			expect(queryKeys.projectConfig("project-1")).toEqual([
+				"project-config",
+				"project-1",
+			]);
+		});
+	});
+
 	describe("git", () => {
 		it("branch() includes folder in key", () => {
 			expect(queryKeys.git.branch("/path/to/repo")).toEqual([
@@ -35,6 +46,13 @@ describe("queryKeys", () => {
 		it("diff() includes profileId in key", () => {
 			expect(queryKeys.git.diff("profile-1")).toEqual([
 				"git-diff",
+				"profile-1",
+			]);
+		});
+
+		it("diffStats() includes profileId in key", () => {
+			expect(queryKeys.git.diffStats("profile-1")).toEqual([
+				"git-diff-stats",
 				"profile-1",
 			]);
 		});


### PR DESCRIPTION
## Summary
- add a CI-oriented Tauri desktop smoke test under `e2e-tests/`
- add a GitHub Actions workflow to run the smoke test on Linux with `xvfb`
- add root command entrypoints for running the smoke test locally or in CI

## Validation
- `bun run test:tauri-smoke` on macOS: skips as expected because Tauri does not provide a desktop WebDriver client on macOS
- local prebuild chain completed successfully: helper build, frontend build, and app `cargo build`

## Notes
- the desktop e2e suite is intended for Linux CI runners
- if CI exposes issues in the workflow or smoke assertions, I will push follow-up fixes on this branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive end-to-end smoke testing for the desktop application with automated CI/CD integration.

* **Bug Fixes**
  * Improved platform compatibility by restricting sound and system font features to macOS where they are supported.

* **Tests**
  * Expanded test coverage for configuration queries and file diff analysis.
  * Updated test fixtures to match current data structure requirements.

* **Chores**
  * Added GitHub Actions workflow for automated smoke test execution.
  * Introduced new test commands for local and CI environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->