### PR TITLE
fix(build): handle empty array expansion under bash nounset mode

### DIFF
--- a/justfile
+++ b/justfile
@@ -31,7 +31,7 @@ build-helper:
         CARGO_TARGET_ARGS=(--target "${TARGET_TRIPLE}")
         TARGET_DIR="target/${TARGET_TRIPLE}/release"
     fi
-    cd src-tauri && cargo build --release -p twocode-helper "${CARGO_TARGET_ARGS[@]}"
+    cd src-tauri && cargo build --release -p twocode-helper ${CARGO_TARGET_ARGS[@]+"${CARGO_TARGET_ARGS[@]}"}
     mkdir -p binaries
     cp -f "${TARGET_DIR}/2code-helper${BIN_SUFFIX}" "binaries/2code-helper-${TARGET_TRIPLE}${BIN_SUFFIX}"
     chmod +x "binaries/2code-helper-${TARGET_TRIPLE}${BIN_SUFFIX}"
@@ -51,7 +51,7 @@ build-helper-dev:
         CARGO_TARGET_ARGS=(--target "${TARGET_TRIPLE}")
         TARGET_DIR="target/${TARGET_TRIPLE}/debug"
     fi
-    cd src-tauri && cargo build -p twocode-helper "${CARGO_TARGET_ARGS[@]}"
+    cd src-tauri && cargo build -p twocode-helper ${CARGO_TARGET_ARGS[@]+"${CARGO_TARGET_ARGS[@]}"}
     mkdir -p binaries
     cp -f "${TARGET_DIR}/2code-helper${BIN_SUFFIX}" "binaries/2code-helper-${TARGET_TRIPLE}${BIN_SUFFIX}"
     chmod +x "binaries/2code-helper-${TARGET_TRIPLE}${BIN_SUFFIX}"


### PR DESCRIPTION
## Summary
- Fix `CARGO_TARGET_ARGS[@]: unbound variable` error when building locally
- Use `${arr[@]+"${arr[@]}"}` pattern to safely expand empty arrays with `set -u`
- Cross-compile via `TWOCODE_HELPER_TARGET` still works as intended

## Root cause
Commit e865cec added `CARGO_TARGET_ARGS=()` for cross-compile support. Under `set -euo pipefail`, referencing an empty bash array with `"${arr[@]}"` triggers `unbound variable`. This breaks all local builds where target matches host.

## Test plan
- [x] `just build-helper-dev` passes locally (native target, empty array)
- [x] `just build-helper` passes locally (release build)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to improve how build arguments are processed during the compilation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->