### PR TITLE
fix(lint): restore eslint config on dev

### DIFF
--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -1,7 +1,7 @@
 {
   "name": "2code-e2e-tests",
-  "private": true,
   "type": "module",
+  "private": true,
   "scripts": {
     "test": "mocha \"test/**/*.test.mjs\""
   },

--- a/e2e-tests/test/smoke.test.mjs
+++ b/e2e-tests/test/smoke.test.mjs
@@ -6,6 +6,7 @@ import { spawn, spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 import { expect } from "chai";
+import { after, afterEach, before, describe, it } from "mocha";
 import { Builder, By, Capabilities } from "selenium-webdriver";
 
 const testDir = fileURLToPath(new URL(".", import.meta.url));
@@ -31,7 +32,7 @@ let driver;
 let tauriDriver;
 let tauriDriverClosed = false;
 
-describe("Tauri smoke", function () {
+describe("tauri smoke", () => {
 	before(async function () {
 		if (process.platform === "darwin") {
 			console.warn(
@@ -93,7 +94,7 @@ describe("Tauri smoke", function () {
 		}
 	});
 
-	after(async function () {
+	after(async () => {
 		await closeResources();
 	});
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,12 +1,45 @@
+import eslintReact from "@eslint-react/eslint-plugin";
 import antfu from "@antfu/eslint-config";
+import reactRefresh from "eslint-plugin-react-refresh";
+
+const reactFiles = ["src/**/*.ts", "src/**/*.tsx"];
+const reactComponentFiles = ["src/**/*.tsx"];
 
 export default antfu({
 	stylistic: false,
-	react: true,
+	react: false,
 	imports: false,
 })
 	.append({
-		ignores: ["**/*.md", "./src-tauri/target/**"],
+		ignores: [
+			"**/*.md",
+			"./src-tauri/target/**",
+			"./src/generated/**",
+			"./src/paraglide/**",
+		],
+	})
+	.append({
+		files: reactFiles,
+		languageOptions: {
+			parserOptions: {
+				ecmaFeatures: {
+					jsx: true,
+				},
+			},
+			sourceType: "module",
+		},
+		plugins: eslintReact.configs["recommended-typescript"].plugins,
+		rules: {
+			...eslintReact.configs["recommended-typescript"].rules,
+			"@eslint-react/dom-no-string-style-prop": "off",
+			"@eslint-react/dom-no-unknown-property": "off",
+			"@eslint-react/prefer-namespace-import": "error",
+		},
+	})
+	.append({
+		files: reactComponentFiles,
+		plugins: reactRefresh.configs.vite.plugins,
+		rules: reactRefresh.configs.vite.rules,
 	})
 	.append({
 		rules: {

--- a/src/AppRoot.tsx
+++ b/src/AppRoot.tsx
@@ -1,0 +1,7 @@
+import App from "./App";
+import { useLocale } from "./shared/lib/locale";
+
+export default function AppRoot() {
+	useLocale();
+	return <App />;
+}

--- a/src/features/home/TourOnboarding.tsx
+++ b/src/features/home/TourOnboarding.tsx
@@ -12,6 +12,7 @@ export function TourOnboarding({ isEnabled }: TourOnboardingProps) {
 	const locale = useLocale();
 	const driverObj = useMemo<any>(() => {
 		if (!isEnabled) return null;
+		void locale;
 
 		const d = driver({
 			animate: true,

--- a/src/features/settings/SettingsPage.tsx
+++ b/src/features/settings/SettingsPage.tsx
@@ -44,14 +44,16 @@ export default function SettingsPage() {
 		useState<TerminalThemeId | null>(null);
 
 	const themeCollection = useMemo(
-		() =>
-			createListCollection({
+		() => {
+			void locale;
+			return createListCollection({
 				items: [
 					{ value: "system", label: m.themeSystem() },
 					{ value: "light", label: m.themeLight() },
 					{ value: "dark", label: m.themeDark() },
 				],
-			}),
+			});
+		},
 		[locale],
 	);
 

--- a/src/features/settings/SoundPicker.tsx
+++ b/src/features/settings/SoundPicker.tsx
@@ -24,13 +24,15 @@ export function SoundPicker() {
 	const locale = useLocale();
 
 	const soundCollection = useMemo(
-		() =>
-			createListCollection({
+		() => {
+			void locale;
+			return createListCollection({
 				items: [
 					{ value: "", label: m.notificationSoundNone() },
 					...sounds.map((s) => ({ value: s, label: s })),
 				],
-			}),
+			});
+		},
 		[locale, sounds],
 	);
 

--- a/src/features/terminal/Terminal.tsx
+++ b/src/features/terminal/Terminal.tsx
@@ -191,7 +191,7 @@ export function Terminal({ profileId, sessionId, isActive }: TerminalProps) {
 					void clearPtyOutput({ sessionId })
 						.catch(() => {})
 						.finally(() => {
-							void writeToPty({ sessionId, data: "\x0c" });
+							void writeToPty({ sessionId, data: "\x0C" });
 						});
 					return false;
 				}

--- a/src/features/terminal/keybindings.test.ts
+++ b/src/features/terminal/keybindings.test.ts
@@ -26,7 +26,7 @@ describe("getTerminalShortcutSequence", () => {
 				makeEvent({ metaKey: true, key: "ArrowLeft" }),
 				"MacIntel",
 			),
-		).toBe("\x1b[H");
+		).toBe("\x1B[H");
 	});
 
 	it("maps Cmd+Right to line end on macOS", () => {
@@ -35,7 +35,7 @@ describe("getTerminalShortcutSequence", () => {
 				makeEvent({ metaKey: true, key: "ArrowRight" }),
 				"MacIntel",
 			),
-		).toBe("\x1b[F");
+		).toBe("\x1B[F");
 	});
 
 	it("does not map Cmd+Arrow on non-macOS platforms", () => {
@@ -50,13 +50,13 @@ describe("getTerminalShortcutSequence", () => {
 	it("maps Alt+Left to previous word", () => {
 		expect(
 			getTerminalShortcutSequence(makeEvent({ altKey: true, key: "ArrowLeft" })),
-		).toBe("\x1bb");
+		).toBe("\x1Bb");
 	});
 
 	it("maps Alt+Right to next word", () => {
 		expect(
 			getTerminalShortcutSequence(makeEvent({ altKey: true, key: "ArrowRight" })),
-		).toBe("\x1bf");
+		).toBe("\x1Bf");
 	});
 
 	it("ignores other modifier combinations and non-keydown events", () => {

--- a/src/features/terminal/keybindings.ts
+++ b/src/features/terminal/keybindings.ts
@@ -38,19 +38,19 @@ export function getTerminalShortcutAction(
 
 	if (isPlainMetaShortcut(event, platform) && !event.shiftKey) {
 		if (event.key === "ArrowLeft") {
-			return { type: "write-sequence", sequence: "\x1b[H" };
+			return { type: "write-sequence", sequence: "\x1B[H" };
 		}
 		if (event.key === "ArrowRight") {
-			return { type: "write-sequence", sequence: "\x1b[F" };
+			return { type: "write-sequence", sequence: "\x1B[F" };
 		}
 	}
 
 	if (event.altKey && !event.metaKey && !event.ctrlKey && !event.shiftKey) {
 		if (event.key === "ArrowLeft") {
-			return { type: "write-sequence", sequence: "\x1bb" };
+			return { type: "write-sequence", sequence: "\x1Bb" };
 		}
 		if (event.key === "ArrowRight") {
-			return { type: "write-sequence", sequence: "\x1bf" };
+			return { type: "write-sequence", sequence: "\x1Bf" };
 		}
 	}
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,18 +3,12 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import * as React from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router";
-import App from "./App";
-import { useLocale } from "./shared/lib/locale";
+import AppRoot from "./AppRoot";
 import { queryClient } from "./shared/lib/queryClient";
 import { ThemeProvider } from "./shared/providers/ThemeProvider";
 import { Toaster } from "./shared/providers/Toaster";
 import { appSystem } from "./theme/system";
 import "./features/watcher/fileWatcher";
-
-function LocaleAdapter() {
-	useLocale();
-	return <App />;
-}
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
 	<React.StrictMode>
@@ -22,7 +16,7 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
 			<ChakraProvider value={appSystem}>
 				<ThemeProvider>
 					<BrowserRouter>
-						<LocaleAdapter />
+						<AppRoot />
 					</BrowserRouter>
 					<Toaster />
 				</ThemeProvider>


### PR DESCRIPTION
## Stack Context

This PR restores ESLint on `dev` without downgrading `@eslint-react/eslint-plugin`.

## What

- disable `@antfu/eslint-config`'s built-in React preset and wire in the official ESLint React 4.x preset directly
- ignore generated frontend bindings from lint
- fix the remaining repo lint violations surfaced after the config started loading again

## Why

`@antfu/eslint-config@8.1.1` still expects the older split React plugin shape, while this repo uses `@eslint-react/eslint-plugin@4.x`.
That mismatch caused ESLint to fail during config loading before it could lint any project files.

Using ESLint React's official 4.x preset keeps the newer plugin version in place and avoids pinning the repo back to an older major.

## Validation

- `bun run lint`
- `bunx tsc --noEmit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated smoke test structure and escape sequence expectations.

* **Bug Fixes**
  * Standardized terminal escape sequence casing for consistent control character handling.

* **Chores**
  * Enhanced ESLint configuration with React-specific linting plugins.
  * Refactored application root component architecture.
  * Reordered package configuration fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->