### PR TITLE
feat(terminal): animate tab open and close

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -30,6 +30,7 @@
         "consola": "^3.4.2",
         "driver.js": "^1.4.0",
         "immer": "^11.1.4",
+        "motion": "^12.38.0",
         "next-themes": "^0.4.6",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
@@ -1063,6 +1064,8 @@
 
     "formatly": ["formatly@0.3.0", "", { "dependencies": { "fd-package-json": "^2.0.0" }, "bin": { "formatly": "bin/index.mjs" } }, "sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w=="],
 
+    "framer-motion": ["framer-motion@12.38.0", "", { "dependencies": { "motion-dom": "^12.38.0", "motion-utils": "^12.36.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g=="],
+
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
@@ -1360,6 +1363,12 @@
     "mlly": ["mlly@1.8.0", "", { "dependencies": { "acorn": "^8.15.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "ufo": "^1.6.1" } }, "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g=="],
 
     "module-replacements": ["module-replacements@2.11.0", "", {}, "sha512-j5sNQm3VCpQQ7nTqGeOZtoJtV3uKERgCBm9QRhmGRiXiqkf7iRFOkfxdJRZWLkqYY8PNf4cDQF/WfXUYLENrRA=="],
+
+    "motion": ["motion@12.38.0", "", { "dependencies": { "framer-motion": "^12.38.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-uYfXzeHlgThchzwz5Te47dlv5JOUC7OB4rjJ/7XTUgtBZD8CchMN8qEJ4ZVsUmTyYA44zjV0fBwsiktRuFnn+w=="],
+
+    "motion-dom": ["motion-dom@12.38.0", "", { "dependencies": { "motion-utils": "^12.36.0" } }, "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA=="],
+
+    "motion-utils": ["motion-utils@12.36.0", "", {}, "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "consola": "^3.4.2",
     "driver.js": "^1.4.0",
     "immer": "^11.1.4",
+    "motion": "^12.38.0",
     "next-themes": "^0.4.6",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",

--- a/src/features/terminal/TerminalTabs.tsx
+++ b/src/features/terminal/TerminalTabs.tsx
@@ -10,6 +10,7 @@ import {
 	Tabs,
 	Text,
 } from "@chakra-ui/react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { useEffect, useRef, useState } from "react";
 import { getIconForFile } from "vscode-icons-js";
 import { FiPlus, FiTerminal } from "react-icons/fi";
@@ -38,6 +39,14 @@ import { Terminal } from "./Terminal";
 // which would break useShallow's equality check and cause infinite re-renders.
 const EMPTY_TERMINAL_PROFILE = { tabs: [] as { id: string; title: string }[], activeTabId: null as string | null };
 const EMPTY_FILE_PROFILE = { tabs: [] as { filePath: string; title: string }[], activeFilePath: null as string | null, fileTabActive: false };
+const TAB_ANIMATION = {
+	duration: 0.18,
+	ease: [0.22, 1, 0.36, 1],
+} as const;
+const TAB_EXIT_ANIMATION = {
+	duration: 0.14,
+	ease: [0.4, 0, 1, 1],
+} as const;
 
 interface TerminalTabsProps {
 	projectId: string;
@@ -71,6 +80,7 @@ export default function TerminalTabs({
 	const closeTab = useCloseTerminalTab();
 	const projectConfig = useProjectConfigQuery(projectId);
 	const globalTemplates = useTerminalTemplatesStore((s) => s.templates);
+	const prefersReducedMotion = useReducedMotion();
 	const [isTemplateMenuOpen, setIsTemplateMenuOpen] = useState(false);
 	const [templateMenuPosition, setTemplateMenuPosition] = useState<{
 		top: number;
@@ -88,6 +98,38 @@ export default function TerminalTabs({
 	const activeValue = fileTabActive
 		? (activeFilePath ?? "")
 		: (activeTabId ?? "");
+	const tabMotionProps = prefersReducedMotion
+		? {}
+		: {
+				layout: "position" as const,
+				initial: {
+					opacity: 0,
+					scale: 0.92,
+					y: 6,
+				},
+				animate: {
+					opacity: 1,
+					scale: 1,
+					y: 0,
+				},
+				exit: {
+					opacity: 0,
+					scale: 0.88,
+					y: -6,
+					width: 0,
+				},
+				transition: {
+					layout: TAB_ANIMATION,
+					default: TAB_ANIMATION,
+					opacity: TAB_EXIT_ANIMATION,
+				},
+			};
+	const buttonMotionProps = prefersReducedMotion
+		? {}
+		: {
+				layout: "position" as const,
+				transition: TAB_ANIMATION,
+			};
 
 	function handleTabChange(value: string) {
 		const isFileTab = fileTabs.some((t) => t.filePath === value);
@@ -168,97 +210,121 @@ export default function TerminalTabs({
 			>
 				<Box overflowX="auto" overflowY="hidden" w="full" minW="0">
 					<Tabs.List w="full" minW="max-content" flexWrap="nowrap">
-						{tabs.map((tab) => {
-							const displayTitle =
-								tab.title.length > 10
-									? `${tab.title.slice(0, 10)}...`
-									: tab.title;
-							return (
-								<Tabs.Trigger
-									key={tab.id}
-									value={tab.id}
-									flexShrink={0}
-								>
-									<FiTerminal />
-									<HStack gap="2">
-										{displayTitle}
-										{notifiedTabs.has(tab.id) &&
-											tab.id !== activeTabId && (
-												<Circle size="2" bg="green.500" />
-											)}
-										<CloseButton
-											as="span"
-											role="button"
-											size="2xs"
-											onClick={(e) => {
-												e.stopPropagation();
-												closeTab.mutate({
-													profileId,
-													sessionId: tab.id,
-												});
-											}}
-										/>
-									</HStack>
-								</Tabs.Trigger>
-							);
-						})}
+						<AnimatePresence initial={false}>
+							{tabs.map((tab) => {
+								const displayTitle =
+									tab.title.length > 10
+										? `${tab.title.slice(0, 10)}...`
+										: tab.title;
+								return (
+									<motion.div
+										key={`terminal:${tab.id}`}
+										style={{
+											display: "flex",
+											flexShrink: 0,
+											overflow: "hidden",
+											transformOrigin: "left center",
+										}}
+										{...tabMotionProps}
+									>
+										<Tabs.Trigger value={tab.id} flexShrink={0}>
+											<FiTerminal />
+											<HStack gap="2">
+												{displayTitle}
+												{notifiedTabs.has(tab.id) &&
+													tab.id !== activeTabId && (
+														<Circle size="2" bg="green.500" />
+													)}
+												<CloseButton
+													as="span"
+													role="button"
+													size="2xs"
+													onClick={(e) => {
+														e.stopPropagation();
+														closeTab.mutate({
+															profileId,
+															sessionId: tab.id,
+														});
+													}}
+												/>
+											</HStack>
+										</Tabs.Trigger>
+									</motion.div>
+								);
+							})}
 
-						{fileTabs.map((tab) => {
-							const displayTitle =
-								tab.title.length > 14
-									? `${tab.title.slice(0, 14)}...`
-									: tab.title;
-							return (
-								<Tabs.Trigger
-									key={tab.filePath}
-									value={tab.filePath}
-									flexShrink={0}
-								>
-									<img
-										src={fileIconUrl(tab.title)}
-										width={14}
-										height={14}
-										alt=""
-										draggable={false}
-									/>
-									<HStack gap="2">
-										{displayTitle}
-										<CloseButton
-											as="span"
-											role="button"
-											size="2xs"
-											onClick={(e) => {
-												e.stopPropagation();
-												closeFileTab(profileId, tab.filePath);
-											}}
-										/>
-									</HStack>
-								</Tabs.Trigger>
-							);
-						})}
+							{fileTabs.map((tab) => {
+								const displayTitle =
+									tab.title.length > 14
+										? `${tab.title.slice(0, 14)}...`
+										: tab.title;
+								return (
+									<motion.div
+										key={`file:${tab.filePath}`}
+										style={{
+											display: "flex",
+											flexShrink: 0,
+											overflow: "hidden",
+											transformOrigin: "left center",
+										}}
+										{...tabMotionProps}
+									>
+										<Tabs.Trigger
+											value={tab.filePath}
+											flexShrink={0}
+										>
+											<img
+												src={fileIconUrl(tab.title)}
+												width={14}
+												height={14}
+												alt=""
+												draggable={false}
+											/>
+											<HStack gap="2">
+												{displayTitle}
+												<CloseButton
+													as="span"
+													role="button"
+													size="2xs"
+													onClick={(e) => {
+														e.stopPropagation();
+														closeFileTab(profileId, tab.filePath);
+													}}
+												/>
+											</HStack>
+										</Tabs.Trigger>
+									</motion.div>
+								);
+							})}
+						</AnimatePresence>
 
-						<Box
-							ref={newTerminalButtonRef}
-							display="inline-flex"
-							flexShrink={0}
-							alignSelf="center"
-							ms="2"
-							onMouseEnter={openTemplateMenu}
-							onMouseLeave={scheduleTemplateMenuClose}
+						<motion.div
+							style={{ display: "flex", flexShrink: 0 }}
+							{...buttonMotionProps}
 						>
-							<Button
-								size="2xs"
-								variant="ghost"
-								disabled={createTab.isPending}
-								onClick={() => {
-									setIsTemplateMenuOpen(false);
-									createTab.mutate({ profileId, cwd });
-									setTerminalActive(profileId);
-								}}
+							<Box
+								ref={newTerminalButtonRef}
+								display="inline-flex"
+								flexShrink={0}
+								alignSelf="center"
+								ms="2"
+								onMouseEnter={openTemplateMenu}
+								onMouseLeave={scheduleTemplateMenuClose}
 							>
-								<FiPlus /> {m.newTerminal()}
-							</Button>
-						</Box>
+								<Button
+									size="2xs"
+									variant="ghost"
+									disabled={createTab.isPending}
+									onClick={() => {
+										setIsTemplateMenuOpen(false);
+										createTab.mutate({ profileId, cwd });
+										setTerminalActive(profileId);
+									}}
+								>
+									<FiPlus /> {m.newTerminal()}
+								</Button>
+							</Box>
+						</motion.div>
 					</Tabs.List>
 				</Box>
 			</Tabs.Root>


### PR DESCRIPTION
## Stack Context

This PR smooths terminal tab interactions by adding motion.dev entry and exit animations without changing the existing terminal mount lifecycle.

## What?

- add `motion` as a frontend dependency
- animate terminal and file tabs when they are created, closed, and shifted by neighboring tabs
- respect reduced-motion preferences while keeping the New Terminal button aligned with the animated layout

## Why?

Tabs currently appear and disappear abruptly, which makes the strip feel harsher than the rest of the UI. This keeps the existing xterm persistence behavior intact and moves the polish entirely into the tab-list presentation layer.

## Validation

- `bun x tsc --noEmit`
- `bun x eslint src/features/terminal/TerminalTabs.tsx`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Terminal and file tabs now animate smoothly with fade and scale effects when opening and closing, providing enhanced visual feedback during transitions.
  * The new terminal button also features animation aligned with tab behavior.
  * All animations respect system accessibility preferences, automatically disabling motion when reduced motion is enabled.

* **Chores**
  * Added animation dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->