### PR TITLE
fix: truncate sidebar profile names

### DIFF
--- a/src/layout/sidebar/ProfileItem.tsx
+++ b/src/layout/sidebar/ProfileItem.tsx
@@ -1,10 +1,11 @@
-import { Circle, HStack, Icon, Menu, Portal, Text } from "@chakra-ui/react";
+import { Circle, HStack, Icon, Menu, Portal } from "@chakra-ui/react";
 import { FiGitBranch } from "react-icons/fi";
 import { NavLink } from "react-router";
 import DeleteProfileDialog from "@/features/profiles/DeleteProfileDialog";
 import { useProfileHasNotification, useTerminalStore } from "@/features/terminal/store";
 import type { Profile } from "@/generated";
 import * as m from "@/paraglide/messages.js";
+import OverflowTooltipText from "@/shared/components/OverflowTooltipText";
 import { SidebarActiveIndicator } from "@/shared/components/SidebarActiveIndicator";
 import { useDialogState } from "@/shared/hooks/useDialogState";
 
@@ -30,7 +31,9 @@ export function ProfileItem({
 						data-sidebar-item
 						gap="2"
 						w="full"
-						minW="max-content"
+						minW="0"
+						maxW="var(--sidebar-width)"
+						overflow="hidden"
 						position="relative"
 						ps="9"
 						pe="4"
@@ -47,12 +50,16 @@ export function ProfileItem({
 							{isActive && (
 								<SidebarActiveIndicator insetInlineStart="0" />
 							)}
-							<Icon fontSize="xs" color="fg.muted">
+							<Icon fontSize="xs" color="fg.muted" flexShrink={0}>
 								<FiGitBranch />
 							</Icon>
-							<Text whiteSpace="nowrap" flexShrink={0}>
-								{profile.branch_name}
-							</Text>
+							<OverflowTooltipText
+								displayValue={profile.branch_name}
+								tooltipValue={profile.branch_name}
+								fontSize="sm"
+								flex="1 1 auto"
+								minW="0"
+							/>
 							{hasNotification && (
 								<Circle
 									size="2"

--- a/src/layout/sidebar/ProfileList.tsx
+++ b/src/layout/sidebar/ProfileList.tsx
@@ -31,7 +31,9 @@ export function ProfileList({
 				as="button"
 				gap="2"
 				w="full"
-				minW="max-content"
+				minW="0"
+				maxW="var(--sidebar-width)"
+				overflow="hidden"
 				ps="9"
 				pe="4"
 				py="1"
@@ -41,10 +43,10 @@ export function ProfileList({
 				_hover={{ bg: "bg.subtle", color: "fg" }}
 				onClick={createDialog.onOpen}
 			>
-				<Icon fontSize="xs">
+				<Icon fontSize="xs" flexShrink={0}>
 					<FiPlus />
 				</Icon>
-				<Text whiteSpace="nowrap" flexShrink={0}>
+				<Text flex="1 1 auto" minW="0" truncate>
 					{m.createProfile()}
 				</Text>
 			</HStack>

--- a/src/layout/sidebar/ProjectMenuItem.tsx
+++ b/src/layout/sidebar/ProjectMenuItem.tsx
@@ -19,6 +19,7 @@ import RenameProjectDialog from "@/features/projects/RenameProjectDialog";
 import { useProfileHasNotification, useTerminalStore } from "@/features/terminal/store";
 import type { ProjectWithProfiles } from "@/generated";
 import * as m from "@/paraglide/messages.js";
+import OverflowTooltipText from "@/shared/components/OverflowTooltipText";
 import { SidebarActiveIndicator } from "@/shared/components/SidebarActiveIndicator";
 import { useDialogState } from "@/shared/hooks/useDialogState";
 import { ProjectAvatar } from "./ProjectAvatar";
@@ -49,6 +50,7 @@ export function ProjectMenuItem({ project }: { project: ProjectWithProfiles }) {
 		defaultProfile?.id ?? "",
 	);
 	const markProfileRead = useTerminalStore((s) => s.markProfileRead);
+	const defaultProfileLabel = m.defaultProfile();
 
 	const renameDialog = useDialogState();
 	const deleteDialog = useDialogState();
@@ -186,7 +188,9 @@ export function ProjectMenuItem({ project }: { project: ProjectWithProfiles }) {
 						data-sidebar-item
 						gap="2"
 						w="full"
-						minW="max-content"
+						minW="0"
+						maxW="var(--sidebar-width)"
+						overflow="hidden"
 						position="relative"
 						ps="9"
 						pe="4"
@@ -207,12 +211,16 @@ export function ProjectMenuItem({ project }: { project: ProjectWithProfiles }) {
 							{isDefaultActive && (
 								<SidebarActiveIndicator insetInlineStart="0" />
 							)}
-							<Icon fontSize="xs" color="fg.muted">
+							<Icon fontSize="xs" color="fg.muted" flexShrink={0}>
 								<FiTerminal />
 							</Icon>
-							<Text whiteSpace="nowrap" flexShrink={0}>
-								{m.defaultProfile()}
-							</Text>
+							<OverflowTooltipText
+								displayValue={defaultProfileLabel}
+								tooltipValue={defaultProfileLabel}
+								fontSize="sm"
+								flex="1 1 auto"
+								minW="0"
+							/>
 							{hasDefaultNotification && (
 								<Circle
 									size="2"


### PR DESCRIPTION
## Summary
- reuse the pretext-backed overflow text component for sidebar profile labels
- constrain profile rows to the current sidebar width so long branch names ellipsize
- keep profile notification dots and icons from shrinking out of view

## Verification
- bunx eslint --fix src/layout/sidebar/ProfileItem.tsx src/layout/sidebar/ProfileList.tsx src/layout/sidebar/ProjectMenuItem.tsx
- bun run build