### PR TITLE
perf: parse git file list paths once

### DIFF
--- a/src/features/git/components/FileListItem.bench.ts
+++ b/src/features/git/components/FileListItem.bench.ts
@@ -1,0 +1,40 @@
+import { bench, describe } from "vitest";
+import { getFileNameParts } from "./FileListItem";
+
+const fileNames = Array.from({ length: 10_000 }, (_, index) =>
+	index % 5 === 0
+		? `README-${index}.md`
+		: `src/features/git/components/deep/path/FileListItem-${index}.tsx`,
+);
+let sink = 0;
+
+function splitFileNameParts(fileName: string) {
+	const basename = fileName.split("/").pop() ?? fileName;
+	const parentPath = fileName.includes("/")
+		? fileName.split("/").slice(0, -1).join("/")
+		: null;
+
+	return { basename, parentPath };
+}
+
+describe("git file list item path parsing", () => {
+	bench("split path twice", () => {
+		let totalLength = 0;
+		for (const fileName of fileNames) {
+			const parts = splitFileNameParts(fileName);
+			totalLength += parts.basename.length + (parts.parentPath?.length ?? 0);
+		}
+		sink = totalLength;
+		if (sink === Number.NEGATIVE_INFINITY) throw new Error("unreachable");
+	});
+
+	bench("lastIndexOf path once", () => {
+		let totalLength = 0;
+		for (const fileName of fileNames) {
+			const parts = getFileNameParts(fileName);
+			totalLength += parts.basename.length + (parts.parentPath?.length ?? 0);
+		}
+		sink = totalLength;
+		if (sink === Number.NEGATIVE_INFINITY) throw new Error("unreachable");
+	});
+});

--- a/src/features/git/components/FileListItem.test.ts
+++ b/src/features/git/components/FileListItem.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { getFileNameParts } from "./FileListItem";
+
+describe("getFileNameParts", () => {
+	it("returns the full file name when there is no parent path", () => {
+		expect(getFileNameParts("README.md")).toEqual({
+			basename: "README.md",
+			parentPath: null,
+		});
+	});
+
+	it("splits nested paths into parent path and basename", () => {
+		expect(getFileNameParts("src/features/git/utils.ts")).toEqual({
+			basename: "utils.ts",
+			parentPath: "src/features/git",
+		});
+	});
+});

--- a/src/features/git/components/FileListItem.tsx
+++ b/src/features/git/components/FileListItem.tsx
@@ -14,6 +14,18 @@ export interface FileListItemProps {
 	onToggleIncluded?: (included: boolean) => void;
 }
 
+export function getFileNameParts(fileName: string) {
+	const separatorIndex = fileName.lastIndexOf("/");
+	if (separatorIndex === -1) {
+		return { basename: fileName, parentPath: null };
+	}
+
+	return {
+		basename: fileName.slice(separatorIndex + 1),
+		parentPath: fileName.slice(0, separatorIndex),
+	};
+}
+
 export function FileListItem({
 	file,
 	isActive,
@@ -24,11 +36,8 @@ export function FileListItem({
 	onToggleIncluded,
 }: FileListItemProps) {
 	const badge = changeBadge[file.type] ?? changeBadge.change;
-	const basename = file.name.split("/").pop() ?? file.name;
+	const { basename, parentPath } = getFileNameParts(file.name);
 	const effectiveIncluded = isIncluded ?? true;
-	const parentPath = file.name.includes("/")
-		? file.name.split("/").slice(0, -1).join("/")
-		: null;
 
 	return (
 		<HStack


### PR DESCRIPTION
## Summary

- parse git file list item paths with one `lastIndexOf("/")` pass
- avoid the previous double `split("/")` allocation per rendered file row
- add focused unit coverage and a Vitest benchmark for the path parser

## Benchmark

```bash
bunx vitest bench src/features/git/components/FileListItem.bench.ts --run
```

Result:

```text
lastIndexOf path once ... 12.66x faster than split path twice
```

## Validation

```bash
bunx vitest run src/features/git/components/FileListItem.test.ts src/features/git/components/ChangesFileList.test.tsx
bunx tsc --noEmit
```

Result:

```text
Test Files  2 passed (2)
Tests       4 passed (4)
```
