### PR TITLE
perf: reuse file tree path collator

### DIFF
--- a/src/features/projects/FileTreePanel.bench.ts
+++ b/src/features/projects/FileTreePanel.bench.ts
@@ -1,0 +1,24 @@
+import { bench, describe } from "vitest";
+
+const paths = Array.from({ length: 25_000 }, (_, index) =>
+	`src/Deep/Path/Module${String(25_000 - index).padStart(5, "0")}/Target.ts`,
+);
+const collator = new Intl.Collator(undefined, { sensitivity: "base" });
+
+describe("file tree path sorting", () => {
+	bench("localeCompare with options", () => {
+		const sorted = [...paths].sort((left, right) =>
+			left.localeCompare(right, undefined, { sensitivity: "base" }),
+		);
+		if (sorted.length !== paths.length) {
+			throw new Error("localeCompare sort lost paths");
+		}
+	});
+
+	bench("reused Intl.Collator", () => {
+		const sorted = [...paths].sort(collator.compare);
+		if (sorted.length !== paths.length) {
+			throw new Error("collator sort lost paths");
+		}
+	});
+});

--- a/src/features/projects/FileTreePanel.tsx
+++ b/src/features/projects/FileTreePanel.tsx
@@ -60,6 +60,9 @@ const FILE_TREE_GIT_STATUSES = new Set<GitStatusEntry["status"]>([
 	"renamed",
 	"untracked",
 ]);
+const FILE_TREE_PATH_COLLATOR = new Intl.Collator(undefined, {
+	sensitivity: "base",
+});
 
 const FILE_TREE_HOST_STYLE = {
 	height: "100%",
@@ -185,9 +188,7 @@ function buildModelPaths(
 		seenPathCollisionKeys.add(collisionKey);
 		paths.push(entry.path);
 	}
-	paths.sort((left, right) =>
-		left.localeCompare(right, undefined, { sensitivity: "base" }),
-	);
+	paths.sort(FILE_TREE_PATH_COLLATOR.compare);
 	return paths;
 }
 


### PR DESCRIPTION
## Stack Context

This is the first PR in the file tree performance stack.

## What?

- Reuses a module-level `Intl.Collator` for file tree model path sorting.
- Adds a Vitest benchmark for the collator comparison.

## Why?

The file tree can sort thousands of paths when git status entries are merged into loaded tree paths. Calling `localeCompare` with options in every sort comparison repeatedly configures comparison behavior; a reused collator avoids that repeated work.

## Benchmark

Command:

```bash
bunx vitest bench src/features/projects/FileTreePanel.bench.ts --run
```

Result on this machine:

```text
reused Intl.Collator - src/features/projects/FileTreePanel.bench.ts > file tree path sorting
  32.68x faster than localeCompare with options
```

Validation:

```bash
bunx tsc --noEmit
```

Result: passed.
