### PR TITLE
fix(terminal): remove mono font from file tab labels

### DIFF
--- a/src/features/terminal/TerminalTabs.tsx
+++ b/src/features/terminal/TerminalTabs.tsx
@@ -221,7 +221,7 @@ export default function TerminalTabs({
 										alt=""
 										draggable={false}
 									/>
-									<HStack gap="2" fontFamily="mono">
+									<HStack gap="2">
 										{displayTitle}
 										<CloseButton
 											as="span"


### PR DESCRIPTION
## Why?

File tab labels were inheriting `fontFamily="mono"` from the `HStack` wrapper, making the filename text render in monospace font. Only the file content inside `FileViewerPane` should use mono font — tab labels should match the UI's default font like terminal tabs do.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Minor styling update to terminal tab interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->