### PR TITLE
fix: keep create profile label compact

### DIFF
--- a/src/layout/sidebar/ProfileList.tsx
+++ b/src/layout/sidebar/ProfileList.tsx
@@ -46,7 +46,7 @@ export function ProfileList({
 				<Icon fontSize="xs" flexShrink={0}>
 					<FiPlus />
 				</Icon>
-				<Text flex="1 1 auto" minW="0" truncate>
+				<Text flex="0 1 auto" minW="0" truncate>
 					{m.createProfile()}
 				</Text>
 			</HStack>


### PR DESCRIPTION
## Summary
- prevent the create-profile label from growing across the sidebar row
- keep the label adjacent to the plus icon while still allowing truncation in narrow sidebars

## Verification
- bunx eslint --fix src/layout/sidebar/ProfileList.tsx
- bun run build