### PR TITLE
perf: cache terminal tab lookups

### DIFF
--- a/src/features/terminal/TerminalTabs.bench.ts
+++ b/src/features/terminal/TerminalTabs.bench.ts
@@ -1,0 +1,45 @@
+import { bench, describe } from "vitest";
+
+const terminalTabs = Array.from({ length: 1_000 }, (_, index) => ({
+	id: `session-${index}`,
+}));
+const fileTabs = Array.from({ length: 1_000 }, (_, index) => ({
+	filePath: `src/file-${index}.ts`,
+}));
+const selectedValues = Array.from({ length: 10_000 }, (_, index) =>
+	index % 2 === 0
+		? `src/file-${index % fileTabs.length}.ts`
+		: `session-${index % terminalTabs.length}`,
+);
+const terminalTabIdSet = new Set(terminalTabs.map((tab) => tab.id));
+const fileTabPathSet = new Set(fileTabs.map((tab) => tab.filePath));
+
+describe("terminal tab lookup", () => {
+	bench("linear scan", () => {
+		let count = 0;
+		for (const value of selectedValues) {
+			if (fileTabs.some((tab) => tab.filePath === value)) {
+				count++;
+		} else if (terminalTabs.some((tab) => tab.id === value)) {
+			count++;
+		}
+	}
+		if (count !== selectedValues.length) {
+			throw new Error("linear scan missed tab values");
+		}
+	});
+
+	bench("set lookup", () => {
+		let count = 0;
+		for (const value of selectedValues) {
+			if (fileTabPathSet.has(value)) {
+				count++;
+		} else if (terminalTabIdSet.has(value)) {
+			count++;
+		}
+	}
+		if (count !== selectedValues.length) {
+			throw new Error("set lookup missed tab values");
+		}
+	});
+});

--- a/src/features/terminal/TerminalTabs.tsx
+++ b/src/features/terminal/TerminalTabs.tsx
@@ -126,6 +126,14 @@ export default function TerminalTabs({
 		() => new Set(dirtyFilePaths),
 		[dirtyFilePaths],
 	);
+	const terminalTabIdSet = useMemo(
+		() => new Set(tabs.map((tab) => tab.id)),
+		[tabs],
+	);
+	const fileTabPathSet = useMemo(
+		() => new Set(fileTabs.map((tab) => tab.filePath)),
+		[fileTabs],
+	);
 
 	const closeTab = useCloseTerminalTab();
 	const prefersReducedMotion = useReducedMotion();
@@ -137,14 +145,12 @@ export default function TerminalTabs({
 	const tabMotionProps = prefersReducedMotion ? {} : FULL_TAB_MOTION_PROPS;
 
 	function handleTabChange(value: string) {
-		const isFileTab = fileTabs.some((tab) => tab.filePath === value);
-		if (isFileTab) {
+		if (fileTabPathSet.has(value)) {
 			setFileActive(profileId, value);
 			return;
 		}
 
-		const isTerminalTab = tabs.some((tab) => tab.id === value);
-		if (!isTerminalTab) return;
+		if (!terminalTabIdSet.has(value)) return;
 
 		setActiveTab(profileId, value);
 		setTerminalActive(profileId);


### PR DESCRIPTION
## Stack Context

This PR is an independent terminal tab interaction performance optimization.

## What?

- Memoizes terminal tab IDs and file tab paths as `Set`s for active tab selection lookup.
- Adds a Vitest benchmark comparing the previous linear scan path with the Set lookup path.

## Why?

Tab selection previously scanned file tabs and terminal tabs linearly for every selection value. With many tabs, this makes selection work scale with tab count. The memoized sets keep lookup cost constant after the tab arrays change.

## Benchmark

Command:

```bash
bunx vitest bench src/features/terminal/TerminalTabs.bench.ts --run
```

Result on this machine:

```text
set lookup - src/features/terminal/TerminalTabs.bench.ts > terminal tab lookup
  155.62x faster than linear scan
```

Validation:

```bash
bunx tsc --noEmit
```

Result: passed.
