### PR TITLE
fix(git): remove file tree toggle padding

### DIFF
--- a/src/features/git/ProjectTopBar.tsx
+++ b/src/features/git/ProjectTopBar.tsx
@@ -120,6 +120,7 @@ export default function ProjectTopBar({
 									aria-label={isFileTreeOpen ? "Close file tree" : "Open file tree"}
 									size="xs"
 									variant="ghost"
+									p="0"
 									onClick={onToggleFileTree}
 								>
 									<FiSidebar />


### PR DESCRIPTION
## Stack Context

This PR removes the extra padding from the file tree toggle button in `ProjectTopBar` so the control sits flush in the project top bar.

## Why?

The default Chakra `IconButton` padding made the file tree toggle look larger than intended relative to the surrounding top bar controls. Setting `p="0"` keeps the button aligned without affecting the other actions in the bar.
