### PR TITLE
[codex] migrate terminal to wterm

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,13 +21,9 @@
         "@tauri-apps/plugin-shell": "^2.3.5",
         "@tauri-apps/plugin-store": "^2.4.2",
         "@types/react-syntax-highlighter": "^15.5.13",
-        "@xterm/addon-clipboard": "^0.3.0-beta.197",
-        "@xterm/addon-fit": "^0.12.0-beta.197",
-        "@xterm/addon-image": "^0.10.0-beta.197",
-        "@xterm/addon-ligatures": "^0.11.0-beta.197",
-        "@xterm/addon-progress": "^0.3.0-beta.197",
-        "@xterm/addon-web-links": "^0.13.0-beta.197",
-        "@xterm/xterm": "^6.1.0-beta.197",
+        "@wterm/core": "0.1.8",
+        "@wterm/dom": "0.1.8",
+        "@wterm/react": "0.1.8",
         "consola": "^3.4.2",
         "driver.js": "^1.4.0",
         "immer": "^11.1.4",
@@ -70,9 +66,6 @@
         "vitest": "^4.1.4",
       },
     },
-  },
-  "patchedDependencies": {
-    "@xterm/xterm@6.1.0-beta.197": "patches/@xterm%2Fxterm@6.1.0-beta.197.patch",
   },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
@@ -615,19 +608,11 @@
 
     "@vue/shared": ["@vue/shared@3.5.28", "", {}, "sha512-cfWa1fCGBxrvaHRhvV3Is0MgmrbSCxYTXCSCau2I0a1Xw1N1pHAvkWCiXPRAqjvToILvguNyEwjevUqAuBQWvQ=="],
 
-    "@xterm/addon-clipboard": ["@xterm/addon-clipboard@0.3.0-beta.197", "", { "dependencies": { "js-base64": "^3.7.5" }, "peerDependencies": { "@xterm/xterm": "^6.1.0-beta.197" } }, "sha512-o0u0xR/6QwTj7WytfMaNbz4Gm/lp2eW3EFzHN6LvQhqZEBdMt+GUb/GHgCM7YO35TP21W7DInqvZl+1WOzanJQ=="],
+    "@wterm/core": ["@wterm/core@0.1.8", "", {}, "sha512-suOX4Irv3/a90Y5Xn60wza7mIUG2Mu1d2U61g2nbDjs4wWD8SCbi26FUZczuKNo2xqWWjkynNXTTULuAjhiJYg=="],
 
-    "@xterm/addon-fit": ["@xterm/addon-fit@0.12.0-beta.197", "", { "peerDependencies": { "@xterm/xterm": "^6.1.0-beta.197" } }, "sha512-EoYQVIWp90XmNXBfrEocz5tk44JLMdHL9+Asd57Bj9DuERLLszA8pkF3wbuR5C7555g3sRTMTHlzYQ3gv9xbOw=="],
+    "@wterm/dom": ["@wterm/dom@0.1.8", "", { "dependencies": { "@wterm/core": "0.1.8" } }, "sha512-o1HNI7x3WprzUsWglOzro9f9FDCSJQXTACW9AwpCT6C60EhGchrTM5ruvsqtJj+g2YFqBFcOKSs0HTXJcm7XwA=="],
 
-    "@xterm/addon-image": ["@xterm/addon-image@0.10.0-beta.197", "", { "peerDependencies": { "@xterm/xterm": "^6.1.0-beta.197" } }, "sha512-31oIqBm+Yk3xyYGjBhhp308gDyFywv3JJAWBflycgqZFbvfZ2ju4IvHmvKJhp8qC+0ac6SRAA7XBKGqtoZjcsA=="],
-
-    "@xterm/addon-ligatures": ["@xterm/addon-ligatures@0.11.0-beta.197", "", { "dependencies": { "lru-cache": "^6.0.0", "opentype.js": "^0.8.0" }, "peerDependencies": { "@xterm/xterm": "^6.1.0-beta.197" } }, "sha512-76arq3li5i71YP8RMatAsE7H79FvRV/gaLF/iwgxeQgIXurVt3bEuwta64JlMe+BchelmoVv22T4yQjFo2pOkQ=="],
-
-    "@xterm/addon-progress": ["@xterm/addon-progress@0.3.0-beta.197", "", { "peerDependencies": { "@xterm/xterm": "^6.1.0-beta.197" } }, "sha512-ZvWE78sIBu0rAjpvycuKZqBVWLcm5ePO/oH4tBIwJLIY3g2FpRKKorBGPN9raBHw3Bfxzg7tZAFqv6iuDZxEIw=="],
-
-    "@xterm/addon-web-links": ["@xterm/addon-web-links@0.13.0-beta.197", "", { "peerDependencies": { "@xterm/xterm": "^6.1.0-beta.197" } }, "sha512-8MgssTKGYJIgZpemu34KBIsmB0qh/XsQxugOhaYym8qSjn8KAMn9FN0j15W6XwEFQDAu1vtBh1jiKjQfyvHoqQ=="],
-
-    "@xterm/xterm": ["@xterm/xterm@6.1.0-beta.197", "", {}, "sha512-vzoc8sBcsvFpziSgeVGKZQDT1T/9MmEUKfUDpVqc3slDv7o0SiQCjvPeOF8y1++5vx2xmUn8lfcLnbfdtigtSQ=="],
+    "@wterm/react": ["@wterm/react@0.1.8", "", { "peerDependencies": { "@wterm/dom": "0.1.7", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-eW+olCGansLe47Kz9oxsMJLAkysvHItxp7EBlpVmh3I+b98ge42vwekjH67x7ME+MShMpZ4KJhtLhqBtKV44fg=="],
 
     "@zag-js/accordion": ["@zag-js/accordion@1.39.1", "", { "dependencies": { "@zag-js/anatomy": "1.39.1", "@zag-js/core": "1.39.1", "@zag-js/dom-query": "1.39.1", "@zag-js/types": "1.39.1", "@zag-js/utils": "1.39.1" } }, "sha512-GA3m7gRTm3weSe1eMlHIsTNztcjZ6joIaRgxxKil7q/UX0xIVVGDy0aCr6oo7FAuoMiOOBVurYXILpFZ30nOXA=="],
 
@@ -1167,8 +1152,6 @@
 
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
-    "js-base64": ["js-base64@3.7.8", "", {}, "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow=="],
-
     "js-sha256": ["js-sha256@0.11.1", "", {}, "sha512-o6WSo/LUvY2uC4j7mO50a2ms7E/EAdbP0swigLV+nzHKTTaYnaLIWJ02VdXrsJX0vGedDESQnLsOekr94ryfjg=="],
 
     "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
@@ -1399,8 +1382,6 @@
 
     "oniguruma-to-es": ["oniguruma-to-es@4.3.4", "", { "dependencies": { "oniguruma-parser": "^0.12.1", "regex": "^6.0.1", "regex-recursion": "^6.0.2" } }, "sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA=="],
 
-    "opentype.js": ["opentype.js@0.8.0", "", { "dependencies": { "tiny-inflate": "^1.0.2" }, "bin": { "ot": "./bin/ot" } }, "sha512-FQHR4oGP+a0m/f6yHoRpBOIbn/5ZWxKd4D/djHVJu8+KpBTYrJda0b7mLcgDEMWXE9xBCJm+qb0yv6FcvPjukg=="],
-
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
     "ora": ["ora@8.2.0", "", { "dependencies": { "chalk": "^5.3.0", "cli-cursor": "^5.0.0", "cli-spinners": "^2.9.2", "is-interactive": "^2.0.0", "is-unicode-supported": "^2.0.0", "log-symbols": "^6.0.0", "stdin-discarder": "^0.2.2", "string-width": "^7.2.0", "strip-ansi": "^7.1.0" } }, "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw=="],
@@ -1611,8 +1592,6 @@
 
     "tapable": ["tapable@2.3.0", "", {}, "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg=="],
 
-    "tiny-inflate": ["tiny-inflate@1.0.3", "", {}, "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="],
-
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 
     "tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
@@ -1721,7 +1700,7 @@
 
     "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
 
-    "yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+    "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
 
@@ -1784,8 +1763,6 @@
     "@vue/compiler-sfc/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "@vue/compiler-sfc/postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
-
-    "@xterm/addon-ligatures/lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
 
     "clean-regexp/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
 
@@ -1860,8 +1837,6 @@
     "vue-eslint-parser/espree": ["espree@11.1.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^5.0.0" } }, "sha512-WFWYhO1fV4iYkqOOvq8FbqIhr2pYfoDY0kCotMkDeNtGpiGGkZ1iov2u8ydjtgM8yF8rzK7oaTbw2NAzbAbehw=="],
 
     "yaml-eslint-parser/eslint-visitor-keys": ["eslint-visitor-keys@5.0.0", "", {}, "sha512-A0XeIi7CXU7nPlfHS9loMYEKxUaONu/hTEzHTGba9Huu94Cq1hPivf+DE5erJozZOky0LfvXAyrV/tcswpLI0Q=="],
-
-    "@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "data-urls/whatwg-url/@exodus/bytes": ["@exodus/bytes@1.14.1", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-OhkBFWI6GcRMUroChZiopRiSp2iAMvEBK47NhJooDqz1RERO4QuZIZnjP63TXX8GAiLABkYmX+fuQsdJ1dd2QQ=="],
 

--- a/package.json
+++ b/package.json
@@ -34,13 +34,9 @@
     "@tauri-apps/plugin-shell": "^2.3.5",
     "@tauri-apps/plugin-store": "^2.4.2",
     "@types/react-syntax-highlighter": "^15.5.13",
-    "@xterm/addon-clipboard": "^0.3.0-beta.197",
-    "@xterm/addon-fit": "^0.12.0-beta.197",
-    "@xterm/addon-image": "^0.10.0-beta.197",
-    "@xterm/addon-ligatures": "^0.11.0-beta.197",
-    "@xterm/addon-progress": "^0.3.0-beta.197",
-    "@xterm/addon-web-links": "^0.13.0-beta.197",
-    "@xterm/xterm": "^6.1.0-beta.197",
+    "@wterm/core": "0.1.8",
+    "@wterm/dom": "0.1.8",
+    "@wterm/react": "0.1.8",
     "consola": "^3.4.2",
     "driver.js": "^1.4.0",
     "immer": "^11.1.4",
@@ -81,8 +77,5 @@
     "typescript": "~6.0.2",
     "vite": "^8.0.8",
     "vitest": "^4.1.4"
-  },
-  "patchedDependencies": {
-    "@xterm/xterm@6.1.0-beta.197": "patches/@xterm%2Fxterm@6.1.0-beta.197.patch"
   }
 }

--- a/src/features/git/components/GitDiffContent.tsx
+++ b/src/features/git/components/GitDiffContent.tsx
@@ -13,7 +13,7 @@ import * as m from "@/paraglide/messages.js";
 import { LoadingSpinner } from "@/shared/components/Fallbacks";
 import { isInteractiveKeyboardTarget } from "@/shared/lib/dom";
 import { areSetsEqual } from "@/shared/lib/setUtils";
-import { toaster } from "@/shared/providers/Toaster";
+import { toaster } from "@/shared/providers/toastController";
 import {
 	type GitDiffAction,
 	GitDiffContext,

--- a/src/features/git/components/GitDiffPane.tsx
+++ b/src/features/git/components/GitDiffPane.tsx
@@ -17,7 +17,7 @@ import { useMemo, useState } from "react";
 import * as m from "@/paraglide/messages.js";
 import { useTerminalSettingsStore } from "@/features/settings/stores/terminalSettingsStore";
 import { copyTextToClipboard } from "@/shared/lib/clipboard";
-import { toaster } from "@/shared/providers/Toaster";
+import { toaster } from "@/shared/providers/toastController";
 import {
 	formatGitDiffCommentLocation,
 	formatGitDiffCommentPayload,

--- a/src/features/terminal/AGENTS.md
+++ b/src/features/terminal/AGENTS.md
@@ -1,27 +1,29 @@
 # AGENTS.md — src/features/terminal
 
 ## OVERVIEW
-PTY terminal management with xterm.js. The most complex frontend feature.
+PTY terminal management with `@wterm/react`. The most complex frontend feature.
 
 ## FILES
 | File | Role |
 |------|------|
 | `store.ts` | Zustand+Immer state: `profiles` (tabs per project), `notifiedTabs` (Set) |
 | `state.ts` | Terminal state types and tab lifecycle logic |
-| `Terminal.tsx` | xterm.js component (~305 lines) — connects PTY to xterm |
+| `Terminal.tsx` | `@wterm/react` component — connects PTY to wterm |
 | `TerminalLayer.tsx` | Persistent overlay across all routes (CSS display:none) |
 | `TerminalTabs.tsx` | Tab bar with notification dots |
 | `TerminalPreview.tsx` | Read-only terminal snapshot for non-active profiles |
 | `hooks.ts` | `useCreateTerminalTab`, `useCloseTerminalTab`, `useRestoreTerminals`, `useTerminalTheme` |
-| `themes.ts` | xterm.js color theme definitions |
+| `themes.ts` | Terminal color theme definitions |
 
 ## KEY PATTERNS
 
-**Never unmount terminals** — `TerminalLayer` renders all terminals always; CSS `display: none` hides inactive ones. Conditional rendering breaks xterm.js canvas state.
+**Never unmount terminals** — `TerminalLayer` renders all terminals always; CSS `display: none` hides inactive ones. Conditional rendering breaks terminal state restoration and layout sync.
 
-**xterm.js addon stack** (loaded in `Terminal.tsx`):
-- `FitAddon` — resize to container
-- `WebLinksAddon`, `ClipboardAddon`, `ImageAddon`, `LigaturesAddon`, `ProgressAddon`
+**wterm integration** (implemented in `Terminal.tsx`):
+- `autoResize` handles container size changes
+- Terminal-specific shortcuts are intercepted in React and forwarded to the PTY
+- Theme/font changes are applied via CSS custom properties and a manual layout sync pass
+- URL activation is detected from DOM rows and routed through the existing confirm dialog
 
 **Session restoration flow**:
 1. Fetch closed session history from DB
@@ -36,12 +38,12 @@ PTY terminal management with xterm.js. The most complex frontend feature.
 | Task | Location |
 |------|----------|
 | Tab state shape | `store.ts` — `profiles[profileId].tabs`, `activeTabId`, `counter` |
-| xterm instance creation | `Terminal.tsx` lines ~145–297 (ref callback) |
+| wterm instance wiring | `Terminal.tsx` |
 | PTY output streaming | `src-tauri/crates/infra/src/pty.rs` |
 | Scrollback restore | `Terminal.tsx` + `src-tauri/crates/service/src/pty.rs` |
 | Shell env vars for helper | `infra/shell_init.rs` (`_2CODE_HELPER_URL`, `_2CODE_SESSION_ID`) |
 
 ## ANTI-PATTERNS
-- Conditional rendering of `<Terminal>` — breaks xterm state (use CSS only)
+- Conditional rendering of `<Terminal>` — breaks persistent terminal state (use CSS only)
 - `useTerminalStore(…)` in mutations — use `useTerminalStore.getState()` instead
 - Removing `find_utf8_boundary` call in PTY output — breaks multibyte characters

--- a/src/features/terminal/Terminal.tsx
+++ b/src/features/terminal/Terminal.tsx
@@ -1,15 +1,19 @@
 import type { UnlistenFn } from "@tauri-apps/api/event";
 import { listen } from "@tauri-apps/api/event";
 import { open } from "@tauri-apps/plugin-shell";
-import { ClipboardAddon } from "@xterm/addon-clipboard";
-import { FitAddon } from "@xterm/addon-fit";
-import { ImageAddon } from "@xterm/addon-image";
-import { LigaturesAddon } from "@xterm/addon-ligatures";
-import { ProgressAddon } from "@xterm/addon-progress";
-import { WebLinksAddon } from "@xterm/addon-web-links";
-import { Terminal as XTerm } from "@xterm/xterm";
+import type { TerminalHandle } from "@wterm/react";
+import { Terminal as WTermTerminal } from "@wterm/react";
 import consola from "consola";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+	type CSSProperties,
+	type MouseEvent as ReactMouseEvent,
+	type KeyboardEvent as ReactKeyboardEvent,
+} from "react";
 import { useTerminalSettingsStore } from "@/features/settings/stores/terminalSettingsStore";
 import {
 	clearPtyOutput,
@@ -23,7 +27,8 @@ import { getTerminalShortcutAction } from "./keybindings";
 import { shouldBypassTerminalLinkConfirm } from "./linkOpening";
 import { sessionHistory } from "./state";
 import { useTerminalStore } from "./store";
-import "@xterm/xterm/css/xterm.css";
+import "@wterm/react/css";
+import "./terminal.css";
 
 interface TerminalProps {
 	profileId: string;
@@ -31,12 +36,124 @@ interface TerminalProps {
 	isActive: boolean;
 }
 
+type TerminalStyle = CSSProperties & Record<`--${string}`, string | number>;
+
+const URL_PATTERN = /https?:\/\/[^\s<>"'`]+/g;
+const TRAILING_URI_PUNCTUATION_PATTERN = /[),.;:!?]+$/u;
+
+function getTerminalRowHeight(fontSize: number) {
+	return Math.max(16, Math.round(fontSize * 1.3));
+}
+
+function trimTerminalUri(uri: string) {
+	return uri.replace(TRAILING_URI_PUNCTUATION_PATTERN, "");
+}
+
+function getCaretPositionFromPoint(x: number, y: number) {
+	if ("caretPositionFromPoint" in document) {
+		const position = document.caretPositionFromPoint(x, y);
+		if (position) {
+			return {
+				node: position.offsetNode,
+				offset: position.offset,
+			};
+		}
+	}
+
+	if ("caretRangeFromPoint" in document) {
+		const range = document.caretRangeFromPoint?.(x, y);
+		if (range) {
+			return {
+				node: range.startContainer,
+				offset: range.startOffset,
+			};
+		}
+	}
+
+	return null;
+}
+
+function findTextOffsetInRow(
+	row: HTMLElement,
+	targetNode: Node,
+	targetOffset: number,
+) {
+	const walker = document.createTreeWalker(row, NodeFilter.SHOW_TEXT);
+	let offset = 0;
+
+	while (walker.nextNode()) {
+		const current = walker.currentNode;
+		const text = current.textContent ?? "";
+		if (current === targetNode) {
+			return offset + Math.min(targetOffset, text.length);
+		}
+		offset += text.length;
+	}
+
+	return null;
+}
+
+function findUriAtOffset(text: string, offset: number) {
+	for (const match of text.matchAll(URL_PATTERN)) {
+		const index = match.index ?? -1;
+		const value = trimTerminalUri(match[0]);
+		if (offset >= index && offset <= index + value.length) {
+			return value;
+		}
+	}
+
+	return null;
+}
+
+function findTerminalUriFromClick(
+	event: MouseEvent,
+	root: HTMLDivElement,
+) {
+	const selection = window.getSelection();
+	if (selection && !selection.isCollapsed) return null;
+
+	const caret = getCaretPositionFromPoint(event.clientX, event.clientY);
+	if (!caret) return null;
+
+	const row =
+		caret.node instanceof Element
+			? caret.node.closest<HTMLElement>(".term-row")
+			: caret.node.parentElement?.closest<HTMLElement>(".term-row");
+	if (!row || !root.contains(row)) return null;
+
+	const offset = findTextOffsetInRow(row, caret.node, caret.offset);
+	if (offset == null) return null;
+
+	return findUriAtOffset(row.textContent ?? "", offset);
+}
+
+function measureTerminalCellWidth(
+	container: HTMLDivElement,
+	fontFamily: string,
+	fontSize: number,
+) {
+	const probe = document.createElement("span");
+	probe.textContent = "W";
+	probe.style.position = "absolute";
+	probe.style.visibility = "hidden";
+	probe.style.pointerEvents = "none";
+	probe.style.whiteSpace = "pre";
+	probe.style.fontFamily = `"${fontFamily}", monospace`;
+	probe.style.fontSize = `${fontSize}px`;
+	container.appendChild(probe);
+	const width = probe.getBoundingClientRect().width;
+	probe.remove();
+
+	return width > 0 ? width : null;
+}
+
 export function Terminal({ profileId, sessionId, isActive }: TerminalProps) {
-	const termRef = useRef<XTerm | null>(null);
-	const fitAddonRef = useRef<FitAddon | null>(null);
+	const terminalRef = useRef<TerminalHandle | null>(null);
+	const viewportRef = useRef<HTMLDivElement | null>(null);
 	const isStreamReadyRef = useRef(false);
 	const pendingEventsRef = useRef<string[]>([]);
 	const layoutFrameRef = useRef<number | null>(null);
+	const disposedRef = useRef(false);
 	const [pendingLink, setPendingLink] = useState<string | null>(null);
 	const fontFamily = useTerminalSettingsStore((s) => s.fontFamily);
 	const fontSize = useTerminalSettingsStore((s) => s.fontSize);
@@ -47,61 +164,123 @@ export function Terminal({ profileId, sessionId, isActive }: TerminalProps) {
 		(s) => s.decreaseFontSize,
 	);
 	const theme = useTerminalTheme();
+	const terminalRowHeight = useMemo(
+		() => getTerminalRowHeight(fontSize),
+		[fontSize],
+	);
 
-	const initFontFamilyRef = useRef(fontFamily);
-	const initFontSizeRef = useRef(fontSize);
-	const initThemeRef = useRef(theme);
-
-	const syncTerminalLayout = useCallback((delayFrames = 0) => {
-		if (layoutFrameRef.current !== null) {
-			window.cancelAnimationFrame(layoutFrameRef.current);
-		}
-
-		let remainingFrames = delayFrames;
-		const tick = () => {
-			if (remainingFrames > 0) {
-				remainingFrames -= 1;
-				layoutFrameRef.current = window.requestAnimationFrame(tick);
-				return;
+	const syncTerminalLayout = useCallback(
+		(delayFrames = 0) => {
+			if (layoutFrameRef.current !== null) {
+				window.cancelAnimationFrame(layoutFrameRef.current);
 			}
 
-			layoutFrameRef.current = null;
+			let remainingFrames = delayFrames;
+			const tick = () => {
+				if (remainingFrames > 0) {
+					remainingFrames -= 1;
+					layoutFrameRef.current = window.requestAnimationFrame(tick);
+					return;
+				}
 
-			const term = termRef.current;
-			const fitAddon = fitAddonRef.current;
-			if (!term || !fitAddon) return;
+				layoutFrameRef.current = null;
 
-			const nextDimensions = fitAddon.proposeDimensions();
-			if (
-				nextDimensions &&
-				(nextDimensions.cols !== term.cols ||
-					nextDimensions.rows !== term.rows)
-			) {
-				fitAddon.fit();
-				return;
-			}
+				const viewport = viewportRef.current;
+				const terminal = terminalRef.current;
+				const instance = terminal?.instance;
+				if (!viewport || !terminal || !instance) return;
 
-			if (term.rows > 0) {
-				term.refresh(0, term.rows - 1);
-			}
-		};
+				const rect = viewport.getBoundingClientRect();
+				if (rect.width <= 0 || rect.height <= 0) return;
 
-		layoutFrameRef.current = window.requestAnimationFrame(tick);
-	}, []);
+				const cellWidth = measureTerminalCellWidth(
+					viewport,
+					fontFamily,
+					fontSize,
+				);
+				if (!cellWidth) return;
+
+				const cols = Math.max(1, Math.floor(rect.width / cellWidth));
+				const rows = Math.max(
+					1,
+					Math.floor(rect.height / terminalRowHeight),
+				);
+				if (cols !== instance.cols || rows !== instance.rows) {
+					terminal.resize(cols, rows);
+				}
+			};
+
+			layoutFrameRef.current = window.requestAnimationFrame(tick);
+		},
+		[fontFamily, fontSize, terminalRowHeight],
+	);
 
 	useEffect(() => {
-		if (termRef.current) {
-			termRef.current.options.theme = theme;
-			syncTerminalLayout();
+		disposedRef.current = false;
+		const unlisteners: UnlistenFn[] = [];
+		let listenersDisposed = false;
+
+		consola.info(`[pty-terminal] mount sessionId=${sessionId}`);
+
+		async function setupListeners() {
+			const unlistenOutput = await listen<string>(
+				`pty-output-${sessionId}`,
+				(event) => {
+					if (!isStreamReadyRef.current) {
+						pendingEventsRef.current.push(event.payload);
+						return;
+					}
+					terminalRef.current?.write(event.payload);
+				},
+			);
+			const unlistenExit = await listen(`pty-exit-${sessionId}`, () => {
+				terminalRef.current?.write(
+					"\r\n\x1B[90m[Process exited]\x1B[0m\r\n",
+				);
+			});
+
+			if (listenersDisposed || disposedRef.current) {
+				unlistenOutput();
+				unlistenExit();
+				return;
+			}
+
+			unlisteners.push(unlistenOutput, unlistenExit);
+			consola.info(
+				`[pty-terminal] live listeners registered for session ${sessionId}`,
+			);
 		}
+
+		void setupListeners();
+
+		return () => {
+			disposedRef.current = true;
+			listenersDisposed = true;
+			consola.info(`[pty-terminal] unmount sessionId=${sessionId}`);
+
+			void flushPtyOutput({ sessionId }).catch(() => {});
+
+			isStreamReadyRef.current = false;
+			pendingEventsRef.current = [];
+
+			if (layoutFrameRef.current !== null) {
+				window.cancelAnimationFrame(layoutFrameRef.current);
+				layoutFrameRef.current = null;
+			}
+
+			for (const unlisten of unlisteners) {
+				unlisten();
+			}
+
+			terminalRef.current = null;
+		};
+	}, [sessionId]);
+
+	useEffect(() => {
+		syncTerminalLayout();
 	}, [syncTerminalLayout, theme]);
 
 	useEffect(() => {
-		const term = termRef.current;
-		if (!term) return;
-
-		term.options.fontFamily = `"${fontFamily}", monospace`;
-		term.options.fontSize = fontSize;
 		syncTerminalLayout(1);
 
 		if (!("fonts" in document)) return;
@@ -122,25 +301,17 @@ export function Terminal({ profileId, sessionId, isActive }: TerminalProps) {
 	}, [fontFamily, fontSize, syncTerminalLayout]);
 
 	useEffect(() => {
-		if (!isActive || !termRef.current) return;
+		if (!isActive) return;
 
 		syncTerminalLayout(2);
 		const focusFrame = window.requestAnimationFrame(() => {
-			termRef.current?.focus();
+			terminalRef.current?.focus();
 		});
 
 		return () => {
 			window.cancelAnimationFrame(focusFrame);
 		};
 	}, [isActive, syncTerminalLayout]);
-
-	useEffect(() => {
-		return () => {
-			if (layoutFrameRef.current !== null) {
-				window.cancelAnimationFrame(layoutFrameRef.current);
-			}
-		};
-	}, []);
 
 	const shellStyle = useMemo(
 		() => ({
@@ -156,6 +327,42 @@ export function Terminal({ profileId, sessionId, isActive }: TerminalProps) {
 		[theme.background],
 	);
 
+	const terminalStyle = useMemo<TerminalStyle>(
+		() => ({
+			width: "100%",
+			height: "100%",
+			padding: 0,
+			borderRadius: 0,
+			boxShadow: "none",
+			overflow: "auto",
+			"--term-bg": theme.background,
+			"--term-fg": theme.foreground,
+			"--term-cursor": theme.cursor,
+			"--term-selection-bg": theme.selectionBackground,
+			"--term-font-family": `"${fontFamily}", monospace`,
+			"--term-font-size": `${fontSize}px`,
+			"--term-line-height": 1.2,
+			"--term-row-height": `${terminalRowHeight}px`,
+			"--term-color-0": theme.black,
+			"--term-color-1": theme.red,
+			"--term-color-2": theme.green,
+			"--term-color-3": theme.yellow,
+			"--term-color-4": theme.blue,
+			"--term-color-5": theme.magenta,
+			"--term-color-6": theme.cyan,
+			"--term-color-7": theme.white,
+			"--term-color-8": theme.brightBlack,
+			"--term-color-9": theme.brightRed,
+			"--term-color-10": theme.brightGreen,
+			"--term-color-11": theme.brightYellow,
+			"--term-color-12": theme.brightBlue,
+			"--term-color-13": theme.brightMagenta,
+			"--term-color-14": theme.brightCyan,
+			"--term-color-15": theme.brightWhite,
+		}),
+		[fontFamily, fontSize, terminalRowHeight, theme],
+	);
+
 	const closePendingLinkDialog = useCallback(() => {
 		setPendingLink(null);
 	}, []);
@@ -168,9 +375,114 @@ export function Terminal({ profileId, sessionId, isActive }: TerminalProps) {
 		void open(uri);
 	}, [pendingLink]);
 
-	const handleTerminalLinkOpen = useCallback(
-		(event: MouseEvent, uri: string) => {
-			if (shouldBypassTerminalLinkConfirm(event)) {
+	const handleTerminalReady = useCallback(() => {
+		if (disposedRef.current) return;
+
+		const terminal = terminalRef.current;
+		if (!terminal) return;
+
+		const history = sessionHistory.get(sessionId);
+		if (history && history.length > 0) {
+			consola.info(
+				`[pty-restore] writing ${history.length} bytes of history for session ${sessionId}`,
+			);
+			terminal.write(history);
+			sessionHistory.delete(sessionId);
+		}
+
+		isStreamReadyRef.current = true;
+		for (const payload of pendingEventsRef.current) {
+			terminal.write(payload);
+		}
+		pendingEventsRef.current = [];
+
+		syncTerminalLayout(1);
+		if (isActive) {
+			terminal.focus();
+		}
+	}, [isActive, sessionId, syncTerminalLayout]);
+
+	const handleTerminalData = useCallback(
+		(data: string) => {
+			void writeToPty({ sessionId, data });
+		},
+		[sessionId],
+	);
+
+	const handleTerminalResize = useCallback(
+		(cols: number, rows: number) => {
+			void resizePty({ sessionId, rows, cols });
+		},
+		[sessionId],
+	);
+
+	const handleTerminalTitle = useCallback(
+		(title: string) => {
+			useTerminalStore
+				.getState()
+				.updateTabTitle(profileId, sessionId, title);
+		},
+		[profileId, sessionId],
+	);
+
+	const handleTerminalError = useCallback(
+		(error: unknown) => {
+			consola.error(
+				`[pty-terminal] init failed for session ${sessionId}`,
+				error,
+			);
+		},
+		[sessionId],
+	);
+
+	const handleTerminalKeyDownCapture = useCallback(
+		(event: ReactKeyboardEvent<HTMLDivElement>) => {
+			const action = getTerminalShortcutAction(event.nativeEvent);
+			if (!action) return;
+
+			event.preventDefault();
+			event.stopPropagation();
+
+			if (action.type === "increase-font-size") {
+				increaseFontSize();
+				return;
+			}
+
+			if (action.type === "decrease-font-size") {
+				decreaseFontSize();
+				return;
+			}
+
+			if (action.type === "clear-screen") {
+				void clearPtyOutput({ sessionId })
+					.catch(() => {})
+					.finally(() => {
+						void writeToPty({ sessionId, data: "\x0C" });
+					});
+				return;
+			}
+
+			void writeToPty({ sessionId, data: action.sequence });
+		},
+		[
+			decreaseFontSize,
+			increaseFontSize,
+			sessionId,
+		],
+	);
+
+	const handleTerminalClick = useCallback(
+		(event: ReactMouseEvent<HTMLDivElement>) => {
+			const uri = findTerminalUriFromClick(
+				event.nativeEvent,
+				event.currentTarget,
+			);
+			if (!uri) return;
+
+			event.preventDefault();
+			event.stopPropagation();
+
+			if (shouldBypassTerminalLinkConfirm(event.nativeEvent)) {
 				void open(uri);
 				return;
 			}
@@ -180,194 +492,28 @@ export function Terminal({ profileId, sessionId, isActive }: TerminalProps) {
 		[],
 	);
 
-	// Stable ref callback — only re-runs when profileId/sessionId changes
-	const terminalRef = useCallback(
-		(container: HTMLDivElement | null) => {
-			if (!container) return;
-			const unlisteners: UnlistenFn[] = [];
-
-			consola.info(`[pty-terminal] mount sessionId=${sessionId}`);
-			let disposed = false;
-
-			// 1. Create xterm (sync)
-			const term = new XTerm({
-				fontFamily: `"${initFontFamilyRef.current}", monospace`,
-				fontSize: initFontSizeRef.current,
-				theme: initThemeRef.current,
-				cursorBlink: true,
-				cursorStyle: "bar",
-				cursorWidth: 4,
-			});
-			unlisteners.push(() => term.dispose());
-
-			term.attachCustomKeyEventHandler((event) => {
-				const action = getTerminalShortcutAction(event);
-				if (!action) return true;
-
-				event.preventDefault();
-				event.stopPropagation();
-
-				if (action.type === "increase-font-size") {
-					increaseFontSize();
-					return false;
-				}
-
-				if (action.type === "decrease-font-size") {
-					decreaseFontSize();
-					return false;
-				}
-
-				if (action.type === "clear-screen") {
-					term.clear();
-					void clearPtyOutput({ sessionId })
-						.catch(() => {})
-						.finally(() => {
-							void writeToPty({ sessionId, data: "\x0C" });
-						});
-					return false;
-				}
-
-				void writeToPty({ sessionId, data: action.sequence });
-				return false;
-			});
-
-			const fitAddon = new FitAddon();
-			term.loadAddon(fitAddon);
-
-			const webLinksAddon = new WebLinksAddon(handleTerminalLinkOpen);
-			term.loadAddon(webLinksAddon);
-
-			term.open(container);
-			termRef.current = term;
-			fitAddonRef.current = fitAddon;
-
-			term.loadAddon(new ClipboardAddon());
-			term.loadAddon(new ImageAddon());
-			term.loadAddon(new LigaturesAddon());
-			term.loadAddon(new ProgressAddon());
-
-			fitAddon.fit();
-			syncTerminalLayout(1);
-
-			// Resize PTY to match xterm dimensions
-			resizePty({ sessionId, rows: term.rows, cols: term.cols });
-
-			// 2. Register listeners (before history write, but buffer events)
-			async function setupListeners() {
-				const unlistenOutput = await listen<string>(
-					`pty-output-${sessionId}`,
-					(event) => {
-						if (!isStreamReadyRef.current) {
-							pendingEventsRef.current.push(event.payload);
-							return;
-						}
-						term.write(event.payload);
-					},
-				);
-				const unlistenExit = await listen(
-					`pty-exit-${sessionId}`,
-					() => {
-						term.write("\r\n\x1B[90m[Process exited]\x1B[0m\r\n");
-					},
-				);
-				if (disposed) {
-					unlistenOutput();
-					unlistenExit();
-					return;
-				}
-				unlisteners.push(unlistenOutput, unlistenExit);
-				consola.info(
-					`[pty-terminal] live listeners registered for session ${sessionId}`,
-				);
-			}
-			void setupListeners();
-
-			// 3. Write history from module-level Map
-			const history = sessionHistory.get(sessionId);
-			if (history && history.length > 0) {
-				consola.info(
-					`[pty-restore] writing ${history.length} bytes of history for session ${sessionId}`,
-				);
-				const renderDisposable = term.onRender(() => {
-					renderDisposable.dispose();
-					term.write(history, () => {
-						sessionHistory.delete(sessionId);
-						isStreamReadyRef.current = true;
-						for (const payload of pendingEventsRef.current) {
-							term.write(payload);
-						}
-						pendingEventsRef.current = [];
-					});
-				});
-			} else {
-				isStreamReadyRef.current = true;
-			}
-
-			// 4. Sync handlers
-			term.onData((data) => {
-				writeToPty({ sessionId, data });
-			});
-
-			term.onResize(({ rows, cols }) => {
-				resizePty({ sessionId, rows, cols });
-			});
-
-			term.onTitleChange((title) => {
-				useTerminalStore
-					.getState()
-					.updateTabTitle(profileId, sessionId, title);
-			});
-
-			const resizeObserver = new ResizeObserver((entries) => {
-				const entry = entries[0];
-				if (
-					entry &&
-					entry.contentRect.width > 0 &&
-					entry.contentRect.height > 0
-				) {
-					syncTerminalLayout();
-				}
-			});
-			resizeObserver.observe(container);
-			unlisteners.push(() => resizeObserver.disconnect());
-
-			// 5. React 19 ref cleanup
-			return () => {
-				consola.info(`[pty-terminal] unmount sessionId=${sessionId}`);
-				disposed = true;
-
-				// Flush buffered PTY output to DB before teardown (best-effort)
-				flushPtyOutput({ sessionId }).catch(() => {});
-
-				// Reset stream state (sessionHistory is only deleted after successful write)
-				isStreamReadyRef.current = false;
-				pendingEventsRef.current = [];
-
-				for (const unlisten of unlisteners) {
-					unlisten();
-				}
-
-				termRef.current = null;
-				fitAddonRef.current = null;
-			};
-		},
-		[
-			decreaseFontSize,
-			handleTerminalLinkOpen,
-			increaseFontSize,
-			profileId,
-			sessionId,
-			syncTerminalLayout,
-		],
-	);
-
 	return (
 		<>
 			<div style={shellStyle}>
 				<div
-					ref={terminalRef}
+					ref={viewportRef}
 					style={{ flex: 1, minWidth: 0, minHeight: 0 }}
-				/>
+				>
+					<WTermTerminal
+						ref={terminalRef}
+						autoResize
+						cursorBlink
+						className="code-terminal"
+						style={terminalStyle}
+						onData={handleTerminalData}
+						onResize={handleTerminalResize}
+						onTitle={handleTerminalTitle}
+						onReady={handleTerminalReady}
+						onError={handleTerminalError}
+						onKeyDownCapture={handleTerminalKeyDownCapture}
+						onClick={handleTerminalClick}
+					/>
+				</div>
 			</div>
 
 			<TerminalLinkConfirmDialog

--- a/src/features/terminal/hooks.test.tsx
+++ b/src/features/terminal/hooks.test.tsx
@@ -170,7 +170,7 @@ describe("terminal hooks", () => {
 		expect(lightHook.result.current).toBe("one-dark");
 	});
 
-	it("returns the resolved xterm theme object for the selected theme id", () => {
+	it("returns the resolved terminal theme object for the selected theme id", () => {
 		const { result } = renderHook(() => useTerminalTheme(), {
 			wrapper: createWrapper(false),
 		});

--- a/src/features/terminal/hooks.ts
+++ b/src/features/terminal/hooks.ts
@@ -1,5 +1,4 @@
 import { useMutation } from "@tanstack/react-query";
-import type { ITheme } from "@xterm/xterm";
 import { use } from "react";
 import { useFileViewerTabsStore } from "@/features/projects/fileViewerTabsStore";
 import { useTerminalSettingsStore } from "@/features/settings/stores/terminalSettingsStore";
@@ -11,7 +10,7 @@ import {
 import { ThemeContext } from "@/shared/providers/themeContext";
 import { useTerminalStore } from "./store";
 import { DEFAULT_TERMINAL_SHELL } from "./templates";
-import type { TerminalThemeId } from "./themes";
+import type { TerminalTheme, TerminalThemeId } from "./themes";
 import { terminalThemes } from "./themes";
 
 export function useCreateTerminalTab() {
@@ -98,7 +97,7 @@ export function useTerminalThemeId(): TerminalThemeId {
 	return isDark ? darkTerminalTheme : lightTerminalTheme;
 }
 
-export function useTerminalTheme(): ITheme {
+export function useTerminalTheme(): TerminalTheme {
 	const id = useTerminalThemeId();
 	return terminalThemes[id] ?? terminalThemes["github-dark"];
 }

--- a/src/features/terminal/terminal.css
+++ b/src/features/terminal/terminal.css
@@ -1,0 +1,7 @@
+.code-terminal {
+	--term-selection-bg: rgba(86, 156, 214, 0.3);
+}
+
+.code-terminal ::selection {
+	background: var(--term-selection-bg);
+}

--- a/src/features/terminal/themes.test.ts
+++ b/src/features/terminal/themes.test.ts
@@ -33,7 +33,7 @@ describe("terminalThemes", () => {
 		expect(terminalThemeIds).toEqual(Object.keys(terminalThemeNames));
 	});
 
-	it("provides a label and full xterm color palette for every theme id", () => {
+	it("provides a label and full terminal color palette for every theme id", () => {
 		for (const id of terminalThemeIds) {
 			expect(terminalThemeNames[id]).toBeTruthy();
 			for (const key of requiredThemeKeys) {

--- a/src/features/terminal/themes.ts
+++ b/src/features/terminal/themes.ts
@@ -1,4 +1,25 @@
-import type { ITheme } from "@xterm/xterm";
+export interface TerminalTheme {
+	background: string;
+	foreground: string;
+	cursor: string;
+	selectionBackground: string;
+	black: string;
+	red: string;
+	green: string;
+	yellow: string;
+	blue: string;
+	magenta: string;
+	cyan: string;
+	white: string;
+	brightBlack: string;
+	brightRed: string;
+	brightGreen: string;
+	brightYellow: string;
+	brightBlue: string;
+	brightMagenta: string;
+	brightCyan: string;
+	brightWhite: string;
+}
 
 export type TerminalThemeId =
 	| "github-dark"
@@ -27,7 +48,7 @@ export const terminalThemeIds: TerminalThemeId[] = Object.keys(
 	terminalThemeNames,
 ) as TerminalThemeId[];
 
-export const terminalThemes: Record<TerminalThemeId, ITheme> = {
+export const terminalThemes: Record<TerminalThemeId, TerminalTheme> = {
 	"github-dark": {
 		background: "#161616",
 		foreground: "#BFD4E1",

--- a/src/shared/components/SidebarLink.test.tsx
+++ b/src/shared/components/SidebarLink.test.tsx
@@ -21,7 +21,7 @@ function renderLink(pathname: string, props?: Partial<React.ComponentProps<typeo
 	);
 }
 
-describe("SidebarLink", () => {
+describe("sidebarLink", () => {
 	it("renders the active indicator when the current route matches the link", () => {
 		const { container } = renderLink("/settings");
 

--- a/src/shared/providers/Toaster.tsx
+++ b/src/shared/providers/Toaster.tsx
@@ -1,16 +1,11 @@
 import {
 	Toaster as ChakraToaster,
-	createToaster,
 	Portal,
 	Spinner,
 	Stack,
 	Toast,
 } from "@chakra-ui/react";
-
-export const toaster = createToaster({
-	placement: "bottom-end",
-	pauseOnPageIdle: true,
-});
+import { toaster } from "./toastController";
 
 export function Toaster() {
 	return (

--- a/src/shared/providers/toastController.ts
+++ b/src/shared/providers/toastController.ts
@@ -1,0 +1,6 @@
+import { createToaster } from "@chakra-ui/react";
+
+export const toaster = createToaster({
+	placement: "bottom-end",
+	pauseOnPageIdle: true,
+});

--- a/src/test/paraglide/messages.ts
+++ b/src/test/paraglide/messages.ts
@@ -1,6 +1,30 @@
 const createMessage = (name: string) => (..._args: unknown[]) => name;
 
+export const accentColor = createMessage("accentColor");
 export const addTerminalTemplate = createMessage("addTerminalTemplate");
+export const agentAcpBridge = createMessage("agentAcpBridge");
+export const agentApiKey = createMessage("agentApiKey");
+export const agentCredentials = createMessage("agentCredentials");
+export const agentCredentialsDetected = createMessage(
+	"agentCredentialsDetected",
+);
+export const agentCredentialsNone = createMessage("agentCredentialsNone");
+export const agentInstall = createMessage("agentInstall");
+export const agentNativeCli = createMessage("agentNativeCli");
+export const agentNativeNotInstalled = createMessage(
+	"agentNativeNotInstalled",
+);
+export const agentNativeNotRequired = createMessage(
+	"agentNativeNotRequired",
+);
+export const agentNotInstalled = createMessage("agentNotInstalled");
+export const agentOAuth = createMessage("agentOAuth");
+export const agentPartial = createMessage("agentPartial");
+export const agentReady = createMessage("agentReady");
+export const agentReinstall = createMessage("agentReinstall");
+export const agentSummary = createMessage("agentSummary");
+export const agents = createMessage("agents");
+export const appearance = createMessage("appearance");
 export const backToCommitList = createMessage("backToCommitList");
 export const borderRadius = createMessage("borderRadius");
 export const branchName = createMessage("branchName");
@@ -42,6 +66,7 @@ export const createProjectHintTemporaryEmpty = createMessage(
 export const createProjectHintTemporaryNamed = createMessage(
 	"createProjectHintTemporaryNamed",
 );
+export const createdAt = createMessage("createdAt");
 export const debugClear = createMessage("debugClear");
 export const debugLog = createMessage("debugLog");
 export const debugMode = createMessage("debugMode");
@@ -57,6 +82,8 @@ export const deleteTerminalTemplate = createMessage("deleteTerminalTemplate");
 export const editTerminalTemplate = createMessage("editTerminalTemplate");
 export const emptyProjectsDesc = createMessage("emptyProjectsDesc");
 export const emptyProjectsTitle = createMessage("emptyProjectsTitle");
+export const fileTreeEmptyDirectory = createMessage("fileTreeEmptyDirectory");
+export const fileTreeLoading = createMessage("fileTreeLoading");
 export const fileTreeResizeSeparator = createMessage("fileTreeResizeSeparator");
 export const fileViewerCloseFileSearch = createMessage(
 	"fileViewerCloseFileSearch",
@@ -124,6 +151,15 @@ export const gitDiffImagePreviewBefore = createMessage(
 export const gitDiffImagePreviewUnavailable = createMessage(
 	"gitDiffImagePreviewUnavailable",
 );
+export const gitDiffLargeGuardrailDescription = createMessage(
+	"gitDiffLargeGuardrailDescription",
+);
+export const gitDiffLargeGuardrailReveal = createMessage(
+	"gitDiffLargeGuardrailReveal",
+);
+export const gitDiffLargeGuardrailTitle = createMessage(
+	"gitDiffLargeGuardrailTitle",
+);
 export const gitDiffPreviewMode = createMessage("gitDiffPreviewMode");
 export const gitDiffPreviewModeSplit = createMessage(
 	"gitDiffPreviewModeSplit",
@@ -151,6 +187,8 @@ export const newTerminal = createMessage("newTerminal");
 export const noChangesDetected = createMessage("noChangesDetected");
 export const noCommitsFound = createMessage("noCommitsFound");
 export const noFileChanges = createMessage("noFileChanges");
+export const noProfiles = createMessage("noProfiles");
+export const noProjectsYet = createMessage("noProjectsYet");
 export const noTemplatesDropdownHint = createMessage(
 	"noTemplatesDropdownHint",
 );
@@ -184,6 +222,7 @@ export const projectTerminalTemplates = createMessage(
 export const projectTerminalTemplatesDescription = createMessage(
 	"projectTerminalTemplatesDescription",
 );
+export const profiles = createMessage("profiles");
 export const projects = createMessage("projects");
 export const radiusLarge = createMessage("radiusLarge");
 export const radiusMedium = createMessage("radiusMedium");
@@ -233,6 +272,10 @@ export const terminalTemplateCwdPlaceholder = createMessage(
 export const terminalTemplateName = createMessage("terminalTemplateName");
 export const terminalTemplateNamePlaceholder = createMessage(
 	"terminalTemplateNamePlaceholder",
+);
+export const terminalTemplateShell = createMessage("terminalTemplateShell");
+export const terminalTemplateShellPlaceholder = createMessage(
+	"terminalTemplateShellPlaceholder",
 );
 export const terminalTemplates = createMessage("terminalTemplates");
 export const terminalTheme = createMessage("terminalTheme");

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,3 +1,4 @@
 /// <reference types="vite/client" />
 
 declare module "@fontsource-variable/bricolage-grotesque" {}
+declare module "@wterm/react/css" {}


### PR DESCRIPTION
## Summary
- replace the frontend terminal implementation with `@wterm/react`
- remove the `@xterm/*` dependency stack and update terminal theming/types
- keep PTY streaming, restore, resize, title sync, and shortcut handling working with the new binding

## Why
- validate whether the app can switch from xterm.js to the wterm React binding
- keep the branch in a shareable state with tests, lint, typecheck, and build passing

## Impact
- terminal rendering now uses wterm
- xterm-specific addon behavior was removed as part of the migration

## Validation
- `bunx tsc --noEmit`
- `bun run test`
- `bun run lint`
- `bun run build`