### PR TITLE
feat(git): add Cmd+G shortcut to open git modal on profile page

### DIFF
--- a/src/features/git/ProjectTopBar.tsx
+++ b/src/features/git/ProjectTopBar.tsx
@@ -7,8 +7,9 @@ import {
 	Text,
 	Tooltip,
 } from "@chakra-ui/react";
-import { Suspense, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
 import { FiGitBranch, FiSettings } from "react-icons/fi";
+import GitDiffDialog from "@/features/git/GitDiffDialog";
 import { useGitBranch } from "@/features/projects/hooks";
 import ProjectSettingsDialog from "@/features/projects/ProjectSettingsDialog";
 import { useSupportedTopbarAppIds } from "@/features/topbar/hooks";
@@ -31,6 +32,30 @@ function GitBranchLabel({ cwd }: { cwd: string }) {
 	);
 }
 
+function GitDiffDialogWithBranch({
+	cwd,
+	isOpen,
+	isActive,
+	onClose,
+	profileId,
+}: {
+	cwd: string;
+	isOpen: boolean;
+	isActive: boolean;
+	onClose: () => void;
+	profileId: string;
+}) {
+	const { data: branch } = useGitBranch(cwd, isOpen && isActive);
+	return (
+		<GitDiffDialog
+			isOpen={isOpen}
+			onClose={onClose}
+			profileId={profileId}
+			branchName={branch ?? undefined}
+		/>
+	);
+}
+
 interface ProjectTopBarProps {
 	projectId: string;
 	projectName: string;
@@ -47,7 +72,20 @@ export default function ProjectTopBar({
 	const activeControls = useTopBarStore((s) => s.activeControls);
 	const controlOptions = useTopBarStore((s) => s.controlOptions);
 	const [settingsOpen, setSettingsOpen] = useState(false);
+	const [gitDiffOpen, setGitDiffOpen] = useState(false);
 	const { data: supportedAppIds = [] } = useSupportedTopbarAppIds();
+
+	useEffect(() => {
+		if (!isActive) return;
+		const handleKeyDown = (e: KeyboardEvent) => {
+			if ((e.metaKey || e.ctrlKey) && e.key === "g") {
+				e.preventDefault();
+				setGitDiffOpen(true);
+			}
+		};
+		window.addEventListener("keydown", handleKeyDown);
+		return () => window.removeEventListener("keydown", handleKeyDown);
+	}, [isActive]);
 	const supportedControlIdSet = new Set(
 		getSupportedControlIds(supportedAppIds),
 	);
@@ -114,7 +152,12 @@ export default function ProjectTopBar({
 								key={controlId}
 								profile={profile}
 								isActive={isActive}
-								options={controlOptions[controlId] ?? {}}
+								options={{
+									...(controlOptions[controlId] ?? {}),
+									...(controlId === "git-diff"
+										? { onOpen: () => setGitDiffOpen(true) }
+										: {}),
+								}}
 							/>
 						);
 					})}
@@ -145,6 +188,25 @@ export default function ProjectTopBar({
 				onClose={() => setSettingsOpen(false)}
 				projectId={projectId}
 			/>
+
+			{profile.is_default ? (
+				<Suspense>
+					<GitDiffDialogWithBranch
+						cwd={profile.worktree_path}
+						isOpen={gitDiffOpen}
+						isActive={isActive}
+						onClose={() => setGitDiffOpen(false)}
+						profileId={profile.id}
+					/>
+				</Suspense>
+			) : (
+				<GitDiffDialog
+					isOpen={gitDiffOpen}
+					onClose={() => setGitDiffOpen(false)}
+					profileId={profile.id}
+					branchName={profile.branch_name}
+				/>
+			)}
 		</>
 	);
 }

--- a/src/features/topbar/controls.tsx
+++ b/src/features/topbar/controls.tsx
@@ -13,13 +13,9 @@ import {
 } from "@icons-pack/react-simple-icons";
 import { Command } from "@tauri-apps/plugin-shell";
 import type { ComponentType } from "react";
-import { Suspense } from "react";
 import { FiFolder, FiTerminal } from "react-icons/fi";
-import GitDiffDialog from "@/features/git/GitDiffDialog";
 import { useGitDiffStats } from "@/features/git/hooks";
-import { useGitBranch } from "@/features/projects/hooks";
 import * as m from "@/paraglide/messages.js";
-import { useDialogState } from "@/shared/hooks/useDialogState";
 import { useOpenTopbarApp } from "./hooks";
 import type { ControlProps, LaunchAppControlId } from "./types";
 
@@ -171,82 +167,38 @@ export function WarpControl(props: ControlProps) {
 	);
 }
 
-function GitDiffBranchDialog({
-	cwd,
-	isOpen,
-	isActive,
-	onClose,
-	profileId,
-}: {
-	cwd: string;
-	isOpen: boolean;
-	isActive: boolean;
-	onClose: () => void;
-	profileId: string;
-}) {
-	const { data: branch } = useGitBranch(cwd, isOpen && isActive);
-	return (
-		<GitDiffDialog
-			isOpen={isOpen}
-			onClose={onClose}
-			profileId={profileId}
-			branchName={branch ?? undefined}
-		/>
-	);
-}
-
-export function GitDiffControl({ profile, isActive }: ControlProps) {
-	const dialog = useDialogState();
+export function GitDiffControl({ profile, isActive, options }: ControlProps) {
+	const onOpen = options.onOpen as (() => void) | undefined;
 	const stats = useGitDiffStats(profile.id, isActive);
 
 	return (
-		<>
-			<Tooltip.Root>
-				<Tooltip.Trigger asChild>
-					<Button
-						aria-label={m.topbarGitDiff()}
-						size="xs"
-						variant="subtle"
-						onClick={dialog.onOpen}
-					>
-						<SiGit size={14} />
-						{stats && (
-							<>
-								<Text as="span" color="green.400" fontSize="xs">
-									+{stats.additions}
-								</Text>
-								<Text as="span" color="red.400" fontSize="xs">
-									-{stats.deletions}
-								</Text>
-							</>
-						)}
-					</Button>
-				</Tooltip.Trigger>
-				<Portal>
-					<Tooltip.Positioner>
-						<Tooltip.Content>{m.topbarGitDiff()}</Tooltip.Content>
-					</Tooltip.Positioner>
-				</Portal>
-			</Tooltip.Root>
-			{profile.is_default ? (
-				<Suspense>
-					<GitDiffBranchDialog
-						cwd={profile.worktree_path}
-						isOpen={dialog.isOpen}
-						isActive={isActive}
-						onClose={dialog.onClose}
-						profileId={profile.id}
-					/>
-				</Suspense>
-			) : (
-				<GitDiffDialog
-					isOpen={dialog.isOpen}
-					onClose={dialog.onClose}
-					profileId={profile.id}
-					branchName={profile.branch_name}
-				/>
-			)}
-		</>
+		<Tooltip.Root>
+			<Tooltip.Trigger asChild>
+				<Button
+					aria-label={m.topbarGitDiff()}
+					size="xs"
+					variant="subtle"
+					onClick={() => onOpen?.()}
+				>
+					<SiGit size={14} />
+					{stats && (
+						<>
+							<Text as="span" color="green.400" fontSize="xs">
+								+{stats.additions}
+							</Text>
+							<Text as="span" color="red.400" fontSize="xs">
+								-{stats.deletions}
+							</Text>
+						</>
+					)}
+				</Button>
+			</Tooltip.Trigger>
+			<Portal>
+				<Tooltip.Positioner>
+					<Tooltip.Content>{m.topbarGitDiff()}</Tooltip.Content>
+				</Tooltip.Positioner>
+			</Portal>
+		</Tooltip.Root>
 	);
 }
 


### PR DESCRIPTION
## Why?

Adds a `Cmd+G` (or `Ctrl+G`) keyboard shortcut on the profile page to open the git diff modal without needing to click the topbar button. The shortcut works regardless of whether the git-diff control is enabled in the topbar.

### Implementation
- Lifted git dialog state from `GitDiffControl` to `ProjectTopBar`, which is always rendered
- Keyboard listener is guarded by `isActive` so only the focused profile responds (important since `TerminalLayer` keeps all profiles mounted simultaneously via CSS display:none)
- `GitDiffControl` button now receives `onOpen` via its options prop and delegates to the shared state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added keyboard shortcut (Ctrl/⌘ + g) to open the Git diff dialog for faster access to version control features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->