### PR TITLE
feat(terminal): support Shift+Enter for multiline command editing

### DIFF
--- a/src-tauri/crates/infra/scripts/default_init.sh
+++ b/src-tauri/crates/infra/scripts/default_init.sh
@@ -44,3 +44,9 @@ command chmod +x "$_2CODE_BIN/claude"
 export PATH="$_2CODE_BIN:$PATH"
 
 unsetopt PROMPT_SP
+
+# Rebind ^J (LF) so Shift+Enter inserts a newline instead of executing.
+# Enter still sends ^M (CR) which remains bound to accept-line.
+_2code_insert_newline() { LBUFFER+=$'\n'; }
+zle -N _2code_insert_newline
+bindkey '^J' _2code_insert_newline

--- a/src/features/terminal/keybindings.test.ts
+++ b/src/features/terminal/keybindings.test.ts
@@ -75,6 +75,18 @@ describe("getTerminalShortcutSequence", () => {
 });
 
 describe("getTerminalShortcutAction", () => {
+	it("maps Shift+Enter to newline for multiline input", () => {
+		expect(
+			getTerminalShortcutAction(makeEvent({ shiftKey: true, key: "Enter" })),
+		).toEqual({ type: "write-sequence", sequence: "\n" });
+	});
+
+	it("does not map plain Enter", () => {
+		expect(
+			getTerminalShortcutAction(makeEvent({ key: "Enter" })),
+		).toBeNull();
+	});
+
 	it("maps Cmd+= to increase font size on macOS", () => {
 		expect(
 			getTerminalShortcutAction(

--- a/src/features/terminal/keybindings.ts
+++ b/src/features/terminal/keybindings.ts
@@ -36,6 +36,10 @@ export function getTerminalShortcutAction(
 ): TerminalShortcutAction | null {
 	if (event.type !== "keydown") return null;
 
+	if (event.shiftKey && !event.metaKey && !event.ctrlKey && !event.altKey && event.key === "Enter") {
+		return { type: "write-sequence", sequence: "\n" };
+	}
+
 	if (isPlainMetaShortcut(event, platform) && !event.shiftKey) {
 		if (event.key === "ArrowLeft") {
 			return { type: "write-sequence", sequence: "\x1B[H" };


### PR DESCRIPTION
## Summary
- Intercept Shift+Enter in `keybindings.ts`, send LF (`\n`) instead of CR (`\r`)
- Rebind `^J` in zsh init to insert a literal newline via custom ZLE widget
- Enter (`^M`/CR) behavior unchanged

This is a workaround for the broader Kitty keyboard protocol adoption tracked in #139.

## How it works
- **Enter** → xterm.js sends `\r` (CR, ^M) → zsh `accept-line` (execute)
- **Shift+Enter** → JS intercept sends `\n` (LF, ^J) → zsh `_2code_insert_newline` (insert newline)

## Industry context
VS Code only supports Shift+Enter multiline for PowerShell (via F12 proxy sequence). Hyper, Tabby, and ttyd don't handle it at all. Our approach is the simplest reliable solution for zsh without requiring Kitty protocol.

## Test plan
- [x] 394 frontend tests pass (2 new tests for Shift+Enter)
- [x] 26 Rust tests pass
- [x] Manual verification: Shift+Enter inserts newline in zsh
- [x] Enter, Ctrl+C, Cmd+C unaffected

Related: #139

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Shift+Enter keybinding to insert newlines in the terminal without executing commands.

* **Chores**
  * Updated shell environment initialization with custom keybinding configurations for enhanced terminal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->