### PR TITLE
feat(profile): auto-generate blank profile branches

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -68,7 +68,7 @@
 	"createProfile": "New Profile",
 	"deleteProfile": "Delete Profile",
 	"branchName": "Branch Name",
-	"branchNamePlaceholder": "e.g. feature/auth",
+	"branchNamePlaceholder": "Optional. Leave empty to auto-generate a PR branch like pr/tokyo-a1b2c3d4",
 	"confirmDeleteProfile": "Are you sure you want to delete this profile? The git worktree will be removed.",
 	"noProfiles": "No profiles yet",
 	"notification": "Notification",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -68,7 +68,7 @@
 	"createProfile": "新建配置",
 	"deleteProfile": "删除配置",
 	"branchName": "分支名称",
-	"branchNamePlaceholder": "例如 feature/auth",
+	"branchNamePlaceholder": "可选；留空会自动生成类似 pr/tokyo-a1b2c3d4 的 PR 分支名",
 	"confirmDeleteProfile": "确定要删除此配置吗？Git 工作树将被移除。",
 	"noProfiles": "暂无配置",
 	"notification": "通知",

--- a/src-tauri/crates/repo/src/profile.rs
+++ b/src-tauri/crates/repo/src/profile.rs
@@ -99,6 +99,17 @@ pub fn get_project_folder(
 		.map_err(|_| AppError::NotFound(format!("Project: {project_id}")))
 }
 
+pub fn list_branch_names_by_project(
+	conn: &mut SqliteConnection,
+	project_id: &str,
+) -> Result<Vec<String>, AppError> {
+	profiles::table
+		.filter(profiles::project_id.eq(project_id))
+		.select(profiles::branch_name)
+		.load(conn)
+		.map_err(|e| AppError::DbError(e.to_string()))
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
@@ -169,6 +180,25 @@ mod tests {
 		let profile = find_by_id(&mut conn, "p1").unwrap();
 		assert_eq!(profile.id, "p1");
 		assert_eq!(profile.branch_name, "main");
+	}
+
+	#[test]
+	fn list_branch_names_filters_by_project() {
+		let mut conn = setup_db();
+		insert_test_project(&mut conn, "proj-1", "/tmp/test-1");
+		insert_test_project(&mut conn, "proj-2", "/tmp/test-2");
+		insert(&mut conn, "p1", "proj-1", "feature/login", "/w/p1").unwrap();
+		insert(&mut conn, "p2", "proj-1", "pr/tokyo-1234abcd", "/w/p2")
+			.unwrap();
+		insert(&mut conn, "p3", "proj-2", "feature/other", "/w/p3").unwrap();
+
+		let branch_names =
+			list_branch_names_by_project(&mut conn, "proj-1").unwrap();
+
+		assert_eq!(branch_names.len(), 3);
+		assert!(branch_names.iter().any(|name| name == "main"));
+		assert!(branch_names.iter().any(|name| name == "feature/login"));
+		assert!(branch_names.iter().any(|name| name == "pr/tokyo-1234abcd"));
 	}
 
 	#[test]

--- a/src-tauri/crates/service/src/profile.rs
+++ b/src-tauri/crates/service/src/profile.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::path::PathBuf;
 
 use diesel::SqliteConnection;
@@ -5,6 +6,40 @@ use uuid::Uuid;
 
 use model::error::AppError;
 use model::profile::Profile;
+
+const AUTO_BRANCH_PREFIX: &str = "pr/";
+const AUTO_BRANCH_CITIES: &[&str] = &[
+	"tokyo",
+	"osaka",
+	"kyoto",
+	"seoul",
+	"busan",
+	"taipei",
+	"tainan",
+	"singapore",
+	"bangkok",
+	"chiang-mai",
+	"hanoi",
+	"saigon",
+	"delhi",
+	"mumbai",
+	"istanbul",
+	"lisbon",
+	"porto",
+	"oslo",
+	"bergen",
+	"helsinki",
+	"prague",
+	"vienna",
+	"zurich",
+	"geneva",
+	"austin",
+	"boston",
+	"miami",
+	"denver",
+	"phoenix",
+	"seattle",
+];
 
 /// Sanitize user input into a valid git branch name.
 /// Splits on `/` to preserve namespace separators (e.g. "feature/auth"),
@@ -16,6 +51,59 @@ fn sanitize_branch_name(input: &str) -> String {
 		.filter(|s| !s.is_empty())
 		.collect::<Vec<_>>()
 		.join("/")
+}
+
+fn extract_auto_branch_city(branch_name: &str) -> Option<&str> {
+	let generated = branch_name.strip_prefix(AUTO_BRANCH_PREFIX)?;
+	let (city, suffix) = generated.rsplit_once('-')?;
+	if city.is_empty() || suffix.is_empty() {
+		return None;
+	}
+	Some(city)
+}
+
+fn build_auto_branch_name(existing_branches: &[String], seed: &Uuid) -> String {
+	let used_cities: HashSet<&str> = existing_branches
+		.iter()
+		.filter_map(|branch| extract_auto_branch_city(branch))
+		.collect();
+	let available_cities: Vec<&str> = AUTO_BRANCH_CITIES
+		.iter()
+		.copied()
+		.filter(|city| !used_cities.contains(city))
+		.collect();
+	let city_pool = if available_cities.is_empty() {
+		AUTO_BRANCH_CITIES
+	} else {
+		available_cities.as_slice()
+	};
+	let city = city_pool[usize::from(seed.as_bytes()[0]) % city_pool.len()];
+	let simple = seed.simple().to_string();
+	let short_id = &simple[..8];
+	format!("{AUTO_BRANCH_PREFIX}{city}-{short_id}")
+}
+
+fn generate_auto_branch_name(
+	conn: &mut SqliteConnection,
+	project_id: &str,
+) -> Result<String, AppError> {
+	let existing_branches =
+		repo::profile::list_branch_names_by_project(conn, project_id)?;
+
+	for _ in 0..5 {
+		let seed = Uuid::new_v4();
+		let branch_name = build_auto_branch_name(&existing_branches, &seed);
+		if !existing_branches
+			.iter()
+			.any(|existing| existing == &branch_name)
+		{
+			return Ok(branch_name);
+		}
+	}
+
+	Err(AppError::GitError(
+		"Failed to auto-generate a unique branch name".to_string(),
+	))
 }
 
 fn resolve_worktree_base() -> Result<PathBuf, AppError> {
@@ -35,10 +123,16 @@ pub fn create(
 ) -> Result<Profile, AppError> {
 	let project_folder = repo::profile::get_project_folder(conn, project_id)?;
 
-	let branch_name = sanitize_branch_name(branch_name);
-	if branch_name.is_empty() {
-		return Err(AppError::GitError("Invalid branch name".to_string()));
-	}
+	let auto_generated = branch_name.trim().is_empty();
+	let branch_name = if auto_generated {
+		generate_auto_branch_name(conn, project_id)?
+	} else {
+		let sanitized = sanitize_branch_name(branch_name);
+		if sanitized.is_empty() {
+			return Err(AppError::GitError("Invalid branch name".to_string()));
+		}
+		sanitized
+	};
 
 	let id = Uuid::new_v4().to_string();
 	let worktree_base = resolve_worktree_base()?;
@@ -46,7 +140,37 @@ pub fn create(
 	let worktree_path = worktree_base.join(&id);
 	let worktree_str = worktree_path.to_string_lossy().to_string();
 
-	infra::git::worktree_add(&project_folder, &branch_name, &worktree_str)?;
+	let branch_name = if auto_generated {
+		let mut candidate = branch_name;
+		let mut created = false;
+		for _ in 0..5 {
+			match infra::git::worktree_add(
+				&project_folder,
+				&candidate,
+				&worktree_str,
+			) {
+				Ok(()) => {
+					created = true;
+					break;
+				}
+				Err(AppError::GitError(message))
+					if message.contains("already exists") =>
+				{
+					candidate = generate_auto_branch_name(conn, project_id)?;
+				}
+				Err(err) => return Err(err),
+			}
+		}
+		if !created {
+			return Err(AppError::GitError(
+				"Failed to auto-generate a unique branch name".to_string(),
+			));
+		}
+		candidate
+	} else {
+		infra::git::worktree_add(&project_folder, &branch_name, &worktree_str)?;
+		branch_name
+	};
 
 	let profile = repo::profile::insert(
 		conn,
@@ -130,5 +254,35 @@ mod tests {
 	#[test]
 	fn sanitize_empty_input() {
 		assert_eq!(sanitize_branch_name(""), "");
+	}
+
+	#[test]
+	fn extract_auto_branch_city_reads_generated_branch() {
+		assert_eq!(
+			extract_auto_branch_city("pr/chiang-mai-deadbeef"),
+			Some("chiang-mai")
+		);
+	}
+
+	#[test]
+	fn extract_auto_branch_city_ignores_non_generated_branch() {
+		assert_eq!(extract_auto_branch_city("feature/auth"), None);
+	}
+
+	#[test]
+	fn build_auto_branch_name_avoids_used_cities() {
+		let existing = vec![
+			"pr/tokyo-11111111".to_string(),
+			"pr/osaka-22222222".to_string(),
+		];
+		let seed =
+			Uuid::parse_str("00000000-0000-4000-8000-000000000000").unwrap();
+
+		let branch_name = build_auto_branch_name(&existing, &seed);
+
+		assert!(branch_name.starts_with("pr/"));
+		assert!(!branch_name.starts_with("pr/tokyo-"));
+		assert!(!branch_name.starts_with("pr/osaka-"));
+		assert!(branch_name.ends_with("-00000000"));
 	}
 }

--- a/src-tauri/tests/integration_project.rs
+++ b/src-tauri/tests/integration_project.rs
@@ -417,6 +417,50 @@ fn create_profile_shows_in_list_projects() {
 	cleanup(&dir);
 }
 
+#[test]
+fn create_profile_blank_name_generates_pr_branch() {
+	let mut conn = setup_db();
+	let (project, _default, dir) = create_project_with_git_repo(&mut conn);
+
+	let profile = service::profile::create(&mut conn, &project.id, "").unwrap();
+
+	assert!(profile.branch_name.starts_with("pr/"));
+	let generated = profile.branch_name.strip_prefix("pr/").unwrap();
+	let (city, short_id) = generated.rsplit_once('-').unwrap();
+	assert!(!city.is_empty());
+	assert_eq!(short_id.len(), 8);
+	assert!(short_id.chars().all(|c| c.is_ascii_hexdigit()));
+
+	service::profile::delete(&mut conn, &profile.id).unwrap();
+	cleanup(&dir);
+}
+
+#[test]
+fn create_profile_blank_name_uses_different_city_until_pool_exhausted() {
+	let mut conn = setup_db();
+	let (project, _default, dir) = create_project_with_git_repo(&mut conn);
+
+	let first = service::profile::create(&mut conn, &project.id, "").unwrap();
+	let second = service::profile::create(&mut conn, &project.id, "").unwrap();
+
+	let first_city = first
+		.branch_name
+		.strip_prefix("pr/")
+		.and_then(|name| name.rsplit_once('-').map(|(city, _)| city))
+		.unwrap();
+	let second_city = second
+		.branch_name
+		.strip_prefix("pr/")
+		.and_then(|name| name.rsplit_once('-').map(|(city, _)| city))
+		.unwrap();
+
+	assert_ne!(first_city, second_city);
+
+	service::profile::delete(&mut conn, &first.id).unwrap();
+	service::profile::delete(&mut conn, &second.id).unwrap();
+	cleanup(&dir);
+}
+
 // ============================================================
 // Profile Creation (Edge Cases)
 // ============================================================

--- a/src/features/profiles/CreateProfileDialog.tsx
+++ b/src/features/profiles/CreateProfileDialog.tsx
@@ -6,7 +6,7 @@ import {
 	Input,
 	Portal,
 } from "@chakra-ui/react";
-import { useForm, useWatch } from "react-hook-form";
+import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router";
 import * as m from "@/paraglide/messages.js";
 import { useCreateProfile } from "./hooks";
@@ -46,8 +46,6 @@ export default function CreateProfileDialog({
 		navigate(`/projects/${projectId}/profiles/${profile.id}`);
 	});
 
-	const branchName = useWatch({ control: form.control, name: "branchName" });
-
 	return (
 		<Dialog.Root
 			lazyMount
@@ -68,13 +66,10 @@ export default function CreateProfileDialog({
 								<Field.Label>{m.branchName()}</Field.Label>
 								<Input
 									placeholder={m.branchNamePlaceholder()}
-									{...form.register("branchName", {
-										validate: (v) => !!v.trim(),
-									})}
+									{...form.register("branchName")}
 									onKeyDown={(e) => {
 										if (
 											e.key === "Enter" &&
-											branchName.trim() &&
 											!createProfile.isPending
 										) {
 											handleCreate();
@@ -88,10 +83,7 @@ export default function CreateProfileDialog({
 								<Button variant="outline">{m.cancel()}</Button>
 							</Dialog.ActionTrigger>
 							<Button
-								disabled={
-									!branchName.trim() ||
-									createProfile.isPending
-								}
+								disabled={createProfile.isPending}
 								loading={createProfile.isPending}
 								onClick={handleCreate}
 							>


### PR DESCRIPTION
## Stack Context
Make profile creation smoother when the user does not want to name a branch up front.

## What?
- Allow creating a profile with an empty branch name.
- Auto-generate a branch name in the form `pr/<city>-<uuid8>`.
- Prefer cities that are not already used by this project's existing auto-generated PR branches.
- Update the branch input placeholder to explain the leave-empty behavior in English and Chinese.
- Add backend tests for the generated branch format and city rotation behavior.

## Why?
The old flow hard-required a branch name and rejected empty input in both the frontend and backend. That adds friction for the common "just give me a disposable PR branch" case. This keeps the explicit naming path unchanged, but makes the empty path deterministic, readable, and unique enough for worktree creation.

## Validation
- `cargo test`
- `bun run build`
