### PR TITLE
perf: optimize git image extension lookup

### DIFF
--- a/src/features/git/imageExtension.bench.ts
+++ b/src/features/git/imageExtension.bench.ts
@@ -1,0 +1,58 @@
+import { bench, describe } from "vitest";
+import { getPreviewableImageMimeType } from "./utils";
+
+const fileNames = Array.from({ length: 100_000 }, (_, index) =>
+	`src/path.with.dots/file-${index}.preview.${index % 2 === 0 ? "PNG" : "txt"}`,
+);
+const previewableImageMimeTypes: Record<string, string> = {
+	png: "image/png",
+	txt: "text/plain",
+};
+
+function splitExtension(fileName: string) {
+	const extension = fileName.split(".").pop()?.toLowerCase();
+	if (!extension) return null;
+	return previewableImageMimeTypes[extension] ?? null;
+}
+
+function lastIndexExtension(fileName: string) {
+	const extensionStart = fileName.lastIndexOf(".");
+	if (extensionStart < 0 || extensionStart === fileName.length - 1) {
+		return null;
+	}
+
+	const extension = fileName.slice(extensionStart + 1).toLowerCase();
+	return previewableImageMimeTypes[extension] ?? null;
+}
+
+describe("git image extension lookup", () => {
+	bench("split extension", () => {
+		let count = 0;
+		for (const fileName of fileNames) {
+			if (splitExtension(fileName)) count++;
+		}
+		if (count !== fileNames.length) {
+			throw new Error("split extension missed extensions");
+		}
+	});
+
+	bench("lastIndexOf extension", () => {
+		let count = 0;
+		for (const fileName of fileNames) {
+			if (lastIndexExtension(fileName)) count++;
+		}
+		if (count !== fileNames.length) {
+			throw new Error("lastIndexOf extension missed extensions");
+		}
+	});
+
+	bench("production lookup", () => {
+		let count = 0;
+		for (const fileName of fileNames) {
+			if (getPreviewableImageMimeType(fileName)) count++;
+		}
+		if (count !== fileNames.length / 2) {
+			throw new Error("production lookup returned wrong image count");
+		}
+	});
+});

--- a/src/features/git/utils.ts
+++ b/src/features/git/utils.ts
@@ -68,11 +68,12 @@ export function isLargeGitDiffFile(
 }
 
 export function getPreviewableImageMimeType(fileName: string) {
-	const extension = fileName.split(".").pop()?.toLowerCase();
-	if (!extension) {
+	const extensionStart = fileName.lastIndexOf(".");
+	if (extensionStart < 0 || extensionStart === fileName.length - 1) {
 		return null;
 	}
 
+	const extension = fileName.slice(extensionStart + 1).toLowerCase();
 	return previewableImageMimeTypes[extension] ?? null;
 }
 


### PR DESCRIPTION
## Stack Context

This PR is an independent git utility performance optimization.

## What?

- Replaces `split(".").pop()` extension extraction with `lastIndexOf` + `slice` in image preview MIME lookup.
- Adds a Vitest benchmark for extension extraction paths.

## Why?

Binary image preview checks only need the final extension. `split` allocates an array of every path segment separated by dots, which is avoidable for paths with dotted directories or filenames.

## Benchmark

Command:

```bash
bunx vitest bench src/features/git/imageExtension.bench.ts --run
```

Result on this machine:

```text
lastIndexOf extension - src/features/git/imageExtension.bench.ts > git image extension lookup
  2.84x faster than split extension
```

Validation:

```bash
bunx vitest run src/features/git/utils.test.ts
bunx tsc --noEmit
```

Result: 36 tests passed; TypeScript passed.
