### PR TITLE
feat(terminal): add font size shortcuts

### DIFF
--- a/src/features/settings/FontSizePicker.tsx
+++ b/src/features/settings/FontSizePicker.tsx
@@ -1,6 +1,10 @@
 import { Field, NumberInput } from "@chakra-ui/react";
 import * as m from "@/paraglide/messages.js";
-import { useTerminalSettingsStore } from "./stores/terminalSettingsStore";
+import {
+	MAX_TERMINAL_FONT_SIZE,
+	MIN_TERMINAL_FONT_SIZE,
+	useTerminalSettingsStore,
+} from "./stores/terminalSettingsStore";
 
 export function FontSizePicker() {
 	const { fontSize, setFontSize } = useTerminalSettingsStore();
@@ -9,10 +13,13 @@ export function FontSizePicker() {
 		<Field.Root>
 			<Field.Label>{m.fontSize()}</Field.Label>
 			<NumberInput.Root
-				min={10}
-				max={20}
+				min={MIN_TERMINAL_FONT_SIZE}
+				max={MAX_TERMINAL_FONT_SIZE}
 				value={String(fontSize)}
-				onValueChange={(e) => setFontSize(Number(e.value))}
+				onValueChange={(e) => {
+					if (e.value === "") return;
+					setFontSize(Number(e.value));
+				}}
 			>
 				<NumberInput.Control />
 				<NumberInput.Input />

--- a/src/features/settings/stores/terminalSettingsStore.test.ts
+++ b/src/features/settings/stores/terminalSettingsStore.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { useTerminalSettingsStore } from "./terminalSettingsStore";
+import {
+	MAX_TERMINAL_FONT_SIZE,
+	MIN_TERMINAL_FONT_SIZE,
+	useTerminalSettingsStore,
+} from "./terminalSettingsStore";
 
 function resetStore() {
 	useTerminalSettingsStore.setState({
@@ -67,6 +71,14 @@ describe("useTerminalSettingsStore", () => {
 			expect(getState().fontSize).toBe(16);
 		});
 
+		it("clamps fontSize to the configured range", () => {
+			getState().setFontSize(MAX_TERMINAL_FONT_SIZE + 5);
+			expect(getState().fontSize).toBe(MAX_TERMINAL_FONT_SIZE);
+
+			getState().setFontSize(MIN_TERMINAL_FONT_SIZE - 5);
+			expect(getState().fontSize).toBe(MIN_TERMINAL_FONT_SIZE);
+		});
+
 		it("does not trigger font CSS sync", () => {
 			getState().setFontFamily("Test Font");
 			const before = document.documentElement.style.getPropertyValue(
@@ -77,6 +89,28 @@ describe("useTerminalSettingsStore", () => {
 				"--chakra-fonts-mono",
 			);
 			expect(after).toBe(before);
+		});
+	});
+
+	describe("fontSize helpers", () => {
+		it("increaseFontSize increments within bounds", () => {
+			getState().increaseFontSize();
+			expect(getState().fontSize).toBe(14);
+		});
+
+		it("decreaseFontSize decrements within bounds", () => {
+			getState().decreaseFontSize();
+			expect(getState().fontSize).toBe(12);
+		});
+
+		it("does not grow past max or shrink past min", () => {
+			getState().setFontSize(MAX_TERMINAL_FONT_SIZE);
+			getState().increaseFontSize();
+			expect(getState().fontSize).toBe(MAX_TERMINAL_FONT_SIZE);
+
+			getState().setFontSize(MIN_TERMINAL_FONT_SIZE);
+			getState().decreaseFontSize();
+			expect(getState().fontSize).toBe(MIN_TERMINAL_FONT_SIZE);
 		});
 	});
 

--- a/src/features/settings/stores/terminalSettingsStore.ts
+++ b/src/features/settings/stores/terminalSettingsStore.ts
@@ -2,6 +2,10 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import type { TerminalThemeId } from "@/features/terminal/themes";
 
+export const DEFAULT_TERMINAL_FONT_SIZE = 13;
+export const MIN_TERMINAL_FONT_SIZE = 10;
+export const MAX_TERMINAL_FONT_SIZE = 20;
+
 interface TerminalSettingsStore {
 	fontFamily: string;
 	fontSize: number;
@@ -11,23 +15,42 @@ interface TerminalSettingsStore {
 	syncTerminalTheme: boolean;
 	setFontFamily: (family: string) => void;
 	setFontSize: (size: number) => void;
+	increaseFontSize: () => void;
+	decreaseFontSize: () => void;
 	setShowAllFonts: (show: boolean) => void;
 	setDarkTerminalTheme: (id: TerminalThemeId) => void;
 	setLightTerminalTheme: (id: TerminalThemeId) => void;
 	setSyncTerminalTheme: (sync: boolean) => void;
 }
 
+function clampTerminalFontSize(size: number) {
+	if (!Number.isFinite(size)) return DEFAULT_TERMINAL_FONT_SIZE;
+	return Math.min(
+		MAX_TERMINAL_FONT_SIZE,
+		Math.max(MIN_TERMINAL_FONT_SIZE, Math.round(size)),
+	);
+}
+
 export const useTerminalSettingsStore = create<TerminalSettingsStore>()(
 	persist(
 		(set) => ({
 			fontFamily: "JetBrains Mono",
-			fontSize: 13,
+			fontSize: DEFAULT_TERMINAL_FONT_SIZE,
 			showAllFonts: false,
 			darkTerminalTheme: "github-dark",
 			lightTerminalTheme: "github-light",
 			syncTerminalTheme: false,
 			setFontFamily: (family) => set({ fontFamily: family }),
-			setFontSize: (size) => set({ fontSize: size }),
+			setFontSize: (size) =>
+				set({ fontSize: clampTerminalFontSize(size) }),
+			increaseFontSize: () =>
+				set((state) => ({
+					fontSize: clampTerminalFontSize(state.fontSize + 1),
+				})),
+			decreaseFontSize: () =>
+				set((state) => ({
+					fontSize: clampTerminalFontSize(state.fontSize - 1),
+				})),
 			setShowAllFonts: (show) => set({ showAllFonts: show }),
 			setDarkTerminalTheme: (id) => set({ darkTerminalTheme: id }),
 			setLightTerminalTheme: (id) => set({ lightTerminalTheme: id }),

--- a/src/features/terminal/Terminal.tsx
+++ b/src/features/terminal/Terminal.tsx
@@ -14,7 +14,7 @@ import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useTerminalSettingsStore } from "@/features/settings/stores/terminalSettingsStore";
 import { flushPtyOutput, resizePty, writeToPty } from "@/generated";
 import { useTerminalTheme } from "./hooks";
-import { getTerminalShortcutSequence } from "./keybindings";
+import { getTerminalShortcutAction } from "./keybindings";
 import { sessionHistory } from "./state";
 import { useTerminalStore } from "./store";
 import "@xterm/xterm/css/xterm.css";
@@ -33,6 +33,8 @@ export function Terminal({ profileId, sessionId, isActive }: TerminalProps) {
 	const layoutFrameRef = useRef<number | null>(null);
 	const fontFamily = useTerminalSettingsStore((s) => s.fontFamily);
 	const fontSize = useTerminalSettingsStore((s) => s.fontSize);
+	const increaseFontSize = useTerminalSettingsStore((s) => s.increaseFontSize);
+	const decreaseFontSize = useTerminalSettingsStore((s) => s.decreaseFontSize);
 	const theme = useTerminalTheme();
 
 	const initFontFamilyRef = useRef(fontFamily);
@@ -163,12 +165,23 @@ export function Terminal({ profileId, sessionId, isActive }: TerminalProps) {
 			unlisteners.push(() => term.dispose());
 
 			term.attachCustomKeyEventHandler((event) => {
-				const sequence = getTerminalShortcutSequence(event);
-				if (!sequence) return true;
+				const action = getTerminalShortcutAction(event);
+				if (!action) return true;
 
 				event.preventDefault();
 				event.stopPropagation();
-				void writeToPty({ sessionId, data: sequence });
+
+				if (action.type === "increase-font-size") {
+					increaseFontSize();
+					return false;
+				}
+
+				if (action.type === "decrease-font-size") {
+					decreaseFontSize();
+					return false;
+				}
+
+				void writeToPty({ sessionId, data: action.sequence });
 				return false;
 			});
 
@@ -304,7 +317,13 @@ export function Terminal({ profileId, sessionId, isActive }: TerminalProps) {
 				fitAddonRef.current = null;
 			};
 		},
-		[profileId, sessionId, syncTerminalLayout],
+		[
+			decreaseFontSize,
+			increaseFontSize,
+			profileId,
+			sessionId,
+			syncTerminalLayout,
+		],
 	);
 
 	return (

--- a/src/features/terminal/keybindings.test.ts
+++ b/src/features/terminal/keybindings.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+	getTerminalShortcutAction,
 	getTerminalShortcutSequence,
 	type TerminalShortcutKeyEvent,
 } from "./keybindings";
@@ -68,6 +69,49 @@ describe("getTerminalShortcutSequence", () => {
 			getTerminalShortcutSequence(
 				makeEvent({ type: "keyup", metaKey: true, key: "ArrowLeft" }),
 				"MacIntel",
+			),
+		).toBeNull();
+	});
+});
+
+describe("getTerminalShortcutAction", () => {
+	it("maps Cmd+= to increase font size on macOS", () => {
+		expect(
+			getTerminalShortcutAction(
+				makeEvent({ metaKey: true, key: "=", code: "Equal" }),
+				"MacIntel",
+			),
+		).toEqual({ type: "increase-font-size" });
+	});
+
+	it("maps Cmd++ to increase font size on macOS", () => {
+		expect(
+			getTerminalShortcutAction(
+				makeEvent({
+					metaKey: true,
+					shiftKey: true,
+					key: "+",
+					code: "Equal",
+				}),
+				"MacIntel",
+			),
+		).toEqual({ type: "increase-font-size" });
+	});
+
+	it("maps Cmd+- to decrease font size on macOS", () => {
+		expect(
+			getTerminalShortcutAction(
+				makeEvent({ metaKey: true, key: "-", code: "Minus" }),
+				"MacIntel",
+			),
+		).toEqual({ type: "decrease-font-size" });
+	});
+
+	it("does not map font size shortcuts on non-macOS platforms", () => {
+		expect(
+			getTerminalShortcutAction(
+				makeEvent({ metaKey: true, key: "=", code: "Equal" }),
+				"Win32",
 			),
 		).toBeNull();
 	});

--- a/src/features/terminal/keybindings.ts
+++ b/src/features/terminal/keybindings.ts
@@ -1,32 +1,83 @@
 export interface TerminalShortcutKeyEvent {
 	type: string;
 	key: string;
+	code?: string;
 	altKey: boolean;
 	ctrlKey: boolean;
 	metaKey: boolean;
 	shiftKey: boolean;
 }
 
+export type TerminalShortcutAction =
+	| { type: "write-sequence"; sequence: string }
+	| { type: "increase-font-size" }
+	| { type: "decrease-font-size" };
+
 function isMacPlatform(platform: string) {
 	return platform.toUpperCase().includes("MAC");
+}
+
+function isPlainMetaShortcut(
+	event: TerminalShortcutKeyEvent,
+	platform: string,
+) {
+	return (
+		isMacPlatform(platform)
+		&& event.metaKey
+		&& !event.ctrlKey
+		&& !event.altKey
+	);
+}
+
+export function getTerminalShortcutAction(
+	event: TerminalShortcutKeyEvent,
+	platform = globalThis.navigator?.platform ?? "",
+): TerminalShortcutAction | null {
+	if (event.type !== "keydown") return null;
+
+	if (isPlainMetaShortcut(event, platform) && !event.shiftKey) {
+		if (event.key === "ArrowLeft") {
+			return { type: "write-sequence", sequence: "\x1b[H" };
+		}
+		if (event.key === "ArrowRight") {
+			return { type: "write-sequence", sequence: "\x1b[F" };
+		}
+	}
+
+	if (event.altKey && !event.metaKey && !event.ctrlKey && !event.shiftKey) {
+		if (event.key === "ArrowLeft") {
+			return { type: "write-sequence", sequence: "\x1bb" };
+		}
+		if (event.key === "ArrowRight") {
+			return { type: "write-sequence", sequence: "\x1bf" };
+		}
+	}
+
+	if (isPlainMetaShortcut(event, platform)) {
+		if (
+			event.code === "Equal"
+			|| event.key === "="
+			|| event.key === "+"
+		) {
+			return { type: "increase-font-size" };
+		}
+		if (
+			event.code === "Minus"
+			|| event.key === "-"
+			|| event.key === "_"
+		) {
+			return { type: "decrease-font-size" };
+		}
+	}
+
+	return null;
 }
 
 export function getTerminalShortcutSequence(
 	event: TerminalShortcutKeyEvent,
 	platform = globalThis.navigator?.platform ?? "",
 ): string | null {
-	if (event.type !== "keydown") return null;
-	if (event.ctrlKey || event.shiftKey) return null;
-
-	if (isMacPlatform(platform) && event.metaKey && !event.altKey) {
-		if (event.key === "ArrowLeft") return "\x1b[H";
-		if (event.key === "ArrowRight") return "\x1b[F";
-	}
-
-	if (event.altKey && !event.metaKey) {
-		if (event.key === "ArrowLeft") return "\x1bb";
-		if (event.key === "ArrowRight") return "\x1bf";
-	}
-
-	return null;
+	const action = getTerminalShortcutAction(event, platform);
+	if (action?.type !== "write-sequence") return null;
+	return action.sequence;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcuts for terminal font size adjustment (Cmd+= to increase, Cmd+- to decrease on macOS)

* **Bug Fixes**
  * Improved font size input validation to prevent invalid or empty values from being processed
  * Font size adjustments now consistently respect minimum and maximum bounds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->