### PR TITLE
feat(sidebar): add resizable side panels

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -87,6 +87,7 @@
 	"radiusXLarge": "Extra Large",
 	"changes": "Changes",
 	"history": "History",
+	"fileTreeResizeSeparator": "Resize file tree",
 	"noChangesDetected": "No changes detected",
 	"selectFileToView": "Select a file to view changes",
 	"noCommitsFound": "No commits found",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -87,6 +87,7 @@
 	"radiusXLarge": "超大",
 	"changes": "变更",
 	"history": "历史",
+	"fileTreeResizeSeparator": "调整文件树宽度",
 	"noChangesDetected": "未检测到变更",
 	"selectFileToView": "选择文件查看变更",
 	"noCommitsFound": "暂无提交记录",

--- a/src/features/projects/FileTreePanel.tsx
+++ b/src/features/projects/FileTreePanel.tsx
@@ -10,13 +10,19 @@ import {
 	FiChevronRight,
 } from "react-icons/fi";
 import type { FileEntry } from "@/generated/types";
+import { useHorizontalResize } from "@/shared/hooks/useHorizontalResize";
 import {
 	getFileIconUrl,
 	getFolderIconUrl,
 } from "@/shared/lib/fileIcons";
 import { useDirectoryListing } from "./hooks";
 import FileViewerDialog from "./FileViewerDialog";
-const FILE_TREE_PANEL_WIDTH = 208;
+import {
+	FILE_TREE_PANEL_MAX_WIDTH,
+	FILE_TREE_PANEL_MIN_WIDTH,
+	useFileTreeStore,
+} from "./fileTreeStore";
+
 const FILE_TREE_PANEL_TRANSITION = {
 	type: "spring",
 	stiffness: 320,
@@ -58,6 +64,8 @@ function TreeNodeLoadingRow({
 		<Flex
 			align="center"
 			gap="2"
+			w="max-content"
+			minW="full"
 			py="0.5"
 			role="status"
 			aria-label={label}
@@ -94,6 +102,8 @@ function TreeNode({
 				<Flex
 					align="center"
 					gap="1"
+					w="max-content"
+					minW="full"
 					px="2"
 					py="0.5"
 					cursor="pointer"
@@ -125,7 +135,7 @@ function TreeNode({
 							draggable={false}
 						/>
 					</Box>
-					<Text fontSize="sm" truncate lineClamp={1}>
+					<Text fontSize="sm" whiteSpace="nowrap" flexShrink={0}>
 						{entry.name}
 					</Text>
 					{isLoading && <Spinner size="xs" ml="1" />}
@@ -175,6 +185,7 @@ function TreeNode({
 										color="fg.muted"
 										style={{ paddingLeft: childPaddingLeft }}
 										py="0.5"
+										whiteSpace="nowrap"
 									>
 										Empty
 									</Text>
@@ -191,6 +202,8 @@ function TreeNode({
 		<Flex
 			align="center"
 			gap="1"
+			w="max-content"
+			minW="full"
 			px="2"
 			py="0.5"
 			cursor="pointer"
@@ -209,7 +222,7 @@ function TreeNode({
 					draggable={false}
 				/>
 			</Box>
-			<Text fontSize="sm" truncate lineClamp={1}>
+			<Text fontSize="sm" whiteSpace="nowrap" flexShrink={0}>
 				{entry.name}
 			</Text>
 		</Flex>
@@ -228,6 +241,15 @@ export default function FileTreePanel({ rootPath, isOpen, onOpenFile }: FileTree
 	);
 	const [openFilePath, setOpenFilePath] = useState<string | null>(null);
 	const prefersReducedMotion = useReducedMotion() ?? false;
+	const panelWidth = useFileTreeStore((s) => s.panelWidth);
+	const setPanelWidth = useFileTreeStore((s) => s.setPanelWidth);
+	const resize = useHorizontalResize({
+		value: panelWidth,
+		min: FILE_TREE_PANEL_MIN_WIDTH,
+		max: FILE_TREE_PANEL_MAX_WIDTH,
+		disabled: !isOpen,
+		onChange: setPanelWidth,
+	});
 
 	const { data: rootEntries, isLoading } = useDirectoryListing(rootPath, isOpen);
 
@@ -254,71 +276,130 @@ export default function FileTreePanel({ rootPath, isOpen, onOpenFile }: FileTree
 	return (
 		<>
 			<Box
-				asChild
+				h="full"
 				flexShrink="0"
-				borderRightWidth={isOpen ? "1px" : "0px"}
-				borderColor="border.subtle"
-				bg="bg.panel"
-				overflow="hidden"
 				pointerEvents={isOpen ? "auto" : "none"}
 				aria-hidden={!isOpen}
 			>
-				<motion.div
-					initial={false}
-					animate={{ width: isOpen ? FILE_TREE_PANEL_WIDTH : 0 }}
-					transition={
-						prefersReducedMotion
-							? { duration: 0 }
-							: FILE_TREE_PANEL_TRANSITION
-					}
-					style={{
-						display: "flex",
-						flexDirection: "column",
-						minWidth: 0,
-						overflow: "hidden",
-						willChange: "width",
-					}}
+				<Box
+					asChild
+					h="full"
+					borderRightWidth={isOpen ? "1px" : "0px"}
+					borderColor="border.subtle"
+					bg="bg.panel"
 				>
-					<Box asChild flex="1" minH="0">
-						<motion.div
-							initial={false}
-							animate={{
-								opacity: isOpen ? 1 : 0,
-								x: isOpen ? 0 : -12,
-							}}
-							transition={
-								prefersReducedMotion
-									? { duration: 0 }
-									: FILE_TREE_CONTENT_TRANSITION
-							}
-							style={{
-								display: "flex",
-								flex: 1,
-								minHeight: 0,
-								minWidth: 0,
-							}}
-						>
-							<Box overflow="auto" flex="1" py="1">
-								{isLoading && (
-									<Flex align="center" justify="center" py="4">
-										<Spinner size="xs" />
-									</Flex>
-								)}
-								{rootEntries?.map((entry) => (
-									<TreeNode
-										key={entry.path}
-										entry={entry}
-										depth={0}
-										expandedPaths={expandedPaths}
-										onToggleDir={toggleDir}
-										onOpenFile={handleOpenFile}
-										prefersReducedMotion={prefersReducedMotion}
-									/>
-								))}
+					<motion.div
+						initial={false}
+						animate={{ width: isOpen ? panelWidth : 0 }}
+						transition={
+							prefersReducedMotion || resize.isDragging
+								? { duration: 0 }
+								: FILE_TREE_PANEL_TRANSITION
+						}
+						style={{
+							display: "flex",
+							flexDirection: "column",
+							minWidth: 0,
+							overflow: "visible",
+							position: "relative",
+							willChange: "width",
+						}}
+					>
+						<Box display="flex" flex="1" minH="0" overflow="hidden">
+							<Box asChild flex="1" minH="0">
+								<motion.div
+									initial={false}
+									animate={{
+										opacity: isOpen ? 1 : 0,
+										x: isOpen ? 0 : -12,
+									}}
+									transition={
+										prefersReducedMotion
+											? { duration: 0 }
+											: FILE_TREE_CONTENT_TRANSITION
+									}
+									style={{
+										display: "flex",
+										flex: 1,
+										minHeight: 0,
+										minWidth: 0,
+									}}
+								>
+									<Box overflow="auto" flex="1" py="1">
+										<Box minW="max-content" minH="full">
+											{isLoading && (
+												<Flex
+													align="center"
+													justify="center"
+													py="4"
+												>
+													<Spinner size="xs" />
+												</Flex>
+											)}
+											{rootEntries?.map((entry) => (
+												<TreeNode
+													key={entry.path}
+													entry={entry}
+													depth={0}
+													expandedPaths={expandedPaths}
+													onToggleDir={toggleDir}
+													onOpenFile={handleOpenFile}
+													prefersReducedMotion={
+														prefersReducedMotion
+													}
+												/>
+											))}
+										</Box>
+									</Box>
+								</motion.div>
 							</Box>
-						</motion.div>
-					</Box>
-				</motion.div>
+						</Box>
+						{isOpen && (
+							<Box
+								role="separator"
+								aria-label="Resize file tree"
+								aria-orientation="vertical"
+								aria-valuemin={FILE_TREE_PANEL_MIN_WIDTH}
+								aria-valuemax={FILE_TREE_PANEL_MAX_WIDTH}
+								aria-valuenow={panelWidth}
+								tabIndex={0}
+								position="absolute"
+								top="0"
+								right="-4px"
+								bottom="0"
+								w="8px"
+								cursor="col-resize"
+								zIndex={1}
+								onPointerDown={resize.handlePointerDown}
+								onKeyDown={resize.handleKeyDown}
+								_before={{
+									content: "\"\"",
+									position: "absolute",
+									top: 0,
+									bottom: 0,
+									left: "50%",
+									transform: "translateX(-50%)",
+									width: "1px",
+									bg: resize.isDragging
+										? "border.emphasized"
+										: "transparent",
+									transition: "background-color 0.16s ease",
+								}}
+								_hover={{
+									_before: {
+										bg: "border.subtle",
+									},
+								}}
+								_focusVisible={{
+									outline: "none",
+									_before: {
+										bg: "border.emphasized",
+									},
+								}}
+							/>
+						)}
+					</motion.div>
+				</Box>
 			</Box>
 
 			<FileViewerDialog

--- a/src/features/projects/FileTreePanel.tsx
+++ b/src/features/projects/FileTreePanel.tsx
@@ -10,6 +10,7 @@ import {
 	FiChevronRight,
 } from "react-icons/fi";
 import type { FileEntry } from "@/generated/types";
+import * as m from "@/paraglide/messages.js";
 import { useHorizontalResize } from "@/shared/hooks/useHorizontalResize";
 import {
 	getFileIconUrl,
@@ -357,7 +358,7 @@ export default function FileTreePanel({ rootPath, isOpen, onOpenFile }: FileTree
 						{isOpen && (
 							<Box
 								role="separator"
-								aria-label="Resize file tree"
+								aria-label={m.fileTreeResizeSeparator()}
 								aria-orientation="vertical"
 								aria-valuemin={FILE_TREE_PANEL_MIN_WIDTH}
 								aria-valuemax={FILE_TREE_PANEL_MAX_WIDTH}

--- a/src/features/projects/fileTreeStore.test.ts
+++ b/src/features/projects/fileTreeStore.test.ts
@@ -3,6 +3,7 @@ import {
 	DEFAULT_FILE_TREE_PANEL_WIDTH,
 	FILE_TREE_PANEL_MAX_WIDTH,
 	FILE_TREE_PANEL_MIN_WIDTH,
+	migrateFileTreePersistedState,
 	useFileTreeStore,
 } from "./fileTreeStore";
 
@@ -33,6 +34,30 @@ describe("useFileTreeStore", () => {
 	it("clamps widths above the maximum", () => {
 		getState().setPanelWidth(FILE_TREE_PANEL_MAX_WIDTH + 40);
 		expect(getState().panelWidth).toBe(FILE_TREE_PANEL_MAX_WIDTH);
+	});
+
+	it("clamps migrated widths below the minimum", () => {
+		expect(
+			migrateFileTreePersistedState({
+				panelWidth: FILE_TREE_PANEL_MIN_WIDTH - 40,
+			}).panelWidth,
+		).toBe(FILE_TREE_PANEL_MIN_WIDTH);
+	});
+
+	it("clamps migrated widths above the maximum", () => {
+		expect(
+			migrateFileTreePersistedState({
+				panelWidth: FILE_TREE_PANEL_MAX_WIDTH + 40,
+			}).panelWidth,
+		).toBe(FILE_TREE_PANEL_MAX_WIDTH);
+	});
+
+	it("falls back to the default width for invalid migrated values", () => {
+		expect(
+			migrateFileTreePersistedState({
+				panelWidth: "not-a-number",
+			}).panelWidth,
+		).toBe(DEFAULT_FILE_TREE_PANEL_WIDTH);
 	});
 
 	it("defaults file trees to open", () => {

--- a/src/features/projects/fileTreeStore.test.ts
+++ b/src/features/projects/fileTreeStore.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+	DEFAULT_FILE_TREE_PANEL_WIDTH,
+	FILE_TREE_PANEL_MAX_WIDTH,
+	FILE_TREE_PANEL_MIN_WIDTH,
+	useFileTreeStore,
+} from "./fileTreeStore";
+
+function resetStore() {
+	useFileTreeStore.setState({
+		openProfiles: {},
+		panelWidth: DEFAULT_FILE_TREE_PANEL_WIDTH,
+	});
+	localStorage.clear();
+}
+
+function getState() {
+	return useFileTreeStore.getState();
+}
+
+describe("useFileTreeStore", () => {
+	beforeEach(resetStore);
+
+	it("defaults the panel width", () => {
+		expect(getState().panelWidth).toBe(DEFAULT_FILE_TREE_PANEL_WIDTH);
+	});
+
+	it("clamps widths below the minimum", () => {
+		getState().setPanelWidth(FILE_TREE_PANEL_MIN_WIDTH - 40);
+		expect(getState().panelWidth).toBe(FILE_TREE_PANEL_MIN_WIDTH);
+	});
+
+	it("clamps widths above the maximum", () => {
+		getState().setPanelWidth(FILE_TREE_PANEL_MAX_WIDTH + 40);
+		expect(getState().panelWidth).toBe(FILE_TREE_PANEL_MAX_WIDTH);
+	});
+
+	it("defaults file trees to open", () => {
+		expect(getState().isOpen("profile-1")).toBe(true);
+	});
+
+	it("toggles a profile-specific open state", () => {
+		getState().toggle("profile-1");
+		expect(getState().isOpen("profile-1")).toBe(false);
+
+		getState().toggle("profile-1");
+		expect(getState().isOpen("profile-1")).toBe(true);
+	});
+});

--- a/src/features/projects/fileTreeStore.ts
+++ b/src/features/projects/fileTreeStore.ts
@@ -12,6 +12,27 @@ export function clampFileTreePanelWidth(width: number) {
 	);
 }
 
+interface FileTreePersistedState {
+	panelWidth: number;
+}
+
+function sanitizePersistedPanelWidth(panelWidth: unknown) {
+	return typeof panelWidth === "number" && Number.isFinite(panelWidth)
+		? clampFileTreePanelWidth(panelWidth)
+		: DEFAULT_FILE_TREE_PANEL_WIDTH;
+}
+
+export function migrateFileTreePersistedState(
+	persistedState: unknown,
+): FileTreePersistedState {
+	if (persistedState && typeof persistedState === "object") {
+		const { panelWidth } = persistedState as { panelWidth?: unknown };
+		return { panelWidth: sanitizePersistedPanelWidth(panelWidth) };
+	}
+
+	return { panelWidth: DEFAULT_FILE_TREE_PANEL_WIDTH };
+}
+
 interface FileTreeState {
 	openProfiles: Record<string, boolean>;
 	panelWidth: number;
@@ -38,7 +59,9 @@ export const useFileTreeStore = create<FileTreeState>()(
 		}),
 		{
 			name: "file-tree-panel",
-			version: 1,
+			version: 2,
+			migrate: (persistedState) =>
+				migrateFileTreePersistedState(persistedState),
 			partialize: (state) => ({ panelWidth: state.panelWidth }),
 		},
 	),

--- a/src/features/projects/fileTreeStore.ts
+++ b/src/features/projects/fileTreeStore.ts
@@ -1,19 +1,45 @@
 import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+export const FILE_TREE_PANEL_MIN_WIDTH = 180;
+export const FILE_TREE_PANEL_MAX_WIDTH = 560;
+export const DEFAULT_FILE_TREE_PANEL_WIDTH = 208;
+
+export function clampFileTreePanelWidth(width: number) {
+	return Math.min(
+		FILE_TREE_PANEL_MAX_WIDTH,
+		Math.max(FILE_TREE_PANEL_MIN_WIDTH, width),
+	);
+}
 
 interface FileTreeState {
 	openProfiles: Record<string, boolean>;
+	panelWidth: number;
 	toggle: (profileId: string) => void;
 	isOpen: (profileId: string) => boolean;
+	setPanelWidth: (width: number) => void;
 }
 
-export const useFileTreeStore = create<FileTreeState>((set, get) => ({
-	openProfiles: {},
-	toggle: (profileId) =>
-		set((state) => ({
-			openProfiles: {
-				...state.openProfiles,
-				[profileId]: !(state.openProfiles[profileId] ?? true),
-			},
-		})),
-	isOpen: (profileId) => get().openProfiles[profileId] ?? true,
-}));
+export const useFileTreeStore = create<FileTreeState>()(
+	persist(
+		(set, get) => ({
+			openProfiles: {},
+			panelWidth: DEFAULT_FILE_TREE_PANEL_WIDTH,
+			toggle: (profileId) =>
+				set((state) => ({
+					openProfiles: {
+						...state.openProfiles,
+						[profileId]: !(state.openProfiles[profileId] ?? true),
+					},
+				})),
+			isOpen: (profileId) => get().openProfiles[profileId] ?? true,
+			setPanelWidth: (width) =>
+				set({ panelWidth: clampFileTreePanelWidth(width) }),
+		}),
+		{
+			name: "file-tree-panel",
+			version: 1,
+			partialize: (state) => ({ panelWidth: state.panelWidth }),
+		},
+	),
+);

--- a/src/layout/AppSidebar.tsx
+++ b/src/layout/AppSidebar.tsx
@@ -8,123 +8,183 @@ import { useProjects } from "@/features/projects/hooks";
 import * as m from "@/paraglide/messages.js";
 import { SidebarLink } from "@/shared/components/SidebarLink";
 import { useDialogState } from "@/shared/hooks/useDialogState";
+import { useHorizontalResize } from "@/shared/hooks/useHorizontalResize";
 import { ProjectMenuItem } from "./sidebar/ProjectMenuItem";
+import {
+	APP_SIDEBAR_MAX_WIDTH,
+	APP_SIDEBAR_MIN_WIDTH,
+	useAppSidebarStore,
+} from "./sidebarStore";
 
 export default function AppSidebar() {
-  const { data: projects } = useProjects();
-  const createDialog = useDialogState();
-  const navRef = useRef<HTMLElement>(null);
+	const { data: projects } = useProjects();
+	const createDialog = useDialogState();
+	const navRef = useRef<HTMLElement>(null);
+	const sidebarWidth = useAppSidebarStore((s) => s.width);
+	const setSidebarWidth = useAppSidebarStore((s) => s.setWidth);
+	const resize = useHorizontalResize({
+		value: sidebarWidth,
+		min: APP_SIDEBAR_MIN_WIDTH,
+		max: APP_SIDEBAR_MAX_WIDTH,
+		onChange: setSidebarWidth,
+	});
 
-  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
-    if (e.key !== "ArrowUp" && e.key !== "ArrowDown") return;
+	const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+		if (e.key !== "ArrowUp" && e.key !== "ArrowDown") return;
 
-    const nav = navRef.current;
-    if (!nav) return;
+		const nav = navRef.current;
+		if (!nav) return;
 
-    const items = Array.from(
-      nav.querySelectorAll<HTMLElement>("[data-sidebar-item]"),
-    );
-    if (items.length === 0) return;
+		const items = Array.from(
+			nav.querySelectorAll<HTMLElement>("[data-sidebar-item]"),
+		);
+		if (items.length === 0) return;
 
-    const currentIndex = items.indexOf(document.activeElement as HTMLElement);
+		const currentIndex = items.indexOf(document.activeElement as HTMLElement);
 
-    let nextIndex: number;
-    if (e.key === "ArrowDown") {
-      nextIndex = currentIndex === -1 ? 0 : (currentIndex + 1) % items.length;
-    } else {
-      nextIndex =
-        currentIndex === -1
-          ? items.length - 1
-          : (currentIndex - 1 + items.length) % items.length;
-    }
+		let nextIndex: number;
+		if (e.key === "ArrowDown") {
+			nextIndex =
+				currentIndex === -1 ? 0 : (currentIndex + 1) % items.length;
+		} else {
+			nextIndex =
+				currentIndex === -1
+					? items.length - 1
+					: (currentIndex - 1 + items.length) % items.length;
+		}
 
-    items[nextIndex]?.focus();
-    e.preventDefault();
-  }, []);
+		items[nextIndex]?.focus();
+		e.preventDefault();
+	}, []);
 
-  return (
-    <>
-      <Box
-        as="nav"
-        ref={navRef}
-        aria-label={m.sideNavLabel()}
-        w="var(--sidebar-width)"
-        flexShrink={0}
-        bg="bg.subtle"
-        onKeyDown={handleKeyDown}
-      >
-        <LayoutGroup id="app-sidebar">
-          <Flex direction="column" h="full" pb="3">
-            <Flex
-              data-tauri-drag-region
-              h="80px"
-              flexShrink={0}
-              align="center"
-              justify="start"
-              paddingInline="4"
-              pt="8"
-            >
-              <Text
-                fontFamily="'Bricolage Grotesque Variable', sans-serif"
-                fontWeight="700"
-                color="fg.muted"
-                letterSpacing="tight"
-                userSelect="none"
-                pointerEvents="none"
-              >
-                2Code
-              </Text>
-            </Flex>
-            {projects.length === 0 && (
-              <SidebarLink
-                to="/"
-                icon={<FiHome />}
-                style={{ marginBottom: 20 }}
-              >
-                {m.home()}
-              </SidebarLink>
-            )}
+	return (
+		<>
+			<Box
+				as="nav"
+				ref={navRef}
+				aria-label={m.sideNavLabel()}
+				w="var(--sidebar-width)"
+				h="full"
+				flexShrink={0}
+				position="relative"
+				bg="bg.subtle"
+				onKeyDown={handleKeyDown}
+			>
+				<Box h="full" overflow="auto">
+					<LayoutGroup id="app-sidebar">
+						<Flex direction="column" h="full" minW="max-content" pb="3">
+							<Flex
+								data-tauri-drag-region
+								h="80px"
+								flexShrink={0}
+								align="center"
+								justify="start"
+								paddingInline="4"
+								pt="8"
+							>
+								<Text
+									fontFamily="'Bricolage Grotesque Variable', sans-serif"
+									fontWeight="700"
+									color="fg.muted"
+									letterSpacing="tight"
+									userSelect="none"
+									pointerEvents="none"
+									whiteSpace="nowrap"
+								>
+									2Code
+								</Text>
+							</Flex>
+							{projects.length === 0 && (
+								<SidebarLink
+									to="/"
+									icon={<FiHome />}
+									style={{ marginBottom: 20 }}
+								>
+									{m.home()}
+								</SidebarLink>
+							)}
 
-            <HStack px="4" pt="2" pb="2" justify="space-between">
-              <Text
-                fontSize="xs"
-                fontWeight="semibold"
-                color="fg.muted"
-                textTransform="uppercase"
-                letterSpacing="wider"
-              >
-                {m.projects()}
-              </Text>
-              <IconButton
-                id="add-project-button"
-                aria-label={m.newProject()}
-                variant="ghost"
-                size="2xs"
-                onClick={createDialog.onOpen}
-              >
-                <FiPlus />
-              </IconButton>
-            </HStack>
+							<HStack px="4" pt="2" pb="2" justify="space-between">
+								<Text
+									fontSize="xs"
+									fontWeight="semibold"
+									color="fg.muted"
+									textTransform="uppercase"
+									letterSpacing="wider"
+									whiteSpace="nowrap"
+								>
+									{m.projects()}
+								</Text>
+								<IconButton
+									id="add-project-button"
+									aria-label={m.newProject()}
+									variant="ghost"
+									size="2xs"
+									onClick={createDialog.onOpen}
+								>
+									<FiPlus />
+								</IconButton>
+							</HStack>
 
-            {projects.map((project) => (
-              <ProjectMenuItem key={project.id} project={project} />
-            ))}
+							{projects.map((project) => (
+								<ProjectMenuItem key={project.id} project={project} />
+							))}
 
-            <Box flex="1" />
+							<Box flex="1" />
 
-            <SidebarLink
-              to="/settings"
-              icon={<FiSettings />}
-            >
-              {m.settings()}
-            </SidebarLink>
-          </Flex>
-        </LayoutGroup>
-      </Box>
-      <CreateProjectDialog
-        isOpen={createDialog.isOpen}
-        onClose={createDialog.onClose}
-      />
-    </>
-  );
+							<SidebarLink to="/settings" icon={<FiSettings />}>
+								{m.settings()}
+							</SidebarLink>
+						</Flex>
+					</LayoutGroup>
+				</Box>
+				<Box
+					role="separator"
+					aria-label="Resize sidebar"
+					aria-orientation="vertical"
+					aria-valuemin={APP_SIDEBAR_MIN_WIDTH}
+					aria-valuemax={APP_SIDEBAR_MAX_WIDTH}
+					aria-valuenow={sidebarWidth}
+					tabIndex={0}
+					position="absolute"
+					top="0"
+					right="-4px"
+					bottom="0"
+					w="8px"
+					cursor="col-resize"
+					zIndex={1}
+					onPointerDown={resize.handlePointerDown}
+					onKeyDown={resize.handleKeyDown}
+					_before={{
+						content: "\"\"",
+						position: "absolute",
+						top: 0,
+						bottom: 0,
+						left: "50%",
+						transform: "translateX(-50%)",
+						width: "1px",
+						bg: resize.isDragging
+							? "border.emphasized"
+							: "transparent",
+						transition: "background-color 0.16s ease",
+					}}
+					_hover={{
+						_before: {
+							bg: "border.subtle",
+						},
+					}}
+					_focusVisible={{
+						outline: "none",
+						_before: {
+							bg: "border.emphasized",
+						},
+					}}
+				/>
+			</Box>
+			<CreateProjectDialog
+				isOpen={createDialog.isOpen}
+				onClose={createDialog.onClose}
+			/>
+		</>
+	);
 }

--- a/src/layout/sidebar/ProfileItem.tsx
+++ b/src/layout/sidebar/ProfileItem.tsx
@@ -29,12 +29,13 @@ export function ProfileItem({
 						asChild
 						data-sidebar-item
 						gap="2"
+						w="full"
+						minW="max-content"
 						position="relative"
 						ps="9"
 						pe="4"
 						py="1"
 						cursor="pointer"
-						truncate
 						fontSize="sm"
 						bg={isActive ? "bg.subtle" : "transparent"}
 						_hover={{ bg: "bg.subtle" }}
@@ -49,7 +50,9 @@ export function ProfileItem({
 							<Icon fontSize="xs" color="fg.muted">
 								<FiGitBranch />
 							</Icon>
-							<Text truncate>{profile.branch_name}</Text>
+							<Text whiteSpace="nowrap" flexShrink={0}>
+								{profile.branch_name}
+							</Text>
 							{hasNotification && (
 								<Circle
 									size="2"

--- a/src/layout/sidebar/ProfileList.tsx
+++ b/src/layout/sidebar/ProfileList.tsx
@@ -30,6 +30,8 @@ export function ProfileList({
 			<HStack
 				as="button"
 				gap="2"
+				w="full"
+				minW="max-content"
 				ps="9"
 				pe="4"
 				py="1"
@@ -42,7 +44,9 @@ export function ProfileList({
 				<Icon fontSize="xs">
 					<FiPlus />
 				</Icon>
-				<Text>{m.createProfile()}</Text>
+				<Text whiteSpace="nowrap" flexShrink={0}>
+					{m.createProfile()}
+				</Text>
 			</HStack>
 			<CreateProfileDialog
 				isOpen={createDialog.isOpen}

--- a/src/layout/sidebar/ProjectMenuItem.tsx
+++ b/src/layout/sidebar/ProjectMenuItem.tsx
@@ -63,6 +63,8 @@ export function ProjectMenuItem({ project }: { project: ProjectWithProfiles }) {
 					<HStack
 						className="group"
 						gap="1"
+						w="full"
+						minW="max-content"
 						px="4"
 						py="1.5"
 						cursor="pointer"
@@ -78,7 +80,13 @@ export function ProjectMenuItem({ project }: { project: ProjectWithProfiles }) {
 						{hasOnlyDefaultProfile && isDefaultActive && (
 							<SidebarActiveIndicator insetInlineStart="1" />
 						)}
-						<Box asChild truncate flex="1" data-sidebar-item>
+						<Box
+							asChild
+							flex="1"
+							minW="fit-content"
+							whiteSpace="nowrap"
+							data-sidebar-item
+						>
 							<NavLink to={defaultProfileUrl}>
 								{project.name}
 							</NavLink>
@@ -168,6 +176,8 @@ export function ProjectMenuItem({ project }: { project: ProjectWithProfiles }) {
 						asChild
 						data-sidebar-item
 						gap="2"
+						w="full"
+						minW="max-content"
 						position="relative"
 						ps="9"
 						pe="4"
@@ -191,7 +201,9 @@ export function ProjectMenuItem({ project }: { project: ProjectWithProfiles }) {
 							<Icon fontSize="xs" color="fg.muted">
 								<FiTerminal />
 							</Icon>
-							<Text truncate>{m.defaultProfile()}</Text>
+							<Text whiteSpace="nowrap" flexShrink={0}>
+								{m.defaultProfile()}
+							</Text>
 							{hasDefaultNotification && (
 								<Circle
 									size="2"

--- a/src/layout/sidebarStore.test.ts
+++ b/src/layout/sidebarStore.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+	APP_SIDEBAR_DEFAULT_WIDTH,
+	APP_SIDEBAR_MAX_WIDTH,
+	APP_SIDEBAR_MIN_WIDTH,
+	useAppSidebarStore,
+} from "./sidebarStore";
+
+function resetStore() {
+	useAppSidebarStore.setState({ width: APP_SIDEBAR_DEFAULT_WIDTH });
+	localStorage.clear();
+}
+
+function getState() {
+	return useAppSidebarStore.getState();
+}
+
+describe("useAppSidebarStore", () => {
+	beforeEach(resetStore);
+
+	it("uses the default width", () => {
+		expect(getState().width).toBe(APP_SIDEBAR_DEFAULT_WIDTH);
+	});
+
+	it("clamps widths below the minimum", () => {
+		getState().setWidth(APP_SIDEBAR_MIN_WIDTH - 40);
+		expect(getState().width).toBe(APP_SIDEBAR_MIN_WIDTH);
+	});
+
+	it("clamps widths above the maximum", () => {
+		getState().setWidth(APP_SIDEBAR_MAX_WIDTH + 40);
+		expect(getState().width).toBe(APP_SIDEBAR_MAX_WIDTH);
+	});
+
+	it("syncs the CSS variable on document.documentElement", () => {
+		getState().setWidth(320);
+		expect(
+			document.documentElement.style.getPropertyValue("--sidebar-width"),
+		).toBe("320px");
+	});
+});

--- a/src/layout/sidebarStore.ts
+++ b/src/layout/sidebarStore.ts
@@ -1,0 +1,48 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+export const APP_SIDEBAR_MIN_WIDTH = 220;
+export const APP_SIDEBAR_MAX_WIDTH = 420;
+export const APP_SIDEBAR_DEFAULT_WIDTH = 250;
+
+export function clampAppSidebarWidth(width: number) {
+	return Math.min(
+		APP_SIDEBAR_MAX_WIDTH,
+		Math.max(APP_SIDEBAR_MIN_WIDTH, width),
+	);
+}
+
+interface AppSidebarStore {
+	width: number;
+	setWidth: (width: number) => void;
+}
+
+export const useAppSidebarStore = create<AppSidebarStore>()(
+	persist(
+		(set) => ({
+			width: APP_SIDEBAR_DEFAULT_WIDTH,
+			setWidth: (width) => set({ width: clampAppSidebarWidth(width) }),
+		}),
+		{
+			name: "app-sidebar-width",
+			version: 1,
+			partialize: (state) => ({ width: state.width }),
+		},
+	),
+);
+
+function syncSidebarWidth(width: number) {
+	if (typeof document === "undefined") return;
+	document.documentElement.style.setProperty(
+		"--sidebar-width",
+		`${clampAppSidebarWidth(width)}px`,
+	);
+}
+
+syncSidebarWidth(useAppSidebarStore.getState().width);
+
+useAppSidebarStore.subscribe((state, prevState) => {
+	if (state.width !== prevState.width) {
+		syncSidebarWidth(state.width);
+	}
+});

--- a/src/shared/components/SidebarLink.tsx
+++ b/src/shared/components/SidebarLink.tsx
@@ -1,39 +1,46 @@
-import { HStack, Icon } from "@chakra-ui/react";
+import { Box, HStack, Icon } from "@chakra-ui/react";
 import { NavLink, useMatch } from "react-router";
 import { SidebarActiveIndicator } from "./SidebarActiveIndicator";
 
 export function SidebarLink({
-  to,
-  icon,
-  children,
-  pattern,
-  style,
+	to,
+	icon,
+	children,
+	pattern,
+	style,
 }: {
-  to: string;
-  icon: React.ReactNode;
-  children: React.ReactNode;
-  pattern?: string;
-  style?: React.CSSProperties;
+	to: string;
+	icon: React.ReactNode;
+	children: React.ReactNode;
+	pattern?: string;
+	style?: React.CSSProperties;
 }) {
-  const isActive = useMatch(pattern ?? to) !== null;
-  return (
-    <HStack
-      asChild
-      data-sidebar-item
-      gap="3"
-      px="4"
-      py="2"
-      cursor="pointer"
-      position="relative"
-      bg={isActive ? "bg.subtle" : "transparent"}
-      _hover={{ bg: "bg.subtle" }}
-      style={style}
-    >
-      <NavLink to={to}>
-        {isActive && <SidebarActiveIndicator insetInlineStart="1" />}
-        <Icon fontSize="md">{icon}</Icon>
-        {children}
-      </NavLink>
-    </HStack>
-  );
+	const isActive = useMatch(pattern ?? to) !== null;
+
+	return (
+		<HStack
+			asChild
+			data-sidebar-item
+			gap="3"
+			w="full"
+			minW="max-content"
+			px="4"
+			py="2"
+			cursor="pointer"
+			position="relative"
+			bg={isActive ? "bg.subtle" : "transparent"}
+			_hover={{ bg: "bg.subtle" }}
+			style={style}
+		>
+			<NavLink to={to}>
+				{isActive && <SidebarActiveIndicator insetInlineStart="1" />}
+				<Icon fontSize="md" flexShrink={0}>
+					{icon}
+				</Icon>
+				<Box as="span" whiteSpace="nowrap" flexShrink={0}>
+					{children}
+				</Box>
+			</NavLink>
+		</HStack>
+	);
 }

--- a/src/shared/hooks/useHorizontalResize.ts
+++ b/src/shared/hooks/useHorizontalResize.ts
@@ -1,0 +1,115 @@
+import {
+	type KeyboardEvent as ReactKeyboardEvent,
+	type PointerEvent as ReactPointerEvent,
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+} from "react";
+
+function clampWidth(value: number, min: number, max: number) {
+	return Math.min(max, Math.max(min, value));
+}
+
+interface UseHorizontalResizeOptions {
+	value: number;
+	min: number;
+	max: number;
+	step?: number;
+	disabled?: boolean;
+	onChange: (value: number) => void;
+}
+
+export function useHorizontalResize({
+	value,
+	min,
+	max,
+	step = 16,
+	disabled = false,
+	onChange,
+}: UseHorizontalResizeOptions) {
+	const [isDragging, setIsDragging] = useState(false);
+	const startXRef = useRef(0);
+	const startValueRef = useRef(value);
+	const valueRef = useRef(value);
+	const onChangeRef = useRef(onChange);
+
+	valueRef.current = value;
+	onChangeRef.current = onChange;
+
+	const applyValue = useCallback((nextValue: number) => {
+		onChangeRef.current(clampWidth(nextValue, min, max));
+	}, [max, min]);
+
+	useEffect(() => {
+		if (!isDragging) return;
+
+		const previousCursor = document.body.style.cursor;
+		const previousUserSelect = document.body.style.userSelect;
+		document.body.style.cursor = "col-resize";
+		document.body.style.userSelect = "none";
+
+		function handlePointerMove(event: PointerEvent) {
+			const deltaX = event.clientX - startXRef.current;
+			applyValue(startValueRef.current + deltaX);
+		}
+
+		function stopDragging() {
+			setIsDragging(false);
+		}
+
+		window.addEventListener("pointermove", handlePointerMove);
+		window.addEventListener("pointerup", stopDragging);
+		window.addEventListener("pointercancel", stopDragging);
+
+		return () => {
+			document.body.style.cursor = previousCursor;
+			document.body.style.userSelect = previousUserSelect;
+			window.removeEventListener("pointermove", handlePointerMove);
+			window.removeEventListener("pointerup", stopDragging);
+			window.removeEventListener("pointercancel", stopDragging);
+		};
+	}, [applyValue, isDragging]);
+
+	function handlePointerDown(event: ReactPointerEvent<HTMLElement>) {
+		if (disabled || event.button !== 0) return;
+
+		startXRef.current = event.clientX;
+		startValueRef.current = valueRef.current;
+		setIsDragging(true);
+		event.preventDefault();
+	}
+
+	function handleKeyDown(event: ReactKeyboardEvent<HTMLElement>) {
+		if (disabled) return;
+
+		switch (event.key) {
+			case "ArrowLeft": {
+				applyValue(valueRef.current - step);
+				event.preventDefault();
+				break;
+			}
+			case "ArrowRight": {
+				applyValue(valueRef.current + step);
+				event.preventDefault();
+				break;
+			}
+			case "Home": {
+				applyValue(min);
+				event.preventDefault();
+				break;
+			}
+			case "End": {
+				applyValue(max);
+				event.preventDefault();
+				break;
+			}
+		}
+	}
+
+	return {
+		isDragging,
+		handlePointerDown,
+		handleKeyDown,
+	};
+}


### PR DESCRIPTION
## Stack Context

This PR makes the main app sidebar and the project file tree sidebar horizontally resizable, and lets both panels scroll horizontally when their content is wider than the current panel width.

## What?

- add a shared horizontal resize hook for pointer and keyboard resizing
- persist the main sidebar width and file tree width in Zustand stores
- add right-edge resize handles to both sidebars
- switch sidebar and file tree rows from forced truncation to horizontal overflow
- add store tests for the new persisted width behavior

## Why?

Both sidebars previously used fixed widths and aggressively truncated labels, which made long project names, branch names, and deep file paths hard to inspect. This keeps the existing layout structure intact while making the panels adjustable and preserving user width preferences across sessions.

## Validation

- `bun run test -- src/features/projects/FileTreePanel.test.tsx src/features/projects/fileTreeStore.test.ts src/layout/sidebarStore.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File tree panel and sidebar are now resizable with drag handles and independently adjustable width limits.
  * Panel widths are automatically saved and restored across sessions.
  * Keyboard support for resizing controls (arrow keys, Home/End keys).
  * Text labels no longer truncate or wrap during horizontal resizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->