### PR TITLE
perf: optimize language extension detection

### DIFF
--- a/src/features/projects/FileViewerDialog.tsx
+++ b/src/features/projects/FileViewerDialog.tsx
@@ -10,76 +10,9 @@ import {
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { useTerminalSettingsStore } from "@/features/settings/stores/terminalSettingsStore";
 import { useTerminalThemeId } from "@/features/terminal/hooks";
+import { detectLanguage } from "@/shared/lib/languageDetection";
 import { getPrismTheme } from "./prismThemes";
 import { useFileContent } from "./hooks";
-
-// Map file extension to Prism language identifier
-function detectLanguage(filename: string): string {
-	const ext = filename.split(".").pop()?.toLowerCase() ?? "";
-	const map: Record<string, string> = {
-		ts: "typescript",
-		tsx: "tsx",
-		js: "javascript",
-		jsx: "jsx",
-		rs: "rust",
-		py: "python",
-		rb: "ruby",
-		go: "go",
-		java: "java",
-		kt: "kotlin",
-		swift: "swift",
-		c: "c",
-		cpp: "cpp",
-		cc: "cpp",
-		h: "c",
-		cs: "csharp",
-		sh: "bash",
-		zsh: "bash",
-		fish: "bash",
-		toml: "toml",
-		yaml: "yaml",
-		yml: "yaml",
-		json: "json",
-		md: "markdown",
-		mdx: "markdown",
-		html: "html",
-		css: "css",
-		scss: "scss",
-		sass: "scss",
-		sql: "sql",
-		graphql: "graphql",
-		gql: "graphql",
-		xml: "xml",
-		dockerfile: "docker",
-		tf: "hcl",
-		hcl: "hcl",
-		lua: "lua",
-		php: "php",
-		r: "r",
-		ex: "elixir",
-		exs: "elixir",
-		erl: "erlang",
-		hs: "haskell",
-		elm: "elm",
-		clj: "clojure",
-		cljs: "clojure",
-		vue: "markup",
-		svelte: "markup",
-		dart: "dart",
-		proto: "protobuf",
-	};
-	// Also handle files with no extension but known names
-	const baseName = filename.toLowerCase();
-	const nameMap: Record<string, string> = {
-		dockerfile: "docker",
-		makefile: "makefile",
-		"justfile": "makefile",
-		".env": "bash",
-		".gitignore": "bash",
-		".gitattributes": "bash",
-	};
-	return nameMap[baseName] ?? map[ext] ?? "text";
-}
 
 interface FileViewerDialogProps {
 	filePath: string | null;

--- a/src/shared/lib/languageDetection.bench.ts
+++ b/src/shared/lib/languageDetection.bench.ts
@@ -1,0 +1,64 @@
+import { bench, describe } from "vitest";
+import { detectLanguage } from "./languageDetection";
+
+const filenames = Array.from({ length: 100_000 }, (_, index) =>
+	index % 10 === 0
+		? "Dockerfile"
+		: `src/path.with.dots/file-${index}.component.${index % 2 === 0 ? "TSX" : "md"}`,
+);
+const extMap: Record<string, string> = {
+	dockerfile: "docker",
+	md: "markdown",
+	tsx: "tsx",
+};
+const nameMap: Record<string, string> = {
+	dockerfile: "docker",
+};
+
+function splitDetectLanguage(filename: string) {
+	const ext = filename.split(".").pop()?.toLowerCase() ?? "";
+	const baseName = filename.toLowerCase();
+	return nameMap[baseName] ?? extMap[ext] ?? "text";
+}
+
+function lastIndexDetectLanguage(filename: string) {
+	const extensionStart = filename.lastIndexOf(".");
+	const ext =
+		extensionStart >= 0 && extensionStart < filename.length - 1
+			? filename.slice(extensionStart + 1).toLowerCase()
+			: "";
+	const baseName = filename.toLowerCase();
+	return nameMap[baseName] ?? extMap[ext] ?? "text";
+}
+
+describe("language detection extension lookup", () => {
+	bench("split extension", () => {
+		let typed = 0;
+		for (const filename of filenames) {
+			if (splitDetectLanguage(filename) !== "text") typed++;
+		}
+		if (typed !== filenames.length) {
+			throw new Error("split detection missed languages");
+		}
+	});
+
+	bench("lastIndexOf extension", () => {
+		let typed = 0;
+		for (const filename of filenames) {
+			if (lastIndexDetectLanguage(filename) !== "text") typed++;
+		}
+		if (typed !== filenames.length) {
+			throw new Error("lastIndexOf detection missed languages");
+		}
+	});
+
+	bench("production detection", () => {
+		let typed = 0;
+		for (const filename of filenames) {
+			if (detectLanguage(filename) !== "text") typed++;
+		}
+		if (typed !== filenames.length) {
+			throw new Error("production detection missed languages");
+		}
+	});
+});

--- a/src/shared/lib/languageDetection.ts
+++ b/src/shared/lib/languageDetection.ts
@@ -67,7 +67,11 @@ const NAME_MAP: Record<string, string> = {
 };
 
 export function detectLanguage(filename: string): string {
-	const ext = filename.split(".").pop()?.toLowerCase() ?? "";
+	const extensionStart = filename.lastIndexOf(".");
+	const ext =
+		extensionStart >= 0 && extensionStart < filename.length - 1
+			? filename.slice(extensionStart + 1).toLowerCase()
+			: "";
 	const baseName = filename.toLowerCase();
 	return NAME_MAP[baseName] ?? EXT_MAP[ext] ?? "text";
 }


### PR DESCRIPTION
## Stack Context

This PR is an independent shared language detection performance and cleanup change.

## What?

- Uses `lastIndexOf` + `slice` instead of `split(".").pop()` for extension parsing in shared language detection.
- Reuses shared `detectLanguage` in `FileViewerDialog` instead of maintaining a duplicate extension map.
- Adds a Vitest benchmark for language extension detection.

## Why?

Language detection only needs the final extension. `split` allocates all dot-separated segments, which is avoidable for dotted paths. Reusing the shared detector also removes duplicate code from the file viewer dialog.

## Benchmark

Command:

```bash
bunx vitest bench src/shared/lib/languageDetection.bench.ts --run
```

Result on this machine:

```text
production detection - src/shared/lib/languageDetection.bench.ts > language detection extension lookup
  1.39x faster than split extension
```

Validation:

```bash
bunx vitest run src/shared/lib/locale.test.ts src/features/projects/FileViewerPane.test.tsx
bunx tsc --noEmit
```

Result: 6 tests passed; TypeScript passed.
