### PR TITLE
[codex] Add command palette file icons

### DIFF
--- a/src/features/projects/CommandPalette.test.tsx
+++ b/src/features/projects/CommandPalette.test.tsx
@@ -91,6 +91,12 @@ describe("commandPalette", () => {
 		await waitFor(() => {
 			expect(screen.getByText("main.ts")).toBeInTheDocument();
 		});
+		expect(
+			screen
+				.getByText("main.ts")
+				.closest("[cmdk-item]")
+				?.querySelector("svg[data-icon-token='typescript']"),
+		).not.toBeNull();
 		await waitFor(() => {
 			expect(
 				document.querySelector("[cmdk-item][aria-selected='true']"),

--- a/src/features/projects/CommandPalette.tsx
+++ b/src/features/projects/CommandPalette.tsx
@@ -4,6 +4,7 @@ import { useDeferredValue, useEffect, useRef, useState } from "react";
 import { useFileViewerTabsStore } from "@/features/projects/fileViewerTabsStore";
 import type { FileSearchResult } from "@/generated";
 import * as m from "@/paraglide/messages.js";
+import FileTreeFileIcon from "@/shared/components/FileTreeFileIcon";
 import { useFileSearch } from "./hooks";
 
 interface CommandPaletteProps {
@@ -160,6 +161,10 @@ export default function CommandPalette({
 						<Box
 							key={result.path}
 							asChild
+							display="flex"
+							alignItems="center"
+							gap="2"
+							minW="0"
 							px="3"
 							py="2"
 							rounded="l1"
@@ -174,6 +179,10 @@ export default function CommandPalette({
 								value={result.path}
 								onSelect={() => commitSelection(result)}
 							>
+								<FileTreeFileIcon
+									fileName={result.name}
+									size={16}
+								/>
 								<Box flex="1" minW="0">
 									<Text fontSize="sm" truncate>
 										{result.name}


### PR DESCRIPTION
## Summary

Adds the same file icon rendering used by the file tree to the Cmd+K command palette search results.

## Impact

File search results are easier to scan because each entry now shows the matching file-type icon next to the filename, consistent with the file sidebar and file tabs.

## Validation

- `bun run paraglide:compile && bunx vitest run src/features/projects/CommandPalette.test.tsx src/shared/components/FileTreeFileIcon.test.tsx`
- `bunx tsc --noEmit`
- `bunx eslint src/features/projects/CommandPalette.tsx src/features/projects/CommandPalette.test.tsx`