### PR TITLE
perf: reuse git diff line stats

### DIFF
--- a/src/features/git/components/GitDiffPane.tsx
+++ b/src/features/git/components/GitDiffPane.tsx
@@ -19,7 +19,6 @@ import {
 	GIT_DIFF_LARGE_FILE_LINE_THRESHOLD,
 	getLineStats,
 	isBinaryImageDiffPreviewable,
-	isLargeGitDiffFile,
 } from "../utils";
 import { BinaryImageDiffPreview, type GitPreviewContext } from "./GitBinaryPreview";
 
@@ -181,7 +180,7 @@ function ActiveGitDiffFilePane({
 		previewContext != null && isBinaryImageDiffPreviewable(activeFile);
 	const showLargeDiffGuardrail =
 		!showBinaryPreview &&
-		isLargeGitDiffFile(activeFile) &&
+		changedLineCount >= GIT_DIFF_LARGE_FILE_LINE_THRESHOLD &&
 		!isLargeDiffExpanded;
 	const showRenameOnlyDiff = activeFile.type === "rename-pure";
 


### PR DESCRIPTION
## Stack Context

This PR is an independent git diff rendering performance optimization.

## What?

- Reuses already computed line stats in `ActiveGitDiffFilePane` when deciding whether to show the large-diff guardrail.
- Adds a Vitest benchmark for the old duplicate scan path vs the reused stats path.

## Why?

Rendering an active diff file already scans hunks to compute additions and deletions for the header. Calling `isLargeGitDiffFile(activeFile)` immediately after scanned the same hunks again. The guardrail can use the existing `changedLineCount` directly.

## Benchmark

Command:

```bash
bunx vitest bench src/features/git/utils.bench.ts --run
```

Result on this machine:

```text
reuse line stats - src/features/git/utils.bench.ts > git diff line stats guardrail
  2.07x faster than duplicate stats scan
```

Validation:

```bash
bunx vitest run src/features/git/utils.test.ts src/features/git/components/GitDiffPane.test.tsx
bunx tsc --noEmit
```

Result: 40 tests passed; TypeScript passed.
