### PR TITLE
chore: add build.sh convenience script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,2 @@
+nr tauri build
+nr open:dmg


### PR DESCRIPTION
## Why?

Adds a `build.sh` convenience script that runs the Tauri production build and immediately opens the resulting `.dmg` for inspection. Saves typing the two commands manually during release testing.
