### PR TITLE
fix(projects): preserve file tree folder expand animation

### DIFF
--- a/src/features/projects/FileTreePanel.test.tsx
+++ b/src/features/projects/FileTreePanel.test.tsx
@@ -1,0 +1,97 @@
+import { ChakraProvider } from "@chakra-ui/react";
+import {
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { FileEntry } from "@/generated/types";
+import { appSystem } from "@/theme/system";
+import FileTreePanel from "./FileTreePanel";
+import { useDirectoryListing } from "./hooks";
+
+vi.mock("./hooks", () => ({
+	useDirectoryListing: vi.fn(),
+}));
+
+vi.mock("./FileViewerDialog", () => ({
+	default: () => null,
+}));
+
+const rootPath = "/root";
+const folderEntry: FileEntry = {
+	name: "src",
+	path: "/root/src",
+	is_dir: true,
+};
+const childEntry: FileEntry = {
+	name: "index.ts",
+	path: "/root/src/index.ts",
+	is_dir: false,
+};
+
+type DirectoryListingResult = ReturnType<typeof useDirectoryListing>;
+
+function createDirectoryListingResult(
+	data: FileEntry[] | undefined,
+	isLoading: boolean,
+): DirectoryListingResult {
+	return {
+		data,
+		isLoading,
+	} as DirectoryListingResult;
+}
+
+describe("fileTreePanel", () => {
+	let folderState: "loading" | "loaded";
+
+	beforeEach(() => {
+		folderState = "loading";
+
+		vi.mocked(useDirectoryListing).mockImplementation((path, enabled = true) => {
+			if (path === rootPath) {
+				return createDirectoryListingResult([folderEntry], false);
+			}
+
+			if (path === folderEntry.path && enabled) {
+				if (folderState === "loading") {
+					return createDirectoryListingResult(undefined, true);
+				}
+
+				return createDirectoryListingResult([childEntry], false);
+			}
+
+			return createDirectoryListingResult(undefined, false);
+		});
+	});
+
+	it("keeps the expanded group mounted while uncached children are loading", async () => {
+		const { rerender } = render(
+			<ChakraProvider value={appSystem}>
+				<FileTreePanel rootPath={rootPath} isOpen />
+			</ChakraProvider>,
+		);
+
+		fireEvent.click(screen.getByText("src"));
+
+		expect(
+			screen.getByRole("status", { name: "Loading src" }),
+		).toBeInTheDocument();
+		expect(screen.queryByText("index.ts")).not.toBeInTheDocument();
+
+		folderState = "loaded";
+		rerender(
+			<ChakraProvider value={appSystem}>
+				<FileTreePanel rootPath={rootPath} isOpen />
+			</ChakraProvider>,
+		);
+
+		await waitFor(() => {
+			expect(screen.getByText("index.ts")).toBeInTheDocument();
+		});
+		expect(
+			screen.queryByRole("status", { name: "Loading src" }),
+		).not.toBeInTheDocument();
+	});
+});

--- a/src/features/projects/FileTreePanel.tsx
+++ b/src/features/projects/FileTreePanel.tsx
@@ -47,6 +47,30 @@ interface TreeNodeProps {
 	prefersReducedMotion: boolean;
 }
 
+function TreeNodeLoadingRow({
+	depth,
+	label,
+}: {
+	depth: number;
+	label: string;
+}) {
+	return (
+		<Flex
+			align="center"
+			gap="2"
+			py="0.5"
+			role="status"
+			aria-label={label}
+			style={{ paddingLeft: `${16 + (depth + 1) * 12 + 18}px` }}
+		>
+			<Spinner size="xs" color="fg.muted" />
+			<Text fontSize="sm" color="fg.muted">
+				Loading...
+			</Text>
+		</Flex>
+	);
+}
+
 function TreeNode({
 	entry,
 	depth,
@@ -60,8 +84,9 @@ function TreeNode({
 		entry.path,
 		entry.is_dir && isExpanded,
 	);
-
 	const indent = depth * 12;
+	const childPaddingLeft = `${16 + (depth + 1) * 12 + 18}px`;
+	const showLoadingRow = isExpanded && isLoading && children == null;
 
 	if (entry.is_dir) {
 		return (
@@ -91,12 +116,12 @@ function TreeNode({
 							<FiChevronRight size={14} />
 						</motion.span>
 					</Box>
-						<Box flexShrink="0" display="flex">
-							<img
-								src={getFolderIconUrl(entry.name, isExpanded)}
-								width={16}
-								height={16}
-								alt=""
+					<Box flexShrink="0" display="flex">
+						<img
+							src={getFolderIconUrl(entry.name, isExpanded)}
+							width={16}
+							height={16}
+							alt=""
 							draggable={false}
 						/>
 					</Box>
@@ -109,6 +134,7 @@ function TreeNode({
 					{isExpanded && (
 						<Box asChild overflow="hidden">
 							<motion.div
+								layout={prefersReducedMotion ? false : "size"}
 								initial={
 									prefersReducedMotion
 										? false
@@ -126,7 +152,13 @@ function TreeNode({
 										: FILE_TREE_GROUP_TRANSITION
 								}
 							>
-								{children && children.map((child) => (
+								{showLoadingRow && (
+									<TreeNodeLoadingRow
+										depth={depth}
+										label={`Loading ${entry.name}`}
+									/>
+								)}
+								{children?.map((child) => (
 									<TreeNode
 										key={child.path}
 										entry={child}
@@ -137,11 +169,11 @@ function TreeNode({
 										prefersReducedMotion={prefersReducedMotion}
 									/>
 								))}
-								{children && children.length === 0 && (
+								{children?.length === 0 && (
 									<Text
 										fontSize="sm"
 										color="fg.muted"
-										style={{ paddingLeft: `${16 + (depth + 1) * 12 + 18}px` }}
+										style={{ paddingLeft: childPaddingLeft }}
 										py="0.5"
 									>
 										Empty

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,3 +1,4 @@
+import "@testing-library/jest-dom/vitest";
 import { vi } from "vitest";
 
 // ─── Fix Node.js 22+ experimental localStorage conflicting with jsdom ───


### PR DESCRIPTION
## Summary
- keep the expanded folder group mounted while uncached children are loading
- render a loading row inside the expanded group so the open animation still has visible height to animate
- add a component test for the uncached folder-expand path and enable jest-dom matchers in Vitest setup

## Testing
- bunx vitest run src/features/projects/FileTreePanel.test.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a loading indicator in the file tree that displays when directory contents are being fetched.

* **Tests**
  * Enhanced test coverage for file tree loading states and directory expansion behavior.
  * Updated test infrastructure with additional DOM testing utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->