### PR TITLE
fix(terminal): align notification dot behavior

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -69,3 +69,4 @@
 | [Data Flow](data-flow.md)         | IPC lifecycle, PTY streaming, notification pipeline, terminal restoration |
 | [API Reference](api-reference.md) | All Tauri commands, Tauri events, HTTP endpoints                          |
 | [Configuration](configuration.md) | Config files, environment variables, database schema                      |
+| [Notification Behavior](notification-behavior.md) | Terminal unread-dot state machine and click behavior          |

--- a/docs/notification-behavior.md
+++ b/docs/notification-behavior.md
@@ -1,0 +1,52 @@
+# Notification Behavior
+
+This document defines the terminal notification state machine for unread green dots in the sidebar and tab strip.
+
+## State Model
+
+- Notification events are reported per `sessionId` from the PTY helper pipeline.
+- Unread state is stored per terminal tab in `terminalStore.notifiedTabs`.
+- Sidebar profile dots are derived from tab unread state. Profiles do not store a separate unread flag.
+- The currently focused tab is the active tab for the profile in the current route:
+  - route shape: `/projects/:projectId/profiles/:profileId`
+  - active tab: `terminalStore.profiles[profileId].activeTabId`
+
+## Render Rules
+
+- A tab shows a green dot when its `sessionId` is in `notifiedTabs` and it is not the profile's active tab.
+- A profile shows a green dot when any of its tabs has unread state.
+- The focused tab must never keep unread state. If a notification is reported for the focused tab, the store drops it immediately.
+- Default profiles follow the same sidebar-dot and read-clearing rules as non-default profiles.
+
+## Behavior Table
+
+| Event | Preconditions | State Transition | Result |
+| --- | --- | --- | --- |
+| PTY reports `notify(sessionId)` for focused tab | `sessionId` belongs to current route profile and equals its `activeTabId` | Remove `sessionId` from `notifiedTabs` | No green dot on tab or sidebar |
+| PTY reports `notify(sessionId)` for background tab in current profile | `sessionId` belongs to current route profile and is not the `activeTabId` | Add `sessionId` to `notifiedTabs` | Green dot on that tab and on the profile sidebar item |
+| PTY reports `notify(sessionId)` for tab in another profile | `sessionId` belongs to a non-focused profile | Add `sessionId` to `notifiedTabs` | Green dot on that tab and on that profile sidebar item |
+| PTY reports `notify(sessionId)` before the tab is mounted in the frontend | `sessionId` is not in `profiles[*].tabs` yet | Add `sessionId` to `notifiedTabs` | Notification survives startup races and appears once the tab is added |
+| User clicks a tab title | Target tab exists in the current profile | Set `activeTabId = tabId`, remove `tabId` from `notifiedTabs` | Only that tab is marked read |
+| User clicks a sidebar profile item | Profile exists in the sidebar | Remove all tabs in that profile from `notifiedTabs` | Entire profile is marked read |
+| Focused profile opens a new tab | `addTab(profileId, sessionId)` and route profile is `profileId` | Create tab, set it active, remove new active tab from `notifiedTabs` | New focused tab never starts with a green dot |
+| Focused profile closes the active tab | Active tab is removed and another tab becomes active | Remove closed tab from `notifiedTabs`, promote next tab, remove promoted active tab from `notifiedTabs` | Newly exposed focused tab does not inherit a green dot |
+| Any tab is closed | Tab exists | Remove closed tab from `notifiedTabs` | Closed tabs leave no unread residue |
+| Profile is removed or pruned as stale | Profile exists in store | Remove all of its tab ids from `notifiedTabs` | No orphan unread state remains |
+
+## Intent
+
+- Sidebar click and tab click intentionally do different things:
+  - sidebar click marks the whole profile as read
+  - tab click marks only the selected tab as read
+- Focus wins over unread. If the user is already looking at a tab, we do not keep or resurrect a green dot for it later.
+
+## Relevant Code
+
+- Frontend state: `src/features/terminal/store.ts`
+- Tab dots: `src/features/terminal/TerminalTabs.tsx`
+- Sidebar dots:
+  - `src/layout/sidebar/ProfileItem.tsx`
+  - `src/layout/sidebar/ProjectMenuItem.tsx`
+- Backend event source:
+  - `src-tauri/src/helper.rs`
+  - `src-tauri/bins/2code-helper/src/main.rs`

--- a/src/features/terminal/store.test.ts
+++ b/src/features/terminal/store.test.ts
@@ -9,10 +9,15 @@ import {
 
 function resetStore() {
 	useTerminalStore.setState({ profiles: {}, notifiedTabs: new Set() });
+	window.history.pushState({}, "", "/");
 }
 
 function getState() {
 	return useTerminalStore.getState();
+}
+
+function setPathname(pathname: string) {
+	window.history.pushState({}, "", pathname);
 }
 
 describe("useTerminalStore", () => {
@@ -57,6 +62,13 @@ describe("useTerminalStore", () => {
 			expect(Object.keys(getState().profiles)).toHaveLength(2);
 			expect(getState().profiles.p1.tabs).toHaveLength(1);
 			expect(getState().profiles.p2.tabs).toHaveLength(1);
+		});
+
+		it("clears pending notification when a focused profile opens the tab", () => {
+			setPathname("/projects/project-1/profiles/p1");
+			getState().markNotified("s1");
+			getState().addTab("p1", "s1", "Shell 1");
+			expect(getState().notifiedTabs.has("s1")).toBe(false);
 		});
 	});
 
@@ -138,6 +150,16 @@ describe("useTerminalStore", () => {
 			getState().closeTab("p1", "s2");
 			expect(getState().profiles.p1.tabs).toHaveLength(1);
 			expect(getState().profiles.p1.activeTabId).toBe("s1");
+		});
+
+		it("clears notification from the newly focused tab after closing the active tab", () => {
+			setPathname("/projects/project-1/profiles/p1");
+			getState().addTab("p1", "s1", "T1");
+			getState().addTab("p1", "s2", "T2");
+			getState().markNotified("s1");
+			getState().closeTab("p1", "s2");
+			expect(getState().profiles.p1.activeTabId).toBe("s1");
+			expect(getState().notifiedTabs.has("s1")).toBe(false);
 		});
 	});
 
@@ -243,6 +265,21 @@ describe("useTerminalStore", () => {
 			getState().markNotified("s1");
 			expect(getState().notifiedTabs.has("s1")).toBe(true);
 			expect(getState().notifiedTabs.size).toBe(1);
+		});
+
+		it("does not keep unread state for the focused active tab", () => {
+			setPathname("/projects/project-1/profiles/p1");
+			getState().addTab("p1", "s1", "T1");
+			getState().markNotified("s1");
+			expect(getState().notifiedTabs.has("s1")).toBe(false);
+		});
+
+		it("still marks unread for active tabs in background profiles", () => {
+			setPathname("/projects/project-1/profiles/p1");
+			getState().addTab("p1", "s1", "T1");
+			getState().addTab("p2", "s2", "T2");
+			getState().markNotified("s2");
+			expect(getState().notifiedTabs.has("s2")).toBe(true);
 		});
 	});
 

--- a/src/features/terminal/store.ts
+++ b/src/features/terminal/store.ts
@@ -17,6 +17,38 @@ interface ProjectTerminalState {
 	counter: number;
 }
 
+const PROFILE_PATH_REGEX = /^\/projects\/[^/]+\/profiles\/([^/]+)$/;
+
+function getFocusedProfileId(): string | null {
+	if (typeof window === "undefined") return null;
+	return window.location.pathname.match(PROFILE_PATH_REGEX)?.[1] ?? null;
+}
+
+function findProfileIdBySessionId(
+	profiles: Record<string, ProjectTerminalState>,
+	sessionId: string,
+): string | null {
+	for (const [profileId, profile] of Object.entries(profiles)) {
+		if (profile.tabs.some((tab) => tab.id === sessionId)) {
+			return profileId;
+		}
+	}
+
+	return null;
+}
+
+function clearProfileActiveTabNotification(
+	state: Pick<TerminalStore, "profiles" | "notifiedTabs">,
+	profileId: string | null,
+) {
+	if (!profileId) return;
+
+	const activeTabId = state.profiles[profileId]?.activeTabId;
+	if (activeTabId) {
+		state.notifiedTabs.delete(activeTabId);
+	}
+}
+
 interface TerminalStore {
 	profiles: Record<string, ProjectTerminalState>;
 	notifiedTabs: Set<string>;
@@ -49,6 +81,10 @@ export const useTerminalStore = create<TerminalStore>()(
 					activeTabId: tab.id,
 					counter: existing.counter + 1,
 				};
+
+				if (getFocusedProfileId() === profileId) {
+					clearProfileActiveTabNotification(state, profileId);
+				}
 			});
 		},
 
@@ -56,6 +92,7 @@ export const useTerminalStore = create<TerminalStore>()(
 			set((state) => {
 				const profile = state.profiles[profileId];
 				if (!profile) return;
+				const wasActiveTab = tabId === profile.activeTabId;
 
 				state.notifiedTabs.delete(tabId);
 
@@ -67,9 +104,12 @@ export const useTerminalStore = create<TerminalStore>()(
 					return;
 				}
 
-				if (tabId === profile.activeTabId) {
+				if (wasActiveTab) {
 					const newIdx = Math.min(idx, profile.tabs.length - 1);
 					profile.activeTabId = profile.tabs[newIdx].id;
+					if (getFocusedProfileId() === profileId) {
+						clearProfileActiveTabNotification(state, profileId);
+					}
 				}
 			});
 		},
@@ -85,6 +125,8 @@ export const useTerminalStore = create<TerminalStore>()(
 
 		removeProfile(profileId) {
 			set((state) => {
+				const profile = state.profiles[profileId];
+				profile?.tabs.forEach((tab) => state.notifiedTabs.delete(tab.id));
 				delete state.profiles[profileId];
 			});
 		},
@@ -101,13 +143,31 @@ export const useTerminalStore = create<TerminalStore>()(
 		removeStaleProfiles(validIds) {
 			set((state) => {
 				for (const id of Object.keys(state.profiles)) {
-					if (!validIds.has(id)) delete state.profiles[id];
+					if (!validIds.has(id)) {
+						state.profiles[id].tabs.forEach((tab) =>
+							state.notifiedTabs.delete(tab.id),
+						);
+						delete state.profiles[id];
+					}
 				}
 			});
 		},
 
 		markNotified(sessionId) {
 			set((state) => {
+				const profileId = findProfileIdBySessionId(
+					state.profiles,
+					sessionId,
+				);
+				if (
+					profileId &&
+					profileId === getFocusedProfileId() &&
+					state.profiles[profileId]?.activeTabId === sessionId
+				) {
+					state.notifiedTabs.delete(sessionId);
+					return;
+				}
+
 				state.notifiedTabs.add(sessionId);
 			});
 		},

--- a/src/layout/sidebar/ProjectMenuItem.tsx
+++ b/src/layout/sidebar/ProjectMenuItem.tsx
@@ -1,5 +1,6 @@
 import {
 	Box,
+	Circle,
 	HStack,
 	Icon,
 	IconButton,
@@ -13,6 +14,7 @@ import { NavLink, useMatch } from "react-router";
 import DeleteProjectDialog from "@/features/projects/DeleteProjectDialog";
 import ProjectSettingsDialog from "@/features/projects/ProjectSettingsDialog";
 import RenameProjectDialog from "@/features/projects/RenameProjectDialog";
+import { useProfileHasNotification, useTerminalStore } from "@/features/terminal/store";
 import type { ProjectWithProfiles } from "@/generated";
 import * as m from "@/paraglide/messages.js";
 import { useDialogState } from "@/shared/hooks/useDialogState";
@@ -37,6 +39,10 @@ export function ProjectMenuItem({ project }: { project: ProjectWithProfiles }) {
 	const defaultProfileUrl = defaultProfile
 		? `/projects/${project.id}/profiles/${defaultProfile.id}`
 		: `/projects/${project.id}`;
+	const hasDefaultNotification = useProfileHasNotification(
+		defaultProfile?.id ?? "",
+	);
+	const markProfileRead = useTerminalStore((s) => s.markProfileRead);
 
 	const renameDialog = useDialogState();
 	const deleteDialog = useDialogState();
@@ -139,11 +145,25 @@ export function ProjectMenuItem({ project }: { project: ProjectWithProfiles }) {
 								: undefined
 						}
 					>
-						<NavLink to={defaultProfileUrl}>
+						<NavLink
+							to={defaultProfileUrl}
+							onClick={() => {
+								if (defaultProfile) {
+									markProfileRead(defaultProfile.id);
+								}
+							}}
+						>
 							<Icon fontSize="xs" color="fg.muted">
 								<FiTerminal />
 							</Icon>
 							<Text truncate>{m.defaultProfile()}</Text>
+							{hasDefaultNotification && (
+								<Circle
+									size="2"
+									bg="green.500"
+									flexShrink={0}
+								/>
+							)}
 						</NavLink>
 					</HStack>
 


### PR DESCRIPTION
## Stack Context

This PR tightens the terminal notification-dot rules so the unread state matches what the user is actually looking at.

## What?

- prevent focused tabs from keeping unread notification dots
- preserve the distinction between sidebar click and tab click read behavior
- apply the same sidebar notification behavior to the default profile item
- document the state machine in `docs/notification-behavior.md`

## Why?

The previous behavior mixed UI hiding with unread state, which allowed the active tab to stay unread internally and still light the sidebar. This change moves the rule into the store: if the tab is currently focused, we drop the unread state instead of only hiding the dot in the view. It also keeps sidebar clicks as "mark the whole profile read" and tab clicks as "mark only this tab read", which is the intended distinction for navigation vs tab-level acknowledgement.

## Validation

- `bun x vitest run src/features/terminal/store.test.ts`
- `bun x tsc --noEmit`

## Notes

- `bun x eslint ...` is currently blocked by a repo-level ESLint config error in `antfu/react/setup` (`react-dom` plugin shape), unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal notifications now display as visual indicators in the sidebar, alerting you to unread activity. Indicators automatically disappear when you view or click on the relevant terminal.

* **Documentation**
  * Added comprehensive documentation covering terminal notification behavior, state management, and notification clearing rules based on user interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->