### PR TITLE
chore(terminal): drop xterm.js WebGL addon

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -26,7 +26,6 @@
         "@xterm/addon-ligatures": "^0.11.0-beta.197",
         "@xterm/addon-progress": "^0.3.0-beta.197",
         "@xterm/addon-web-links": "^0.13.0-beta.197",
-        "@xterm/addon-webgl": "^0.20.0-beta.196",
         "@xterm/xterm": "^6.1.0-beta.197",
         "consola": "^3.4.2",
         "driver.js": "^1.4.0",
@@ -623,8 +622,6 @@
     "@xterm/addon-progress": ["@xterm/addon-progress@0.3.0-beta.197", "", { "peerDependencies": { "@xterm/xterm": "^6.1.0-beta.197" } }, "sha512-ZvWE78sIBu0rAjpvycuKZqBVWLcm5ePO/oH4tBIwJLIY3g2FpRKKorBGPN9raBHw3Bfxzg7tZAFqv6iuDZxEIw=="],
 
     "@xterm/addon-web-links": ["@xterm/addon-web-links@0.13.0-beta.197", "", { "peerDependencies": { "@xterm/xterm": "^6.1.0-beta.197" } }, "sha512-8MgssTKGYJIgZpemu34KBIsmB0qh/XsQxugOhaYym8qSjn8KAMn9FN0j15W6XwEFQDAu1vtBh1jiKjQfyvHoqQ=="],
-
-    "@xterm/addon-webgl": ["@xterm/addon-webgl@0.20.0-beta.196", "", { "peerDependencies": { "@xterm/xterm": "^6.1.0-beta.197" } }, "sha512-5nYgVRwHFVihNNFAARbePZyxi3yAd4VAnF44FaGIjYWCIkA/N27Nl7NwSEX5nHedEbRY/ZfVq/zGFKQBetZlEw=="],
 
     "@xterm/xterm": ["@xterm/xterm@6.1.0-beta.197", "", {}, "sha512-vzoc8sBcsvFpziSgeVGKZQDT1T/9MmEUKfUDpVqc3slDv7o0SiQCjvPeOF8y1++5vx2xmUn8lfcLnbfdtigtSQ=="],
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "@xterm/addon-ligatures": "^0.11.0-beta.197",
     "@xterm/addon-progress": "^0.3.0-beta.197",
     "@xterm/addon-web-links": "^0.13.0-beta.197",
-    "@xterm/addon-webgl": "^0.20.0-beta.196",
     "@xterm/xterm": "^6.1.0-beta.197",
     "consola": "^3.4.2",
     "driver.js": "^1.4.0",

--- a/src/features/terminal/AGENTS.md
+++ b/src/features/terminal/AGENTS.md
@@ -21,7 +21,6 @@ PTY terminal management with xterm.js. The most complex frontend feature.
 
 **xterm.js addon stack** (loaded in `Terminal.tsx`):
 - `FitAddon` — resize to container
-- `WebglAddon` — GPU renderer (with canvas 2D fallback via try/catch)
 - `WebLinksAddon`, `ClipboardAddon`, `ImageAddon`, `LigaturesAddon`, `ProgressAddon`
 
 **Session restoration flow**:

--- a/src/features/terminal/Terminal.tsx
+++ b/src/features/terminal/Terminal.tsx
@@ -6,7 +6,6 @@ import { ImageAddon } from "@xterm/addon-image";
 import { LigaturesAddon } from "@xterm/addon-ligatures";
 import { ProgressAddon } from "@xterm/addon-progress";
 import { WebLinksAddon } from "@xterm/addon-web-links";
-import { WebglAddon } from "@xterm/addon-webgl";
 import { Terminal as XTerm } from "@xterm/xterm";
 import { open } from "@tauri-apps/plugin-shell";
 import consola from "consola";
@@ -212,17 +211,7 @@ export function Terminal({ profileId, sessionId, isActive }: TerminalProps) {
 			termRef.current = term;
 			fitAddonRef.current = fitAddon;
 
-			// WebGL renderer — must load after open(); fall back silently if unavailable
-			try {
-				const webglAddon = new WebglAddon();
-				webglAddon.onContextLoss(() => webglAddon.dispose());
-				term.loadAddon(webglAddon);
-				unlisteners.push(() => webglAddon.dispose());
-			} catch {
-				// WebGL unavailable — xterm falls back to canvas 2D renderer
-			}
-
-			term.loadAddon(new ClipboardAddon());
+term.loadAddon(new ClipboardAddon());
 			term.loadAddon(new ImageAddon());
 			term.loadAddon(new LigaturesAddon());
 			term.loadAddon(new ProgressAddon());


### PR DESCRIPTION
## Why?

WebGL renderer introduces unnecessary complexity and potential context-loss issues. xterm.js falls back to canvas 2D renderer automatically, which is sufficient for this use case.

**Changes:**
- Remove `WebglAddon` import and initialization from `Terminal.tsx`
- Uninstall `@xterm/addon-webgl` package

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Terminal rendering stack simplified by removing WebGL addon. The terminal now uses standard canvas rendering without GPU-accelerated display support.

* **Chores**
  * Removed WebGL addon dependency from project configuration to reduce bundle size and simplify dependencies.

* **Documentation**
  * Updated terminal addon documentation to reflect current addon stack and available features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->