### PR TITLE
feat(empty-state): add template dropdown to new terminal button

### DIFF
--- a/src/features/projects/ProjectDetailPage.tsx
+++ b/src/features/projects/ProjectDetailPage.tsx
@@ -1,11 +1,34 @@
-import { Button, Center, EmptyState, Flex, VStack } from "@chakra-ui/react";
+import {
+	Box,
+	Button,
+	Center,
+	EmptyState,
+	Flex,
+	HStack,
+	Menu,
+	Portal,
+	Stack,
+	Text,
+	VStack,
+} from "@chakra-ui/react";
 import { useMemo } from "react";
-import { FiPlus, FiTerminal } from "react-icons/fi";
+import { FiChevronDown, FiPlus, FiTerminal } from "react-icons/fi";
 import { Navigate, useParams } from "react-router";
 import ProjectTopBar from "@/features/git/ProjectTopBar";
-import { useProject, useProjectProfiles } from "@/features/projects/hooks";
+import {
+	useProject,
+	useProjectConfigQuery,
+	useProjectProfiles,
+} from "@/features/projects/hooks";
+import { useTerminalTemplatesStore } from "@/features/settings/stores/terminalTemplatesStore";
 import { useCreateTerminalTab } from "@/features/terminal/hooks";
 import { useTerminalStore } from "@/features/terminal/store";
+import {
+	resolveGlobalTerminalTemplate,
+	resolveProjectTerminalTemplate,
+	type GlobalTerminalTemplate,
+	type ProjectTerminalTemplate,
+} from "@/features/terminal/templates";
 import * as m from "@/paraglide/messages.js";
 
 export default function ProjectDetailPage() {
@@ -24,6 +47,33 @@ export default function ProjectDetailPage() {
 		(s) => (s.profiles[profileId ?? ""]?.tabs.length ?? 0) > 0,
 	);
 	const createTab = useCreateTerminalTab();
+	const projectConfig = useProjectConfigQuery(project?.id ?? "");
+	const globalTemplates = useTerminalTemplatesStore((s) => s.templates);
+	const projectTemplates = projectConfig.data?.terminal_templates ?? [];
+	const hasTemplates = projectTemplates.length > 0 || globalTemplates.length > 0;
+
+	async function handleTemplateClick(
+		template: GlobalTerminalTemplate | ProjectTerminalTemplate,
+		scope: "global" | "project",
+	) {
+		if (!profile) return;
+		const resolvedTemplate =
+			scope === "project"
+				? await resolveProjectTerminalTemplate(
+						template as ProjectTerminalTemplate,
+						profile.worktree_path,
+					)
+				: resolveGlobalTerminalTemplate(
+						template as GlobalTerminalTemplate,
+						profile.worktree_path,
+					);
+		await createTab.mutateAsync({
+			profileId: profile.id,
+			cwd: resolvedTemplate.cwd,
+			title: resolvedTemplate.name,
+			startupCommands: resolvedTemplate.commands,
+		});
+	}
 
 	if (!project || !profile) {
 		return <Navigate to="/" replace />;
@@ -54,18 +104,118 @@ export default function ProjectDetailPage() {
 								{m.noTerminalsOpenDescription()}
 							</EmptyState.Description>
 						</VStack>
-						<Button
-							disabled={createTab.isPending}
-							onClick={() =>
-								createTab.mutate({
-									profileId: profile.id,
-									cwd: profile.worktree_path,
-								})
-							}
+						<HStack gap="0">
+							<Button
+								disabled={createTab.isPending}
+								borderEndRadius={hasTemplates ? "0" : undefined}
+								onClick={() =>
+									createTab.mutate({
+										profileId: profile.id,
+										cwd: profile.worktree_path,
+									})
+								}
 							>
 								<FiPlus />
 								{m.newTerminal()}
 							</Button>
+							{hasTemplates && (
+								<Menu.Root>
+									<Menu.Trigger asChild>
+										<Button
+											disabled={createTab.isPending}
+											borderStartRadius="0"
+											borderStartWidth="1px"
+											px="2"
+											aria-label="Choose template"
+										>
+											<FiChevronDown />
+										</Button>
+									</Menu.Trigger>
+									<Portal>
+										<Menu.Positioner>
+											<Menu.Content minW="56">
+												{projectTemplates.length > 0 && (
+													<>
+														<Box
+															px="3"
+															pt="2"
+															pb="1"
+															fontSize="xs"
+															fontWeight="semibold"
+															color="fg.muted"
+															textTransform="uppercase"
+														>
+															{m.projectTerminalTemplates()}
+														</Box>
+														{projectTemplates.map((template) => (
+															<Menu.Item
+																key={template.id}
+																value={template.id}
+																onClick={() => {
+																	void handleTemplateClick(
+																		template,
+																		"project",
+																	);
+																}}
+															>
+																<Stack gap="0.5" align="start">
+																	<Text fontSize="sm">
+																		{template.name}
+																	</Text>
+																	{template.cwd.trim() && (
+																		<Text
+																			fontSize="xs"
+																			color="fg.muted"
+																		>
+																			{template.cwd.trim()}
+																		</Text>
+																	)}
+																</Stack>
+															</Menu.Item>
+														))}
+													</>
+												)}
+												{projectTemplates.length > 0 &&
+													globalTemplates.length > 0 && (
+														<Menu.Separator />
+													)}
+												{globalTemplates.length > 0 && (
+													<>
+														<Box
+															px="3"
+															pt="2"
+															pb="1"
+															fontSize="xs"
+															fontWeight="semibold"
+															color="fg.muted"
+															textTransform="uppercase"
+														>
+															{m.globalTerminalTemplates()}
+														</Box>
+														{globalTemplates.map((template) => (
+															<Menu.Item
+																key={template.id}
+																value={template.id}
+																onClick={() => {
+																	void handleTemplateClick(
+																		template,
+																		"global",
+																	);
+																}}
+															>
+																<Text fontSize="sm">
+																	{template.name}
+																</Text>
+															</Menu.Item>
+														))}
+													</>
+												)}
+											</Menu.Content>
+										</Menu.Positioner>
+									</Portal>
+								</Menu.Root>
+							)}
+						</HStack>
 					</EmptyState.Content>
 				</EmptyState.Root>
 			</Center>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal template picker now available on project detail pages for streamlined terminal creation
  * Users can select from project-specific or globally-available templates with pre-configured settings
  * Templates include predefined working directories and commands for faster setup
  * New dropdown menu alongside the standard terminal creation button for easy template access

<!-- end of auto-generated comment: release notes by coderabbit.ai -->