### PR TITLE
perf: index terminal notification sessions

### DIFF
--- a/src/features/terminal/store.test.ts
+++ b/src/features/terminal/store.test.ts
@@ -8,7 +8,11 @@ import {
 } from "./store";
 
 function resetStore() {
-	useTerminalStore.setState({ profiles: {}, notifiedTabs: new Set() });
+	useTerminalStore.setState({
+		profiles: {},
+		notifiedTabs: new Set(),
+		sessionProfileIds: {},
+	});
 	window.history.pushState({}, "", "/");
 }
 

--- a/src/features/terminal/store.ts
+++ b/src/features/terminal/store.ts
@@ -37,6 +37,18 @@ function findProfileIdBySessionId(
 	return null;
 }
 
+function refreshSessionProfileId(
+	state: Pick<TerminalStore, "profiles" | "sessionProfileIds">,
+	sessionId: string,
+) {
+	const profileId = findProfileIdBySessionId(state.profiles, sessionId);
+	if (profileId) {
+		state.sessionProfileIds[sessionId] = profileId;
+	} else {
+		delete state.sessionProfileIds[sessionId];
+	}
+}
+
 function clearProfileActiveTabNotification(
 	state: Pick<TerminalStore, "profiles" | "notifiedTabs">,
 	profileId: string | null,
@@ -52,6 +64,7 @@ function clearProfileActiveTabNotification(
 interface TerminalStore {
 	profiles: Record<string, ProjectTerminalState>;
 	notifiedTabs: Set<string>;
+	sessionProfileIds: Record<string, string>;
 	addTab: (profileId: string, sessionId: string, title: string) => void;
 	closeTab: (profileId: string, tabId: string) => void;
 	setActiveTab: (profileId: string, tabId: string) => void;
@@ -67,6 +80,7 @@ export const useTerminalStore = create<TerminalStore>()(
 	immer((set) => ({
 		profiles: {},
 		notifiedTabs: new Set<string>(),
+		sessionProfileIds: {},
 
 		addTab(profileId, sessionId, title) {
 			set((state) => {
@@ -81,6 +95,7 @@ export const useTerminalStore = create<TerminalStore>()(
 					activeTabId: tab.id,
 					counter: existing.counter + 1,
 				};
+				state.sessionProfileIds[sessionId] ??= profileId;
 
 				if (getFocusedProfileId() === profileId) {
 					clearProfileActiveTabNotification(state, profileId);
@@ -98,6 +113,7 @@ export const useTerminalStore = create<TerminalStore>()(
 
 				const idx = profile.tabs.findIndex((t) => t.id === tabId);
 				profile.tabs = profile.tabs.filter((t) => t.id !== tabId);
+				refreshSessionProfileId(state, tabId);
 
 				if (profile.tabs.length === 0) {
 					delete state.profiles[profileId];
@@ -128,6 +144,9 @@ export const useTerminalStore = create<TerminalStore>()(
 				const profile = state.profiles[profileId];
 				profile?.tabs.forEach((tab) => state.notifiedTabs.delete(tab.id));
 				delete state.profiles[profileId];
+				profile?.tabs.forEach((tab) =>
+					refreshSessionProfileId(state, tab.id),
+				);
 			});
 		},
 
@@ -147,7 +166,13 @@ export const useTerminalStore = create<TerminalStore>()(
 						state.profiles[id].tabs.forEach((tab) =>
 							state.notifiedTabs.delete(tab.id),
 						);
+						const removedSessionIds = state.profiles[id].tabs.map(
+							(tab) => tab.id,
+						);
 						delete state.profiles[id];
+						removedSessionIds.forEach((sessionId) =>
+							refreshSessionProfileId(state, sessionId),
+						);
 					}
 				}
 			});
@@ -155,10 +180,7 @@ export const useTerminalStore = create<TerminalStore>()(
 
 		markNotified(sessionId) {
 			set((state) => {
-				const profileId = findProfileIdBySessionId(
-					state.profiles,
-					sessionId,
-				);
+				const profileId = state.sessionProfileIds[sessionId] ?? null;
 				if (
 					profileId &&
 					profileId === getFocusedProfileId() &&


### PR DESCRIPTION
## Stack Context

This is the second PR in the terminal frontend performance stack, on top of #161.

## What?

- Maintains a `sessionId -> profileId` index in the terminal store.
- Uses the index in `markNotified` instead of scanning every profile and tab.
- Adds a Vitest benchmark for notification session lookup.

## Why?

PTY notification events can arrive frequently. The previous lookup scanned all profiles and their tabs for every notification. Maintaining the index shifts that cost to tab lifecycle updates and makes notification lookup constant-time.

## Benchmark

Command:

```bash
bunx vitest bench src/features/terminal/store.bench.ts --run
```

Result on this machine:

```text
session profile index - src/features/terminal/store.bench.ts > terminal notification profile lookup
  1629.91x faster than scan profiles
```

Validation:

```bash
bunx vitest run src/features/terminal/store.test.ts
bunx tsc --noEmit
```

Result: 58 tests passed; TypeScript passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated terminal store test helpers to ensure comprehensive state initialization.

* **Chores**
  * Improved internal terminal session tracking and notification handling for better reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AkaraChen/2code/pull/167)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->