### PR TITLE
refactor(frontend): consolidate template text utilities and remove redundant refetch

### DIFF
--- a/src/features/projects/ProjectSettingsDialog.tsx
+++ b/src/features/projects/ProjectSettingsDialog.tsx
@@ -19,8 +19,11 @@ import { Suspense, useState } from "react";
 import { useForm } from "react-hook-form";
 import { RiDeleteBinLine, RiPencilLine } from "react-icons/ri";
 import {
+	commandPreview,
+	commandsToText,
 	createEmptyProjectTerminalTemplateDraft,
 	normalizeProjectTerminalTemplates,
+	textToCommands,
 	toProjectTerminalTemplateDraft,
 	type ProjectTerminalTemplateDraft,
 } from "@/features/terminal/templates";
@@ -37,27 +40,6 @@ interface FormValues {
 	initScript: string;
 	setupScript: string;
 	teardownScript: string;
-}
-
-function scriptsToText(scripts: string[]): string {
-	return scripts.join("\n");
-}
-
-function textToScripts(text: string): string[] {
-	return text
-		.split("\n")
-		.map((line) => line.trim())
-		.filter(Boolean);
-}
-
-function commandPreview(commandsText: string) {
-	const lines = commandsText
-		.split("\n")
-		.map((line) => line.trim())
-		.filter(Boolean);
-	if (lines.length === 0) return "";
-	if (lines.length === 1) return lines[0];
-	return `${lines[0]} +${lines.length - 1}`;
 }
 
 // ── Project template draft dialog ─────────────────────────────────────────────
@@ -394,9 +376,9 @@ function ProjectSettingsForm({
 	);
 	const form = useForm<FormValues>({
 		defaultValues: {
-			initScript: scriptsToText(config.init_script),
-			setupScript: scriptsToText(config.setup_script),
-			teardownScript: scriptsToText(config.teardown_script),
+			initScript: commandsToText(config.init_script),
+			setupScript: commandsToText(config.setup_script),
+			teardownScript: commandsToText(config.teardown_script),
 		},
 	});
 
@@ -404,9 +386,9 @@ function ProjectSettingsForm({
 		await saveConfig.mutateAsync({
 			projectId,
 			config: {
-				init_script: textToScripts(data.initScript),
-				setup_script: textToScripts(data.setupScript),
-				teardown_script: textToScripts(data.teardownScript),
+				init_script: textToCommands(data.initScript),
+				setup_script: textToCommands(data.setupScript),
+				teardown_script: textToCommands(data.teardownScript),
 				terminal_templates:
 					normalizeProjectTerminalTemplates(templateDrafts),
 			},

--- a/src/features/projects/hooks.ts
+++ b/src/features/projects/hooks.ts
@@ -63,7 +63,6 @@ export function useCreateProject(options?: {
 		},
 		onSuccess: async (project) => {
 			await queryClient.invalidateQueries({ queryKey: queryKeys.projects.all });
-			await queryClient.refetchQueries({ queryKey: queryKeys.projects.all });
 			const projects = queryClient.getQueryData<ProjectWithProfiles[]>(queryKeys.projects.all);
 			const createdProject = projects?.find((p) => p.id === project.id);
 			if (createdProject) {

--- a/src/features/settings/GlobalTerminalTemplatesSettings.tsx
+++ b/src/features/settings/GlobalTerminalTemplatesSettings.tsx
@@ -17,6 +17,7 @@ import { useMutation } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
 import { RiDeleteBinLine, RiPencilLine } from "react-icons/ri";
 import {
+	commandPreview,
 	createEmptyGlobalTerminalTemplateDraft,
 	normalizeGlobalTerminalTemplates,
 	toGlobalTerminalTemplateDraft,
@@ -144,17 +145,6 @@ function GlobalTerminalTemplateDialog({
 			</Portal>
 		</Dialog.Root>
 	);
-}
-
-function commandPreview(commandsText: string) {
-	const lines = commandsText
-		.split("\n")
-		.map((line) => line.trim())
-		.filter(Boolean);
-
-	if (lines.length === 0) return "";
-	if (lines.length === 1) return lines[0];
-	return `${lines[0]} +${lines.length - 1}`;
 }
 
 export function GlobalTerminalTemplatesSettings() {

--- a/src/features/terminal/templates.ts
+++ b/src/features/terminal/templates.ts
@@ -47,6 +47,16 @@ export function textToCommands(text: string): string[] {
 		.filter(Boolean);
 }
 
+export function commandPreview(commandsText: string): string {
+	const lines = commandsText
+		.split("\n")
+		.map((line) => line.trim())
+		.filter(Boolean);
+	if (lines.length === 0) return "";
+	if (lines.length === 1) return lines[0];
+	return `${lines[0]} +${lines.length - 1}`;
+}
+
 export function createEmptyGlobalTerminalTemplateDraft(): GlobalTerminalTemplateDraft {
 	return {
 		id: createTemplateId(),


### PR DESCRIPTION
## Why?

Three small frontend cleanups found during a codebase-wide simplify pass:

**Duplicate text utilities** — `ProjectSettingsDialog` defined `scriptsToText` and `textToScripts` which are byte-for-byte identical to the already-exported `commandsToText` / `textToCommands` in `features/terminal/templates.ts`. Replaced the local copies with imports from the canonical location.

**Duplicate `commandPreview`** — The same "first-line +N more" preview function was copy-pasted into both `ProjectSettingsDialog` and `GlobalTerminalTemplatesSettings`. Added the canonical version to `templates.ts` (where the other template string utilities live) and imported it in both files.

**Redundant `refetchQueries`** — `useCreateProject.onSuccess` called `invalidateQueries` then immediately `refetchQueries` on the same key. In TanStack Query v5, `await invalidateQueries()` already waits for active-query refetches to complete, matching the pattern used by every other mutation in the same file (`useRenameProject`, `useSaveProjectConfig`, `useDeleteProject`).
