### PR TITLE
refactor(ui): switch icons to feather

### DIFF
--- a/src/features/debug/DebugFloat.tsx
+++ b/src/features/debug/DebugFloat.tsx
@@ -1,5 +1,5 @@
 import { IconButton } from "@chakra-ui/react";
-import { RiBugLine } from "react-icons/ri";
+import { FiTool } from "react-icons/fi";
 import * as m from "@/paraglide/messages.js";
 import DebugLogDialog from "./DebugLogDialog";
 import { useDebugStore } from "./debugStore";
@@ -25,7 +25,7 @@ export default function DebugFloat() {
 				variant="solid"
 				onClick={() => setPanelOpen(true)}
 			>
-				<RiBugLine />
+				<FiTool />
 			</IconButton>
 			<DebugLogDialog
 				isOpen={panelOpen}

--- a/src/features/debug/DebugLogDialog.tsx
+++ b/src/features/debug/DebugLogDialog.tsx
@@ -12,7 +12,7 @@ import {
 	VStack,
 } from "@chakra-ui/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { RiDeleteBinLine } from "react-icons/ri";
+import { FiTrash2 } from "react-icons/fi";
 import type { LogEntry } from "@/generated/types";
 import * as m from "@/paraglide/messages.js";
 import { useDebugLogStore } from "./debugLogStore";
@@ -145,7 +145,7 @@ export default function DebugLogDialog({
 								variant="ghost"
 								onClick={clear}
 							>
-								<RiDeleteBinLine />
+								<FiTrash2 />
 							</IconButton>
 						</HStack>
 

--- a/src/features/git/GitDiffDialog.tsx
+++ b/src/features/git/GitDiffDialog.tsx
@@ -21,7 +21,7 @@ import {
 	useReducer,
 	useRef,
 } from "react";
-import { RiGitBranchLine } from "react-icons/ri";
+import { FiGitBranch } from "react-icons/fi";
 import { useTerminalThemeId } from "@/features/terminal/hooks";
 import type { TerminalThemeId } from "@/features/terminal/themes";
 import * as m from "@/paraglide/messages.js";
@@ -101,7 +101,7 @@ export default function GitDiffDialog({
 							<Dialog.Title fontSize="sm">
 								<HStack gap="1.5" alignItems="center">
 									<Icon fontSize="md">
-										<RiGitBranchLine />
+										<FiGitBranch />
 									</Icon>
 									<Text>{branchName ?? "main"}</Text>
 								</HStack>

--- a/src/features/git/ProjectTopBar.tsx
+++ b/src/features/git/ProjectTopBar.tsx
@@ -8,7 +8,7 @@ import {
 	Tooltip,
 } from "@chakra-ui/react";
 import { Suspense, useState } from "react";
-import { RiGitBranchLine, RiSettings3Line } from "react-icons/ri";
+import { FiGitBranch, FiSettings } from "react-icons/fi";
 import { useGitBranch } from "@/features/projects/hooks";
 import ProjectSettingsDialog from "@/features/projects/ProjectSettingsDialog";
 import { controlRegistry } from "@/features/topbar/registry";
@@ -21,7 +21,7 @@ function GitBranchLabel({ cwd }: { cwd: string }) {
 	if (!branch) return null;
 	return (
 		<HStack gap="1">
-			<RiGitBranchLine />
+			<FiGitBranch />
 			<Text as="span">{branch}</Text>
 		</HStack>
 	);
@@ -82,7 +82,7 @@ export default function ProjectTopBar({
 							) : null
 						) : (
 							<HStack gap="1">
-								<RiGitBranchLine />
+								<FiGitBranch />
 								<Text as="span">{profile.branch_name}</Text>
 							</HStack>
 						)}
@@ -110,7 +110,7 @@ export default function ProjectTopBar({
 								variant="subtle"
 								onClick={() => setSettingsOpen(true)}
 							>
-								<RiSettings3Line />
+								<FiSettings />
 							</IconButton>
 						</Tooltip.Trigger>
 						<Portal>

--- a/src/features/git/components/CommitList.tsx
+++ b/src/features/git/components/CommitList.tsx
@@ -1,5 +1,5 @@
 import { Box, HStack, Icon, Text, VStack } from "@chakra-ui/react";
-import { RiGitCommitLine } from "react-icons/ri";
+import { FiGitCommit } from "react-icons/fi";
 import type { GitCommit } from "@/generated";
 import { useScrollIntoView } from "@/shared/hooks/useScrollIntoView";
 
@@ -66,7 +66,7 @@ export default function CommitList({
 					<HStack gap="2" fontSize="xs" color="fg.muted">
 						<HStack gap="1">
 							<Icon fontSize="xs">
-								<RiGitCommitLine />
+								<FiGitCommit />
 							</Icon>
 							<Text fontFamily="mono">{commit.hash}</Text>
 						</HStack>

--- a/src/features/git/components/HistoryFileList.tsx
+++ b/src/features/git/components/HistoryFileList.tsx
@@ -1,6 +1,6 @@
 import { Box, Flex, HStack, IconButton, Text, VStack } from "@chakra-ui/react";
 import type { FileDiffMetadata } from "@pierre/diffs";
-import { RiArrowLeftLine } from "react-icons/ri";
+import { FiArrowLeft } from "react-icons/fi";
 import type { GitCommit } from "@/generated";
 import * as m from "@/paraglide/messages.js";
 import { useScrollIntoView } from "@/shared/hooks/useScrollIntoView";
@@ -29,7 +29,7 @@ function CommitHeader({
 				aria-label={m.backToCommitList()}
 				onClick={onBack}
 			>
-				<RiArrowLeftLine />
+				<FiArrowLeft />
 			</IconButton>
 			<VStack align="start" gap="0" flex="1" minW="0">
 				<Text fontSize="sm" fontWeight="medium" lineClamp={1}>

--- a/src/features/home/HomePage.tsx
+++ b/src/features/home/HomePage.tsx
@@ -1,6 +1,6 @@
 import { Box, Heading, EmptyState, VStack, Center } from "@chakra-ui/react";
-import { RiFolderAddLine } from "react-icons/ri";
 import { useEffect } from "react";
+import { FiFolderPlus } from "react-icons/fi";
 import { useNavigate } from "react-router";
 import * as m from "@/paraglide/messages.js";
 import { useProjects } from "@/features/projects/hooks";
@@ -35,7 +35,7 @@ export default function HomePage() {
 					<EmptyState.Root>
 						<EmptyState.Content>
 							<EmptyState.Indicator>
-								<RiFolderAddLine />
+								<FiFolderPlus />
 							</EmptyState.Indicator>
 							<VStack textAlign="center">
 								<EmptyState.Title>{m.emptyProjectsTitle()}</EmptyState.Title>

--- a/src/features/projects/CreateProjectDialog.tsx
+++ b/src/features/projects/CreateProjectDialog.tsx
@@ -16,7 +16,7 @@ import {
 import { basename } from "@tauri-apps/api/path";
 import { open } from "@tauri-apps/plugin-dialog";
 import { useForm, useWatch } from "react-hook-form";
-import { RiFolderOpenLine, RiPencilLine } from "react-icons/ri";
+import { FiEdit2, FiFolder } from "react-icons/fi";
 import { useNavigate } from "react-router";
 import * as m from "@/paraglide/messages.js";
 import { useCreateProject } from "./hooks";
@@ -143,7 +143,7 @@ export default function CreateProjectDialog({
 												fontSize="2xl"
 												color="fg.muted"
 											>
-												<RiFolderOpenLine />
+												<FiFolder />
 											</Icon>
 											<Text
 												fontSize="sm"
@@ -171,7 +171,7 @@ export default function CreateProjectDialog({
 												size="xs"
 												onClick={handleChooseFolder}
 											>
-												<RiPencilLine />
+												<FiEdit2 />
 												{m.chooseFolder()}
 											</Button>
 										</HStack>

--- a/src/features/projects/ProjectDetailPage.tsx
+++ b/src/features/projects/ProjectDetailPage.tsx
@@ -1,6 +1,6 @@
 import { Button, Center, EmptyState, Flex, VStack } from "@chakra-ui/react";
 import { useMemo } from "react";
-import { RiAddLine, RiTerminalBoxLine } from "react-icons/ri";
+import { FiPlus, FiTerminal } from "react-icons/fi";
 import { Navigate, useParams } from "react-router";
 import ProjectTopBar from "@/features/git/ProjectTopBar";
 import { useProject, useProjectProfiles } from "@/features/projects/hooks";
@@ -41,11 +41,11 @@ export default function ProjectDetailPage() {
 				isActive
 			/>
 			<Center flex="1">
-				<EmptyState.Root>
-					<EmptyState.Content>
-						<EmptyState.Indicator>
-							<RiTerminalBoxLine />
-						</EmptyState.Indicator>
+					<EmptyState.Root>
+						<EmptyState.Content>
+							<EmptyState.Indicator>
+								<FiTerminal />
+							</EmptyState.Indicator>
 						<VStack textAlign="center">
 							<EmptyState.Title>
 								{m.noTerminalsOpen()}
@@ -62,10 +62,10 @@ export default function ProjectDetailPage() {
 									cwd: profile.worktree_path,
 								})
 							}
-						>
-							<RiAddLine />
-							{m.newTerminal()}
-						</Button>
+							>
+								<FiPlus />
+								{m.newTerminal()}
+							</Button>
 					</EmptyState.Content>
 				</EmptyState.Root>
 			</Center>

--- a/src/features/projects/ProjectSettingsDialog.tsx
+++ b/src/features/projects/ProjectSettingsDialog.tsx
@@ -17,7 +17,7 @@ import {
 } from "@chakra-ui/react";
 import { Suspense, useState } from "react";
 import { useForm } from "react-hook-form";
-import { RiDeleteBinLine, RiPencilLine } from "react-icons/ri";
+import { FiEdit2, FiTrash2 } from "react-icons/fi";
 import {
 	commandPreview,
 	commandsToText,
@@ -319,7 +319,7 @@ function ProjectTemplatesEditor({
 										aria-label={m.editTerminalTemplate()}
 										onClick={() => openEdit(t.id)}
 									>
-										<RiPencilLine />
+										<FiEdit2 />
 									</IconButton>
 									<IconButton
 										variant="ghost"
@@ -334,7 +334,7 @@ function ProjectTemplatesEditor({
 											)
 										}
 									>
-										<RiDeleteBinLine />
+										<FiTrash2 />
 									</IconButton>
 								</HStack>
 							</Flex>

--- a/src/features/settings/GlobalTerminalTemplatesSettings.tsx
+++ b/src/features/settings/GlobalTerminalTemplatesSettings.tsx
@@ -15,7 +15,7 @@ import {
 } from "@chakra-ui/react";
 import { useMutation } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
-import { RiDeleteBinLine, RiPencilLine } from "react-icons/ri";
+import { FiEdit2, FiTrash2 } from "react-icons/fi";
 import {
 	commandPreview,
 	createEmptyGlobalTerminalTemplateDraft,
@@ -283,7 +283,7 @@ export function GlobalTerminalTemplatesSettings() {
 										onClick={() => openEditDialog(template.id)}
 										disabled={replaceTemplates.isPending}
 									>
-										<RiPencilLine />
+										<FiEdit2 />
 									</IconButton>
 									<IconButton
 										variant="ghost"
@@ -293,7 +293,7 @@ export function GlobalTerminalTemplatesSettings() {
 										onClick={() => openEditDialog(template.id)}
 										disabled={replaceTemplates.isPending}
 									>
-										<RiDeleteBinLine />
+										<FiTrash2 />
 									</IconButton>
 								</HStack>
 							</Flex>

--- a/src/features/settings/SoundPicker.tsx
+++ b/src/features/settings/SoundPicker.tsx
@@ -7,7 +7,7 @@ import {
 	Select,
 } from "@chakra-ui/react";
 import { use, useMemo } from "react";
-import { RiVolumeUpLine } from "react-icons/ri";
+import { FiVolume2 } from "react-icons/fi";
 import { listSystemSounds, playSystemSound } from "@/generated";
 import * as m from "@/paraglide/messages.js";
 import { createCachedPromise } from "@/shared/lib/cachedPromise";
@@ -50,7 +50,7 @@ export function SoundPicker() {
 						if (sound) playSystemSound({ name: sound });
 					}}
 				>
-					<RiVolumeUpLine />
+					<FiVolume2 />
 				</IconButton>
 			</Flex>
 			<Select.Root

--- a/src/features/settings/TerminalThemePicker.tsx
+++ b/src/features/settings/TerminalThemePicker.tsx
@@ -7,7 +7,7 @@ import {
 	Portal,
 	Select,
 } from "@chakra-ui/react";
-import { RiEyeLine } from "react-icons/ri";
+import { FiEye } from "react-icons/fi";
 import type { TerminalThemeId } from "@/features/terminal/themes";
 import {
 	terminalThemeIds,
@@ -47,7 +47,7 @@ function ThemeSelect({
 					_hover={{ opacity: 1 }}
 					onClick={() => onPreview(value)}
 				>
-					<RiEyeLine />
+					<FiEye />
 				</IconButton>
 			</Flex>
 			<Select.Root

--- a/src/features/terminal/TerminalTabs.tsx
+++ b/src/features/terminal/TerminalTabs.tsx
@@ -11,7 +11,7 @@ import {
 	Text,
 } from "@chakra-ui/react";
 import { useEffect, useRef, useState } from "react";
-import { RiAddLine, RiTerminalBoxLine } from "react-icons/ri";
+import { FiPlus, FiTerminal } from "react-icons/fi";
 import { useShallow } from "zustand/react/shallow";
 import { useProjectConfigQuery } from "@/features/projects/hooks";
 import { useTerminalTemplatesStore } from "@/features/settings/stores/terminalTemplatesStore";
@@ -133,7 +133,7 @@ export default function TerminalTabs({
 								: tab.title;
 						return (
 							<Tabs.Trigger key={tab.id} value={tab.id}>
-								<RiTerminalBoxLine />
+								<FiTerminal />
 								<HStack gap="2">
 									{displayTitle}
 									{notifiedTabs.has(tab.id) &&
@@ -173,7 +173,7 @@ export default function TerminalTabs({
 								createTab.mutate({ profileId, cwd });
 							}}
 						>
-							<RiAddLine /> {m.newTerminal()}
+							<FiPlus /> {m.newTerminal()}
 						</Button>
 					</Box>
 				</Tabs.List>

--- a/src/features/topbar/DraggableControl.tsx
+++ b/src/features/topbar/DraggableControl.tsx
@@ -1,7 +1,7 @@
 import { Box, HStack, Icon, Portal, Tooltip } from "@chakra-ui/react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { RiDraggable } from "react-icons/ri";
+import { FiMove } from "react-icons/fi";
 import type { ControlDefinition } from "./types";
 
 const DRAG_ICON_SIZE = 16;
@@ -49,7 +49,7 @@ export function DraggableControl({
 				>
 					<HStack gap="1.5">
 						<Icon color="fg.muted" fontSize="sm">
-							<RiDraggable />
+							<FiMove />
 						</Icon>
 						<definition.icon size={DRAG_ICON_SIZE} />
 					</HStack>

--- a/src/features/topbar/TopBarPreview.tsx
+++ b/src/features/topbar/TopBarPreview.tsx
@@ -4,7 +4,7 @@ import {
 	horizontalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { useDroppable } from "@dnd-kit/core";
-import { RiGitBranchLine } from "react-icons/ri";
+import { FiGitBranch } from "react-icons/fi";
 import * as m from "@/paraglide/messages.js";
 import { controlRegistry } from "./registry";
 import { DraggableControl } from "./DraggableControl";
@@ -40,7 +40,7 @@ export function TopBarPreview({ activeControls }: TopBarPreviewProps) {
 							My Project
 						</Text>
 						<HStack gap="1" color="fg.muted" fontSize="sm">
-							<RiGitBranchLine />
+							<FiGitBranch />
 							<Text as="span">main</Text>
 						</HStack>
 					</HStack>

--- a/src/features/topbar/controls.tsx
+++ b/src/features/topbar/controls.tsx
@@ -3,7 +3,7 @@ import type { ComponentType } from "react";
 import { SiCursor, SiGit, SiGithub, SiVscodium, SiWindsurf } from "@icons-pack/react-simple-icons";
 import { Command } from "@tauri-apps/plugin-shell";
 import { Suspense } from "react";
-import { RiFolderLine } from "react-icons/ri";
+import { FiFolder } from "react-icons/fi";
 import GitDiffDialog from "@/features/git/GitDiffDialog";
 import { useGitDiffStats } from "@/features/git/hooks";
 import { useGitBranch } from "@/features/projects/hooks";
@@ -155,10 +155,10 @@ export function RevealInFinderControl({ profile }: ControlProps) {
 				<IconButton
 					aria-label={m.revealInFinder()}
 					size="xs"
-					variant="subtle"
+				variant="subtle"
 					onClick={handleReveal}
 				>
-					<RiFolderLine />
+					<FiFolder />
 				</IconButton>
 			</Tooltip.Trigger>
 			<Portal>

--- a/src/features/topbar/registry.ts
+++ b/src/features/topbar/registry.ts
@@ -1,5 +1,5 @@
 import { SiCursor, SiGit, SiGithub, SiVscodium, SiWindsurf } from "@icons-pack/react-simple-icons";
-import { RiFolderLine } from "react-icons/ri";
+import { FiFolder } from "react-icons/fi";
 import * as m from "@/paraglide/messages.js";
 import {
 	CursorControl,
@@ -50,7 +50,7 @@ const definitions: ControlDefinition[] = [
 	{
 		id: "reveal-in-finder",
 		label: () => m.revealInFinder(),
-		icon: RiFolderLine,
+		icon: FiFolder,
 		optionFields: [],
 		component: RevealInFinderControl,
 	},

--- a/src/layout/AppSidebar.tsx
+++ b/src/layout/AppSidebar.tsx
@@ -1,7 +1,7 @@
 import "@fontsource-variable/bricolage-grotesque";
 import { Box, Flex, HStack, IconButton, Text } from "@chakra-ui/react";
 import { useCallback, useRef } from "react";
-import { RiAddLine, RiHome4Line, RiSettings3Line } from "react-icons/ri";
+import { FiHome, FiPlus, FiSettings } from "react-icons/fi";
 import CreateProjectDialog from "@/features/projects/CreateProjectDialog";
 import { useProjects } from "@/features/projects/hooks";
 import * as m from "@/paraglide/messages.js";
@@ -76,7 +76,7 @@ export default function AppSidebar() {
           {projects.length === 0 && (
             <SidebarLink
               to="/"
-              icon={<RiHome4Line />}
+              icon={<FiHome />}
               style={{ marginBottom: 20 }}
             >
               {m.home()}
@@ -100,7 +100,7 @@ export default function AppSidebar() {
               size="2xs"
               onClick={createDialog.onOpen}
             >
-              <RiAddLine />
+              <FiPlus />
             </IconButton>
           </HStack>
 
@@ -110,7 +110,10 @@ export default function AppSidebar() {
 
           <Box flex="1" />
 
-          <SidebarLink to="/settings" icon={<RiSettings3Line />}>
+          <SidebarLink
+            to="/settings"
+            icon={<FiSettings />}
+          >
             {m.settings()}
           </SidebarLink>
         </Flex>

--- a/src/layout/sidebar/ProfileItem.tsx
+++ b/src/layout/sidebar/ProfileItem.tsx
@@ -1,5 +1,5 @@
 import { Circle, HStack, Icon, Menu, Portal, Text } from "@chakra-ui/react";
-import { RiGitBranchLine } from "react-icons/ri";
+import { FiGitBranch } from "react-icons/fi";
 import { NavLink } from "react-router";
 import DeleteProfileDialog from "@/features/profiles/DeleteProfileDialog";
 import { useProfileHasNotification, useTerminalStore } from "@/features/terminal/store";
@@ -56,7 +56,7 @@ export function ProfileItem({
 							onClick={() => markProfileRead(profile.id)}
 						>
 							<Icon fontSize="xs" color="fg.muted">
-								<RiGitBranchLine />
+								<FiGitBranch />
 							</Icon>
 							<Text truncate>{profile.branch_name}</Text>
 							{hasNotification && (

--- a/src/layout/sidebar/ProfileList.tsx
+++ b/src/layout/sidebar/ProfileList.tsx
@@ -1,5 +1,5 @@
 import { HStack, Icon, Text } from "@chakra-ui/react";
-import { RiAddLine } from "react-icons/ri";
+import { FiPlus } from "react-icons/fi";
 import CreateProfileDialog from "@/features/profiles/CreateProfileDialog";
 import type { Profile } from "@/generated";
 import * as m from "@/paraglide/messages.js";
@@ -40,7 +40,7 @@ export function ProfileList({
 				onClick={createDialog.onOpen}
 			>
 				<Icon fontSize="xs">
-					<RiAddLine />
+					<FiPlus />
 				</Icon>
 				<Text>{m.createProfile()}</Text>
 			</HStack>

--- a/src/layout/sidebar/ProjectMenuItem.tsx
+++ b/src/layout/sidebar/ProjectMenuItem.tsx
@@ -8,11 +8,7 @@ import {
 	Text,
 } from "@chakra-ui/react";
 import { useMemo, useState } from "react";
-import {
-	RiArrowDownSLine,
-	RiArrowRightSLine,
-	RiTerminalBoxLine,
-} from "react-icons/ri";
+import { FiChevronDown, FiChevronRight, FiTerminal } from "react-icons/fi";
 import { NavLink, useMatch } from "react-router";
 import DeleteProjectDialog from "@/features/projects/DeleteProjectDialog";
 import ProjectSettingsDialog from "@/features/projects/ProjectSettingsDialog";
@@ -78,9 +74,9 @@ export function ProjectMenuItem({ project }: { project: ProjectWithProfiles }) {
 							}}
 						>
 							{expanded ? (
-								<RiArrowDownSLine />
+								<FiChevronDown />
 							) : (
-								<RiArrowRightSLine />
+								<FiChevronRight />
 							)}
 						</IconButton>
 					</HStack>
@@ -145,7 +141,7 @@ export function ProjectMenuItem({ project }: { project: ProjectWithProfiles }) {
 					>
 						<NavLink to={defaultProfileUrl}>
 							<Icon fontSize="xs" color="fg.muted">
-								<RiTerminalBoxLine />
+								<FiTerminal />
 							</Icon>
 							<Text truncate>{m.defaultProfile()}</Text>
 						</NavLink>


### PR DESCRIPTION
## Stack Context

This PR switches the apps non-brand icons to Feather icons while keeping brand-specific editor and GitHub icons on Simple Icons.

## What?

- replace the current Hugeicons usage across the React app with Feather icons from react-icons/fi
- remove the Hugeicons packages and restore react-icons
- keep the brand icons in the topbar on @icons-pack/react-simple-icons
- use simpler Feather equivalents for sidebar, project, git, terminal, and settings icons

## Why?

The Hugeicons free set still felt visually too thin even after increasing stroke width. Feather has a cleaner default weight for this UI, so this change reverts the Hugeicons experiment and standardizes the non-brand iconography on Feather instead.
