### PR TITLE
Fix file search shortcut in file tabs

### DIFF
--- a/src/features/projects/CommandPalette.test.tsx
+++ b/src/features/projects/CommandPalette.test.tsx
@@ -1,10 +1,5 @@
 import { ChakraProvider } from "@chakra-ui/react";
-import {
-	fireEvent,
-	render,
-	screen,
-	waitFor,
-} from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { FileSearchResult } from "@/generated";
 import * as m from "@/paraglide/messages.js";
@@ -41,7 +36,19 @@ function createFileSearchResult(
 function renderPalette() {
 	return render(
 		<ChakraProvider value={appSystem}>
-			<CommandPalette profileId="profile-1" />
+			<CommandPalette profileId="profile-1" isActive />
+		</ChakraProvider>,
+	);
+}
+
+function renderPaletteWithKeydownSink() {
+	return render(
+		<ChakraProvider value={appSystem}>
+			<CommandPalette profileId="profile-1" isActive />
+			<textarea
+				aria-label="editor"
+				onKeyDown={(event) => event.stopPropagation()}
+			/>
 		</ChakraProvider>,
 	);
 }
@@ -84,6 +91,19 @@ describe("commandPalette", () => {
 		await waitFor(() => expect(input).toHaveFocus());
 		expect(document.querySelector("[cmdk-root]")).toBeInTheDocument();
 		expect(screen.getByText(m.commandPaletteEmpty())).toBeInTheDocument();
+	});
+
+	it("opens before focused editors can stop keyboard event propagation", async () => {
+		renderPaletteWithKeydownSink();
+		const editor = screen.getByRole("textbox", { name: "editor" });
+		editor.focus();
+
+		fireEvent.keyDown(editor, { key: "k", metaKey: true });
+
+		const input = await screen.findByRole("combobox", {
+			name: m.commandPaletteTitle(),
+		});
+		expect(input).toHaveFocus();
 	});
 
 	it("opens the current file selection with Enter", async () => {

--- a/src/features/projects/CommandPalette.tsx
+++ b/src/features/projects/CommandPalette.tsx
@@ -16,6 +16,7 @@ import { useFileSearch } from "./hooks";
 
 interface CommandPaletteProps {
 	profileId: string;
+	isActive: boolean;
 }
 
 function getParentPathLabel(result: FileSearchResult) {
@@ -57,24 +58,28 @@ function CommandPaletteStatusMessage({ children }: { children: ReactNode }) {
 	);
 }
 
-export default function CommandPalette({ profileId }: CommandPaletteProps) {
+export default function CommandPalette({
+	profileId,
+	isActive,
+}: CommandPaletteProps) {
 	const [isOpen, setIsOpen] = useState(false);
 	const [search, setSearch] = useState("");
 	const inputRef = useRef<HTMLInputElement | null>(null);
 	const deferredSearch = useDeferredValue(search.trim());
+	const isPaletteOpen = isActive && isOpen;
 	const openFile = useFileViewerTabsStore((state) => state.openFile);
 	const {
 		data: results = [],
 		error,
 		isError,
 		isFetching,
-	} = useFileSearch(profileId, deferredSearch, isOpen);
+	} = useFileSearch(profileId, deferredSearch, isPaletteOpen);
 	const shouldShowErrorState = isError && results.length === 0;
 	const shouldShowEmptyState =
 		results.length === 0 && (deferredSearch.length === 0 || !isFetching);
 
 	useEffect(() => {
-		if (!profileId) return;
+		if (!profileId || !isActive) return;
 
 		const handleKeyDown = (event: KeyboardEvent) => {
 			if (event.repeat || event.altKey || event.shiftKey) return;
@@ -82,15 +87,16 @@ export default function CommandPalette({ profileId }: CommandPaletteProps) {
 			if (event.key.toLowerCase() !== "k") return;
 
 			event.preventDefault();
+			event.stopPropagation();
 			setIsOpen(true);
 		};
 
-		window.addEventListener("keydown", handleKeyDown);
-		return () => window.removeEventListener("keydown", handleKeyDown);
-	}, [profileId]);
+		window.addEventListener("keydown", handleKeyDown, true);
+		return () => window.removeEventListener("keydown", handleKeyDown, true);
+	}, [isActive, profileId]);
 
 	useEffect(() => {
-		if (!isOpen) return;
+		if (!isPaletteOpen) return;
 
 		const frameId = window.requestAnimationFrame(() => {
 			inputRef.current?.focus();
@@ -98,7 +104,7 @@ export default function CommandPalette({ profileId }: CommandPaletteProps) {
 		});
 
 		return () => window.cancelAnimationFrame(frameId);
-	}, [isOpen]);
+	}, [isPaletteOpen]);
 
 	function closePalette() {
 		setIsOpen(false);
@@ -112,7 +118,7 @@ export default function CommandPalette({ profileId }: CommandPaletteProps) {
 
 	return (
 		<Command.Dialog
-			open={isOpen}
+			open={isPaletteOpen}
 			onOpenChange={(open) => {
 				if (!open) closePalette();
 			}}

--- a/src/features/projects/ProfileLayout.tsx
+++ b/src/features/projects/ProfileLayout.tsx
@@ -1,6 +1,7 @@
 import { Box, Flex } from "@chakra-ui/react";
 import type { ReactNode } from "react";
 import ProjectTopBar from "@/features/git/ProjectTopBar";
+import CommandPalette from "@/features/projects/CommandPalette";
 import FileTreePanel from "@/features/projects/FileTreePanel";
 import { useFileTreeStore } from "@/features/projects/fileTreeStore";
 import { useFileViewerTabsStore } from "@/features/projects/fileViewerTabsStore";
@@ -27,6 +28,7 @@ export default function ProfileLayout({
 
 	return (
 		<Flex direction="column" h="full">
+			<CommandPalette profileId={profile.id} isActive={isActive} />
 			<Box borderBottomWidth="1px" borderColor="border">
 				<ProjectTopBar
 					projectId={projectId}

--- a/src/features/projects/ProjectDetailPage.tsx
+++ b/src/features/projects/ProjectDetailPage.tsx
@@ -13,7 +13,6 @@ import {
 import { useMemo } from "react";
 import { FiChevronDown, FiPlus, FiTerminal } from "react-icons/fi";
 import { Navigate, useParams } from "react-router";
-import CommandPalette from "@/features/projects/CommandPalette";
 import ProfileLayout from "@/features/projects/ProfileLayout";
 import {
 	useProject,
@@ -103,7 +102,6 @@ export default function ProjectDetailPage() {
 
 	return (
 		<>
-			<CommandPalette profileId={profile.id} />
 			{shouldRenderEmptyState ? (
 				<ProfileLayout
 					projectId={project.id}


### PR DESCRIPTION
## Summary
- Move the file search command palette into the profile layout so it belongs to the active profile surface.
- Listen for Cmd/Ctrl+K in capture phase so focused file editors cannot swallow the shortcut before the palette opens.

## Tests
- bun run paraglide:compile
- bunx vitest run src/features/projects/CommandPalette.test.tsx
- bunx tsc --noEmit
- bunx eslint src/features/projects/CommandPalette.tsx src/features/projects/ProfileLayout.tsx src/features/projects/ProjectDetailPage.tsx src/features/projects/CommandPalette.test.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test case validating command palette keyboard shortcut handling with proper focus management

* **Refactor**
  * Improved command palette component structure to better handle focus and element selection when activated via keyboard shortcut

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AkaraChen/2code/pull/160)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->