### PR TITLE
fix(sidebar): restore drag region near traffic lights

### DIFF
--- a/src/layout/AppSidebar.tsx
+++ b/src/layout/AppSidebar.tsx
@@ -57,12 +57,12 @@ export default function AppSidebar() {
           <Flex direction="column" h="full" pb="3">
             <Flex
               data-tauri-drag-region
-              h="48px"
+              h="80px"
               flexShrink={0}
               align="center"
               justify="start"
               paddingInline="4"
-              mt="8"
+              pt="8"
             >
               <Text
                 fontFamily="'Bricolage Grotesque Variable', sans-serif"


### PR DESCRIPTION
## Stack Context

This PR fixes macOS window dragging near the traffic lights in the sidebar/header area.

## What?

- Expand the sidebar header drag region to cover the empty top offset near the traffic lights.
- Keep the existing visual spacing by using internal top padding instead of external margin.

## Why?

The previous layout pushed the branded header down with margin, which left the top strip near the red/yellow/green window controls outside the Tauri drag region. On macOS with an overlay title bar, that made part of the expected draggable area inert. This change makes the top empty space itself draggable while preserving the same visual layout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Increased the top header container height and adjusted vertical spacing in the sidebar for improved visual layout balance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->