### PR TITLE
refactor(rust): extract shared setup_db test helper and fix config TOCTOU

### DIFF
--- a/src-tauri/crates/infra/src/config.rs
+++ b/src-tauri/crates/infra/src/config.rs
@@ -8,11 +8,13 @@ pub fn load_project_config(
 	project_folder: &str,
 ) -> Result<ProjectConfig, AppError> {
 	let config_path = Path::new(project_folder).join("2code.json");
-	if !config_path.exists() {
-		return Ok(ProjectConfig::default());
-	}
-
-	let content = std::fs::read_to_string(&config_path)?;
+	let content = match std::fs::read_to_string(&config_path) {
+		Ok(c) => c,
+		Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+			return Ok(ProjectConfig::default());
+		}
+		Err(e) => return Err(AppError::IoError(e)),
+	};
 	serde_json::from_str(&content).map_err(|e| {
 		AppError::IoError(std::io::Error::new(
 			std::io::ErrorKind::InvalidData,

--- a/src-tauri/crates/repo/src/lib.rs
+++ b/src-tauri/crates/repo/src/lib.rs
@@ -1,3 +1,6 @@
 pub mod profile;
 pub mod project;
 pub mod pty;
+
+#[cfg(test)]
+pub(crate) mod test_utils;

--- a/src-tauri/crates/repo/src/profile.rs
+++ b/src-tauri/crates/repo/src/profile.rs
@@ -102,20 +102,8 @@ pub fn get_project_folder(
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use diesel_migrations::MigrationHarness;
-	use infra::db::MIGRATIONS;
+	use crate::test_utils::setup_db;
 	use model::project::NewProject;
-
-	fn setup_db() -> SqliteConnection {
-		let mut conn =
-			SqliteConnection::establish(":memory:").expect("in-memory db");
-		diesel::sql_query("PRAGMA foreign_keys=ON;")
-			.execute(&mut conn)
-			.ok();
-		conn.run_pending_migrations(MIGRATIONS)
-			.expect("run migrations");
-		conn
-	}
 
 	/// Insert a test project with its default profile (mirrors real app behavior).
 	fn insert_test_project(

--- a/src-tauri/crates/repo/src/project.rs
+++ b/src-tauri/crates/repo/src/project.rs
@@ -124,22 +124,10 @@ pub fn delete(conn: &mut SqliteConnection, id: &str) -> Result<(), AppError> {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use diesel_migrations::MigrationHarness;
-	use infra::db::MIGRATIONS;
+	use crate::test_utils::setup_db;
 	use model::profile::NewProfile;
 	use model::pty::NewPtySessionRecord;
 	use model::schema::{profiles, pty_sessions};
-
-	fn setup_db() -> SqliteConnection {
-		let mut conn =
-			SqliteConnection::establish(":memory:").expect("in-memory db");
-		diesel::sql_query("PRAGMA foreign_keys=ON;")
-			.execute(&mut conn)
-			.ok();
-		conn.run_pending_migrations(MIGRATIONS)
-			.expect("run migrations");
-		conn
-	}
 
 	#[test]
 	fn insert_and_fetch() {

--- a/src-tauri/crates/repo/src/test_utils.rs
+++ b/src-tauri/crates/repo/src/test_utils.rs
@@ -1,0 +1,14 @@
+#[cfg(test)]
+pub(crate) fn setup_db() -> diesel::SqliteConnection {
+	use diesel::prelude::*;
+	use diesel_migrations::MigrationHarness;
+	use infra::db::MIGRATIONS;
+
+	let mut conn = diesel::SqliteConnection::establish(":memory:").expect("in-memory db");
+	diesel::sql_query("PRAGMA foreign_keys=ON;")
+		.execute(&mut conn)
+		.ok();
+	conn.run_pending_migrations(MIGRATIONS)
+		.expect("run migrations");
+	conn
+}


### PR DESCRIPTION
## Why?

Two Rust cleanups found during a codebase-wide simplify pass:

**Duplicate `setup_db` test helper** — `repo/project.rs` and `repo/profile.rs` both defined an identical `setup_db()` function in their `#[cfg(test)]` modules (establish `:memory:` connection, enable foreign keys, run migrations). Extracted to `repo/src/test_utils.rs` as `pub(crate)` and replaced both local copies with `use crate::test_utils::setup_db`.

**TOCTOU in `config.rs`** — `load_project_config` checked `config_path.exists()` and returned the default if false, then immediately read the file. The exists-check is a TOCTOU race: the file could be deleted between check and read, producing an `IoError` instead of the default. Replaced with a direct `read_to_string` that matches on `ErrorKind::NotFound` to return the default, letting all other errors propagate normally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in configuration file loading to better distinguish between missing configuration files and actual read failures.

* **Tests**
  * Refactored test infrastructure to centralize database setup utilities, reducing code duplication across test modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->