### PR TITLE
feat(terminal): add CJK font fallbacks

### DIFF
--- a/src/features/settings/stores/terminalSettingsStore.ts
+++ b/src/features/settings/stores/terminalSettingsStore.ts
@@ -3,6 +3,7 @@ import { persist } from "zustand/middleware";
 import type { TerminalThemeId } from "@/features/terminal/themes";
 
 export const DEFAULT_TERMINAL_FONT_SIZE = 13;
+export const CJK_FONT_FALLBACKS = '"PingFang SC", "Hiragino Sans GB"';
 export const MIN_TERMINAL_FONT_SIZE = 10;
 export const MAX_TERMINAL_FONT_SIZE = 20;
 
@@ -63,7 +64,7 @@ export const useTerminalSettingsStore = create<TerminalSettingsStore>()(
 function syncMonoFont(fontFamily: string) {
 	document.documentElement.style.setProperty(
 		"--chakra-fonts-mono",
-		`"${fontFamily}", monospace`,
+		`"${fontFamily}", ${CJK_FONT_FALLBACKS}, monospace`,
 	);
 }
 

--- a/src/features/terminal/Terminal.tsx
+++ b/src/features/terminal/Terminal.tsx
@@ -10,7 +10,10 @@ import { Terminal as XTerm } from "@xterm/xterm";
 import { open } from "@tauri-apps/plugin-shell";
 import consola from "consola";
 import { useCallback, useEffect, useMemo, useRef } from "react";
-import { useTerminalSettingsStore } from "@/features/settings/stores/terminalSettingsStore";
+import {
+	CJK_FONT_FALLBACKS,
+	useTerminalSettingsStore,
+} from "@/features/settings/stores/terminalSettingsStore";
 import {
 	clearPtyOutput,
 	flushPtyOutput,
@@ -92,7 +95,7 @@ export function Terminal({ profileId, sessionId, isActive }: TerminalProps) {
 		const term = termRef.current;
 		if (!term) return;
 
-		term.options.fontFamily = `"${fontFamily}", monospace`;
+		term.options.fontFamily = `"${fontFamily}", ${CJK_FONT_FALLBACKS}, monospace`;
 		term.options.fontSize = fontSize;
 		syncTerminalLayout(1);
 
@@ -159,7 +162,7 @@ export function Terminal({ profileId, sessionId, isActive }: TerminalProps) {
 
 			// 1. Create xterm (sync)
 			const term = new XTerm({
-				fontFamily: `"${initFontFamilyRef.current}", monospace`,
+				fontFamily: `"${initFontFamilyRef.current}", ${CJK_FONT_FALLBACKS}, monospace`,
 				fontSize: initFontSizeRef.current,
 				theme: initThemeRef.current,
 				cursorBlink: true,

--- a/src/features/terminal/TerminalPreview.tsx
+++ b/src/features/terminal/TerminalPreview.tsx
@@ -1,4 +1,7 @@
-import { useTerminalSettingsStore } from "@/features/settings/stores/terminalSettingsStore";
+import {
+	CJK_FONT_FALLBACKS,
+	useTerminalSettingsStore,
+} from "@/features/settings/stores/terminalSettingsStore";
 import { useTerminalTheme } from "./hooks";
 import type { TerminalThemeId } from "./themes";
 import { terminalThemes } from "./themes";
@@ -33,7 +36,7 @@ export function TerminalPreview({
 			style={{
 				background: theme.background,
 				color: theme.foreground,
-				fontFamily: `"${fontFamily}", monospace`,
+				fontFamily: `"${fontFamily}", ${CJK_FONT_FALLBACKS}, monospace`,
 				fontSize: `${fontSize}px`,
 				lineHeight: 1.4,
 				padding: "12px 16px",


### PR DESCRIPTION
## Why?

CJK characters (Chinese, Japanese, Korean) in the terminal would fall back to system sans-serif fonts instead of a proper monospace CJK font, causing broken or misaligned display.

Adds `"PingFang SC", "Hiragino Sans GB"` to the font stack (macOS system fonts) between the user-selected font and `monospace`. This means English characters still use the user's chosen font, and only CJK characters fall through to the CJK fallback.

Exports a `CJK_FONT_FALLBACKS` constant from `terminalSettingsStore` and applies it consistently across all 4 font stack construction sites: xterm init, dynamic font update, TerminalPreview, and the `--chakra-fonts-mono` CSS variable.
