### PR TITLE
fix(settings): persist language switching in Tauri

### DIFF
--- a/src/features/home/TourOnboarding.tsx
+++ b/src/features/home/TourOnboarding.tsx
@@ -2,12 +2,14 @@ import { useEffect, useMemo } from "react";
 import { driver } from "driver.js";
 import "driver.js/dist/driver.css";
 import * as m from "@/paraglide/messages.js";
+import { useLocale } from "@/shared/lib/locale";
 
 interface TourOnboardingProps {
 	isEnabled: boolean;
 }
 
 export function TourOnboarding({ isEnabled }: TourOnboardingProps) {
+	const locale = useLocale();
 	const driverObj = useMemo<any>(() => {
 		if (!isEnabled) return null;
 
@@ -42,7 +44,7 @@ export function TourOnboarding({ isEnabled }: TourOnboardingProps) {
 			],
 		});
 		return d;
-	}, [isEnabled]);
+	}, [isEnabled, locale]);
 
 	useEffect(() => {
 		if (driverObj) {

--- a/src/features/settings/SettingsPage.tsx
+++ b/src/features/settings/SettingsPage.tsx
@@ -18,7 +18,7 @@ import { TerminalPreview } from "@/features/terminal/TerminalPreview";
 import type { TerminalThemeId } from "@/features/terminal/themes";
 import * as m from "@/paraglide/messages.js";
 import type { Locale } from "@/paraglide/runtime.js";
-import { getLocale, setLocale } from "@/paraglide/runtime.js";
+import { setAppLocale, useLocale } from "@/shared/lib/locale";
 import { ThemeContext } from "@/shared/providers/themeContext";
 import { BorderRadiusPicker } from "./BorderRadiusPicker";
 import { FontPicker } from "./FontPicker";
@@ -39,6 +39,7 @@ export default function SettingsPage() {
 	const { preference, setPreference } = use(ThemeContext);
 	const { enabled: debugEnabled, setEnabled: setDebugEnabled } =
 		useDebugStore();
+	const locale = useLocale();
 	const [previewThemeId, setPreviewThemeId] =
 		useState<TerminalThemeId | null>(null);
 
@@ -51,7 +52,7 @@ export default function SettingsPage() {
 					{ value: "dark", label: m.themeDark() },
 				],
 			}),
-		[],
+		[locale],
 	);
 
 	return (
@@ -88,9 +89,9 @@ export default function SettingsPage() {
 								<Field.Label>{m.language()}</Field.Label>
 								<Select.Root
 									collection={localeCollection}
-									defaultValue={[getLocale()]}
+									value={[locale]}
 									onValueChange={(e) =>
-										setLocale(e.value[0] as Locale)
+										setAppLocale(e.value[0] as Locale)
 									}
 									size="sm"
 								>

--- a/src/features/settings/SoundPicker.tsx
+++ b/src/features/settings/SoundPicker.tsx
@@ -11,6 +11,7 @@ import { RiVolumeUpLine } from "react-icons/ri";
 import { listSystemSounds, playSystemSound } from "@/generated";
 import * as m from "@/paraglide/messages.js";
 import { createCachedPromise } from "@/shared/lib/cachedPromise";
+import { useLocale } from "@/shared/lib/locale";
 import { useNotificationStore } from "./stores/notificationStore";
 
 const getSoundsPromise = createCachedPromise<string[]>(() =>
@@ -20,6 +21,7 @@ const getSoundsPromise = createCachedPromise<string[]>(() =>
 export function SoundPicker() {
 	const sounds = use(getSoundsPromise());
 	const { enabled, sound, setSound } = useNotificationStore();
+	const locale = useLocale();
 
 	const soundCollection = useMemo(
 		() =>
@@ -29,7 +31,7 @@ export function SoundPicker() {
 					...sounds.map((s) => ({ value: s, label: s })),
 				],
 			}),
-		[sounds],
+		[locale, sounds],
 	);
 
 	return (

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,11 +4,17 @@ import * as React from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router";
 import App from "./App";
+import { useLocale } from "./shared/lib/locale";
 import { queryClient } from "./shared/lib/queryClient";
 import { ThemeProvider } from "./shared/providers/ThemeProvider";
 import { Toaster } from "./shared/providers/Toaster";
 import { appSystem } from "./theme/system";
 import "./features/watcher/fileWatcher";
+
+function LocaleRoot() {
+	useLocale();
+	return <App />;
+}
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
 	<React.StrictMode>
@@ -16,7 +22,7 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
 			<ChakraProvider value={appSystem}>
 				<ThemeProvider>
 					<BrowserRouter>
-						<App />
+						<LocaleRoot />
 					</BrowserRouter>
 					<Toaster />
 				</ThemeProvider>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,7 +11,7 @@ import { Toaster } from "./shared/providers/Toaster";
 import { appSystem } from "./theme/system";
 import "./features/watcher/fileWatcher";
 
-function LocaleRoot() {
+function LocaleAdapter() {
 	useLocale();
 	return <App />;
 }
@@ -22,7 +22,7 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
 			<ChakraProvider value={appSystem}>
 				<ThemeProvider>
 					<BrowserRouter>
-						<LocaleRoot />
+						<LocaleAdapter />
 					</BrowserRouter>
 					<Toaster />
 				</ThemeProvider>

--- a/src/shared/lib/locale.test.ts
+++ b/src/shared/lib/locale.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("locale", () => {
+	beforeEach(() => {
+		vi.resetModules();
+		localStorage.clear();
+	});
+
+	it("initializes locale from localStorage", async () => {
+		localStorage.setItem("PARAGLIDE_LOCALE", "zh");
+
+		const { getAppLocale } = await import("./locale");
+
+		expect(getAppLocale()).toBe("zh");
+	});
+
+	it("persists locale changes synchronously", async () => {
+		const locale = await import("./locale");
+		const runtime = await import("@/paraglide/runtime.js");
+
+		locale.setAppLocale("zh");
+
+		expect(locale.getAppLocale()).toBe("zh");
+		expect(runtime.getLocale()).toBe("zh");
+		expect(localStorage.getItem(runtime.localStorageKey)).toBe("zh");
+	});
+
+	it("overrides runtime setLocale without reloading", async () => {
+		const locale = await import("./locale");
+		const runtime = await import("@/paraglide/runtime.js");
+
+		runtime.setLocale("zh");
+
+		expect(locale.getAppLocale()).toBe("zh");
+		expect(runtime.getLocale()).toBe("zh");
+	});
+});

--- a/src/shared/lib/locale.ts
+++ b/src/shared/lib/locale.ts
@@ -1,0 +1,79 @@
+import { useSyncExternalStore } from "react";
+import {
+	baseLocale,
+	getLocale as getRuntimeLocale,
+	isLocale,
+	localStorageKey,
+	overwriteGetLocale,
+	overwriteSetLocale,
+} from "@/paraglide/runtime.js";
+import type { Locale } from "@/paraglide/runtime.js";
+
+const originalGetLocale = getRuntimeLocale;
+const listeners = new Set<() => void>();
+
+function notifyLocaleChange() {
+	for (const listener of listeners) listener();
+}
+
+function readStoredLocale(): Locale | undefined {
+	if (typeof window === "undefined") return undefined;
+	const locale = window.localStorage.getItem(localStorageKey);
+	return isLocale(locale) ? locale : undefined;
+}
+
+function writeStoredLocale(locale: Locale) {
+	if (typeof window === "undefined") return;
+	window.localStorage.setItem(localStorageKey, locale);
+}
+
+function resolveInitialLocale(): Locale {
+	const storedLocale = readStoredLocale();
+	if (storedLocale) return storedLocale;
+
+	try {
+		return originalGetLocale();
+	} catch {
+		return baseLocale;
+	}
+}
+
+let currentLocale = resolveInitialLocale();
+
+function applyLocale(locale: Locale) {
+	writeStoredLocale(locale);
+
+	if (locale === currentLocale) return;
+
+	currentLocale = locale;
+	notifyLocaleChange();
+}
+
+overwriteGetLocale(() => currentLocale);
+overwriteSetLocale((newLocale) => {
+	// Desktop locale changes should update in place instead of reloading.
+	applyLocale(newLocale);
+});
+
+applyLocale(currentLocale);
+
+function subscribe(listener: () => void) {
+	listeners.add(listener);
+	return () => listeners.delete(listener);
+}
+
+function getSnapshot() {
+	return currentLocale;
+}
+
+export function useLocale() {
+	return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
+export function setAppLocale(locale: Locale) {
+	applyLocale(locale);
+}
+
+export function getAppLocale() {
+	return currentLocale;
+}


### PR DESCRIPTION
## Stack Context

This PR fixes desktop language switching in Settings so locale changes persist correctly when running in Tauri.

## What?

- replace Paraglide's cookie-and-reload locale flow with a synchronous localStorage-backed app locale store
- rerender the app and locale-sensitive settings controls from locale state instead of relying on a page refresh
- add tests for locale persistence and runtime overrides

## Why?

Paraglide's default locale setter writes a cookie and reloads the page. In the Tauri WebView, that flow is unreliable, so the UI briefly flips to the selected language and then falls back to the previous locale. This change keeps locale persistence entirely in-process with synchronous localStorage reads and writes, which is a better fit for desktop settings behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Language changes now properly reflect across the app, including in the onboarding tour
* Settings language selector now correctly updates the entire application interface
* Sound picker responds appropriately to language preference changes

## Tests
* Added test coverage for language persistence and synchronization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->