### PR TITLE
perf: pretrim debug log buffer

### DIFF
--- a/src/features/debug/debugLogStore.bench.ts
+++ b/src/features/debug/debugLogStore.bench.ts
@@ -1,0 +1,37 @@
+import { bench, describe } from "vitest";
+
+const MAX_LOGS = 1_000;
+const entries = Array.from({ length: 100_000 }, (_, timestamp) => ({
+	timestamp,
+	level: "info",
+	source: "bench",
+	message: `log ${timestamp}`,
+}));
+
+describe("debug log trimming", () => {
+	bench("push then trim", () => {
+		const logs: typeof entries = [];
+		for (const entry of entries) {
+			logs.push(entry);
+			if (logs.length > MAX_LOGS) {
+				logs.splice(0, logs.length - MAX_LOGS);
+			}
+		}
+		if (logs.length !== MAX_LOGS) {
+			throw new Error("push-then-trim kept wrong log count");
+		}
+	});
+
+	bench("trim then push", () => {
+		const logs: typeof entries = [];
+		for (const entry of entries) {
+			if (logs.length >= MAX_LOGS) {
+				logs.splice(0, logs.length - MAX_LOGS + 1);
+			}
+			logs.push(entry);
+		}
+		if (logs.length !== MAX_LOGS) {
+			throw new Error("trim-then-push kept wrong log count");
+		}
+	});
+});

--- a/src/features/debug/debugLogStore.ts
+++ b/src/features/debug/debugLogStore.ts
@@ -15,10 +15,10 @@ export const useDebugLogStore = create<DebugLogStore>()(
 		logs: [],
 		addLog: (entry) =>
 			set((state) => {
-				state.logs.push(entry);
-				if (state.logs.length > MAX_LOGS) {
-					state.logs.splice(0, state.logs.length - MAX_LOGS);
+				if (state.logs.length >= MAX_LOGS) {
+					state.logs.splice(0, state.logs.length - MAX_LOGS + 1);
 				}
+				state.logs.push(entry);
 			}),
 		clear: () => set({ logs: [] }),
 	})),


### PR DESCRIPTION
## Stack Context

This PR is an independent debug logging performance optimization.

## What?

- Trims the debug log buffer before pushing a new entry once it is at capacity.
- Adds a Vitest benchmark for the old push-then-trim path vs the new trim-then-push path.

## Why?

When the debug log buffer is full, pushing first temporarily grows the array beyond the cap and then splices it back down. Pretrimming makes room before appending and avoids that temporary overflow.

## Benchmark

Command:

```bash
bunx vitest bench src/features/debug/debugLogStore.bench.ts --run
```

Result on this machine:

```text
trim then push - src/features/debug/debugLogStore.bench.ts > debug log trimming
  1.22x faster than push then trim
```

Validation:

```bash
bunx vitest run src/features/debug/debugLogStore.test.ts
bunx tsc --noEmit
```

Result: 11 tests passed; TypeScript passed.
