### PR TITLE
feat(terminal): add keyboard shortcuts for navigation

### DIFF
--- a/src/features/terminal/Terminal.tsx
+++ b/src/features/terminal/Terminal.tsx
@@ -14,6 +14,7 @@ import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useTerminalSettingsStore } from "@/features/settings/stores/terminalSettingsStore";
 import { flushPtyOutput, resizePty, writeToPty } from "@/generated";
 import { useTerminalTheme } from "./hooks";
+import { getTerminalShortcutSequence } from "./keybindings";
 import { sessionHistory } from "./state";
 import { useTerminalStore } from "./store";
 import "@xterm/xterm/css/xterm.css";
@@ -160,6 +161,16 @@ export function Terminal({ profileId, sessionId, isActive }: TerminalProps) {
 				cursorWidth: 4,
 			});
 			unlisteners.push(() => term.dispose());
+
+			term.attachCustomKeyEventHandler((event) => {
+				const sequence = getTerminalShortcutSequence(event);
+				if (!sequence) return true;
+
+				event.preventDefault();
+				event.stopPropagation();
+				void writeToPty({ sessionId, data: sequence });
+				return false;
+			});
 
 			const fitAddon = new FitAddon();
 			term.loadAddon(fitAddon);

--- a/src/features/terminal/keybindings.test.ts
+++ b/src/features/terminal/keybindings.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+	getTerminalShortcutSequence,
+	type TerminalShortcutKeyEvent,
+} from "./keybindings";
+
+function makeEvent(
+	overrides: Partial<TerminalShortcutKeyEvent> = {},
+): TerminalShortcutKeyEvent {
+	return {
+		type: "keydown",
+		key: "a",
+		altKey: false,
+		ctrlKey: false,
+		metaKey: false,
+		shiftKey: false,
+		...overrides,
+	};
+}
+
+describe("getTerminalShortcutSequence", () => {
+	it("maps Cmd+Left to line start on macOS", () => {
+		expect(
+			getTerminalShortcutSequence(
+				makeEvent({ metaKey: true, key: "ArrowLeft" }),
+				"MacIntel",
+			),
+		).toBe("\x1b[H");
+	});
+
+	it("maps Cmd+Right to line end on macOS", () => {
+		expect(
+			getTerminalShortcutSequence(
+				makeEvent({ metaKey: true, key: "ArrowRight" }),
+				"MacIntel",
+			),
+		).toBe("\x1b[F");
+	});
+
+	it("does not map Cmd+Arrow on non-macOS platforms", () => {
+		expect(
+			getTerminalShortcutSequence(
+				makeEvent({ metaKey: true, key: "ArrowLeft" }),
+				"Win32",
+			),
+		).toBeNull();
+	});
+
+	it("maps Alt+Left to previous word", () => {
+		expect(
+			getTerminalShortcutSequence(makeEvent({ altKey: true, key: "ArrowLeft" })),
+		).toBe("\x1bb");
+	});
+
+	it("maps Alt+Right to next word", () => {
+		expect(
+			getTerminalShortcutSequence(makeEvent({ altKey: true, key: "ArrowRight" })),
+		).toBe("\x1bf");
+	});
+
+	it("ignores other modifier combinations and non-keydown events", () => {
+		expect(
+			getTerminalShortcutSequence(
+				makeEvent({ ctrlKey: true, altKey: true, key: "ArrowLeft" }),
+			),
+		).toBeNull();
+		expect(
+			getTerminalShortcutSequence(
+				makeEvent({ type: "keyup", metaKey: true, key: "ArrowLeft" }),
+				"MacIntel",
+			),
+		).toBeNull();
+	});
+});

--- a/src/features/terminal/keybindings.ts
+++ b/src/features/terminal/keybindings.ts
@@ -1,0 +1,32 @@
+export interface TerminalShortcutKeyEvent {
+	type: string;
+	key: string;
+	altKey: boolean;
+	ctrlKey: boolean;
+	metaKey: boolean;
+	shiftKey: boolean;
+}
+
+function isMacPlatform(platform: string) {
+	return platform.toUpperCase().includes("MAC");
+}
+
+export function getTerminalShortcutSequence(
+	event: TerminalShortcutKeyEvent,
+	platform = globalThis.navigator?.platform ?? "",
+): string | null {
+	if (event.type !== "keydown") return null;
+	if (event.ctrlKey || event.shiftKey) return null;
+
+	if (isMacPlatform(platform) && event.metaKey && !event.altKey) {
+		if (event.key === "ArrowLeft") return "\x1b[H";
+		if (event.key === "ArrowRight") return "\x1b[F";
+	}
+
+	if (event.altKey && !event.metaKey) {
+		if (event.key === "ArrowLeft") return "\x1bb";
+		if (event.key === "ArrowRight") return "\x1bf";
+	}
+
+	return null;
+}


### PR DESCRIPTION
Add support for terminal keyboard shortcuts:
- Cmd+ArrowLeft/Right on Mac → Home/End
- Alt+ArrowLeft/Right → Word navigation

Introduces keybindings module with getTerminalShortcutSequence
function and corresponding unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added terminal keyboard shortcuts for improved command-line navigation, including Command/Option+Arrow key combinations on macOS and Alt+Arrow key bindings on all platforms for word and line navigation.

* **Tests**
  * Added comprehensive test coverage for keyboard shortcut mappings and platform-specific behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->