### PR TITLE
fix: keep sidebar controls visible on resize

### DIFF
--- a/src/layout/AppSidebar.tsx
+++ b/src/layout/AppSidebar.tsx
@@ -70,9 +70,9 @@ export default function AppSidebar() {
 				bg="bg.subtle"
 				onKeyDown={handleKeyDown}
 			>
-				<Box h="full" overflow="auto">
+				<Box h="full" overflowY="auto" overflowX="hidden">
 					<LayoutGroup id="app-sidebar">
-						<Flex direction="column" h="full" minW="max-content" pb="3">
+						<Flex direction="column" h="full" w="full" minW="0" pb="3">
 							<Flex
 								data-tauri-drag-region
 								h="80px"
@@ -104,8 +104,15 @@ export default function AppSidebar() {
 								</SidebarLink>
 							)}
 
-							<HStack px="4" pt="2" pb="2" justify="space-between">
-								<HStack gap="2" minW={0}>
+							<HStack
+								px="4"
+								pt="2"
+								pb="2"
+								justify="space-between"
+								w="full"
+								minW="0"
+							>
+								<HStack gap="2" flex="1 1 auto" minW="0">
 									<Icon fontSize="xs" color="fg.muted" flexShrink={0}>
 										<FiFolder />
 									</Icon>
@@ -115,7 +122,7 @@ export default function AppSidebar() {
 										color="fg.muted"
 										textTransform="uppercase"
 										letterSpacing="wider"
-										whiteSpace="nowrap"
+										truncate
 									>
 										{m.projects()}
 									</Text>
@@ -125,6 +132,7 @@ export default function AppSidebar() {
 									aria-label={m.newProject()}
 									variant="ghost"
 									size="2xs"
+									flexShrink={0}
 									onClick={createDialog.onOpen}
 								>
 									<FiPlus />

--- a/src/layout/sidebar/ProjectMenuItem.tsx
+++ b/src/layout/sidebar/ProjectMenuItem.tsx
@@ -67,7 +67,8 @@ export function ProjectMenuItem({ project }: { project: ProjectWithProfiles }) {
 						className="group"
 						gap="1"
 						w="full"
-						minW="max-content"
+						minW="0"
+						overflow="hidden"
 						px="4"
 						py="1.5"
 						cursor="pointer"
@@ -85,18 +86,24 @@ export function ProjectMenuItem({ project }: { project: ProjectWithProfiles }) {
 						)}
 						<Box
 							asChild
-							flex="1"
-							minW="fit-content"
-							whiteSpace="nowrap"
+							flex="1 1 auto"
+							minW="0"
+							overflow="hidden"
 							data-sidebar-item
 						>
 							<NavLink to={defaultProfileUrl}>
-								<HStack gap="2" align="center">
+								<HStack
+									gap="2"
+									align="center"
+									w="full"
+									minW="0"
+									overflow="hidden"
+								>
 									<ProjectAvatar
 										projectId={project.id}
 										projectName={project.name}
 									/>
-									<Text whiteSpace="nowrap" flexShrink={0}>
+									<Text flex="1 1 auto" minW="0" truncate>
 										{project.name}
 									</Text>
 								</HStack>
@@ -110,6 +117,7 @@ export function ProjectMenuItem({ project }: { project: ProjectWithProfiles }) {
 										as="span"
 										variant="ghost"
 										size="2xs"
+										flexShrink={0}
 										opacity="0"
 										_groupHover={{ opacity: 1 }}
 										onClick={(e) => {
@@ -134,6 +142,7 @@ export function ProjectMenuItem({ project }: { project: ProjectWithProfiles }) {
 								as="span"
 								variant="ghost"
 								size="2xs"
+								flexShrink={0}
 								onClick={(e) => {
 									e.preventDefault();
 									e.stopPropagation();


### PR DESCRIPTION
## Summary
- keep sidebar content constrained to the resized sidebar width instead of max-content width
- make project names truncate through a complete min-width: 0 shrink chain
- keep project add and expand controls from shrinking or being pushed outside the visible sidebar

## Verification
- bunx eslint --fix src/layout/AppSidebar.tsx src/layout/sidebar/ProjectMenuItem.tsx
- git diff --check
- bun run build