### PR TITLE
perf: streamline sidebar project grouping

### DIFF
--- a/src/layout/AppSidebar.bench.ts
+++ b/src/layout/AppSidebar.bench.ts
@@ -1,0 +1,71 @@
+import type { ProjectGroup, ProjectWithProfiles } from "@/generated";
+import { bench, describe } from "vitest";
+import { groupSidebarProjects } from "./AppSidebar";
+
+const groups: ProjectGroup[] = Array.from({ length: 300 }, (_, index) => ({
+	id: `group-${index}`,
+	name: `Group ${index}`,
+	created_at: "2026-05-15T00:00:00Z",
+}));
+
+const projects: ProjectWithProfiles[] = Array.from(
+	{ length: 10_000 },
+	(_, index) => ({
+		id: `project-${index}`,
+		name: `Project ${index}`,
+		folder: `/repo/project-${index}`,
+		created_at: "2026-05-15T00:00:00Z",
+		group_id:
+			index % 7 === 0
+				? `missing-${index}`
+				: index % 5 === 0
+					? null
+					: `group-${index % groups.length}`,
+		profiles: [],
+	}),
+);
+let sink = 0;
+
+function groupSidebarProjectsWithSet(
+	projectGroups: ProjectGroup[],
+	projects: ProjectWithProfiles[],
+) {
+	const knownGroupIds = new Set(projectGroups.map((group) => group.id));
+	const projectsByGroup = new Map(
+		projectGroups.map((group) => [group.id, [] as ProjectWithProfiles[]]),
+	);
+	const ungroupedProjects: ProjectWithProfiles[] = [];
+
+	for (const project of projects) {
+		const groupId = project.group_id ?? null;
+		if (groupId && knownGroupIds.has(groupId)) {
+			projectsByGroup.get(groupId)?.push(project);
+		} else {
+			ungroupedProjects.push(project);
+		}
+	}
+
+	return {
+		groups: projectGroups
+			.map((group) => ({
+				group,
+				projects: projectsByGroup.get(group.id) ?? [],
+			}))
+			.filter((group) => group.projects.length > 0),
+		ungroupedProjects,
+	};
+}
+
+describe("app sidebar project grouping", () => {
+	bench("set plus map/filter grouping", () => {
+		const result = groupSidebarProjectsWithSet(groups, projects);
+		sink = result.groups.length + result.ungroupedProjects.length;
+		if (sink === Number.NEGATIVE_INFINITY) throw new Error("unreachable");
+	});
+
+	bench("map-only grouping", () => {
+		const result = groupSidebarProjects(groups, projects);
+		sink = result.groups.length + result.ungroupedProjects.length;
+		if (sink === Number.NEGATIVE_INFINITY) throw new Error("unreachable");
+	});
+});

--- a/src/layout/AppSidebar.test.ts
+++ b/src/layout/AppSidebar.test.ts
@@ -1,0 +1,47 @@
+import type { ProjectGroup, ProjectWithProfiles } from "@/generated";
+import { describe, expect, it } from "vitest";
+import { groupSidebarProjects } from "./AppSidebar";
+
+function makeProject(
+	id: string,
+	groupId: string | null,
+): ProjectWithProfiles {
+	return {
+		id,
+		name: id,
+		folder: `/repo/${id}`,
+		created_at: "2026-05-15T00:00:00Z",
+		group_id: groupId,
+		profiles: [],
+	};
+}
+
+const groups: ProjectGroup[] = [
+	{ id: "g1", name: "Group 1", created_at: "2026-05-15T00:00:00Z" },
+	{ id: "g2", name: "Group 2", created_at: "2026-05-15T00:00:00Z" },
+];
+
+describe("groupSidebarProjects", () => {
+	it("groups projects by known group and keeps unknown groups ungrouped", () => {
+		const result = groupSidebarProjects(groups, [
+			makeProject("p1", "g1"),
+			makeProject("p2", null),
+			makeProject("p3", "missing"),
+			makeProject("p4", "g2"),
+		]);
+
+		expect(result.groups).toEqual([
+			{ group: groups[0], projects: [makeProject("p1", "g1")] },
+			{ group: groups[1], projects: [makeProject("p4", "g2")] },
+		]);
+		expect(result.ungroupedProjects).toEqual([
+			makeProject("p2", null),
+			makeProject("p3", "missing"),
+		]);
+	});
+
+	it("omits empty groups", () => {
+		expect(groupSidebarProjects(groups, [makeProject("p1", "g1")]).groups)
+			.toEqual([{ group: groups[0], projects: [makeProject("p1", "g1")] }]);
+	});
+});

--- a/src/layout/AppSidebar.tsx
+++ b/src/layout/AppSidebar.tsx
@@ -4,6 +4,7 @@ import { LayoutGroup } from "motion/react";
 import { useCallback, useMemo, useRef } from "react";
 import { FiFolder, FiHome, FiPlus, FiSettings } from "react-icons/fi";
 import CreateProjectDialog from "@/features/projects/CreateProjectDialog";
+import type { ProjectGroup, ProjectWithProfiles } from "@/generated";
 import { useProjectGroups, useProjects } from "@/features/projects/hooks";
 import * as m from "@/paraglide/messages.js";
 import { SidebarLink } from "@/shared/components/SidebarLink";
@@ -21,6 +22,45 @@ function isMacPlatform() {
 	return /mac/i.test(`${navigator.platform} ${navigator.userAgent}`);
 }
 
+export function groupSidebarProjects(
+	projectGroups: ProjectGroup[],
+	projects: ProjectWithProfiles[],
+) {
+	const projectsByGroup = new Map<string, ProjectWithProfiles[]>();
+	for (const group of projectGroups) {
+		projectsByGroup.set(group.id, []);
+	}
+
+	const ungroupedProjects: ProjectWithProfiles[] = [];
+	for (const project of projects) {
+		const groupId = project.group_id ?? null;
+		if (!groupId) {
+			ungroupedProjects.push(project);
+			continue;
+		}
+
+		const groupProjects = projectsByGroup.get(groupId);
+		if (groupProjects) {
+			groupProjects.push(project);
+		} else {
+			ungroupedProjects.push(project);
+		}
+	}
+
+	const groups: Array<{
+		group: ProjectGroup;
+		projects: ProjectWithProfiles[];
+	}> = [];
+	for (const group of projectGroups) {
+		const groupProjects = projectsByGroup.get(group.id);
+		if (groupProjects && groupProjects.length > 0) {
+			groups.push({ group, projects: groupProjects });
+		}
+	}
+
+	return { groups, ungroupedProjects };
+}
+
 export default function AppSidebar() {
 	const { data: projects } = useProjects();
 	const { data: projectGroups } = useProjectGroups();
@@ -34,32 +74,10 @@ export default function AppSidebar() {
 		max: APP_SIDEBAR_MAX_WIDTH,
 		onChange: setSidebarWidth,
 	});
-	const groupedProjects = useMemo(() => {
-		const knownGroupIds = new Set(projectGroups.map((group) => group.id));
-		const projectsByGroup = new Map(
-			projectGroups.map((group) => [group.id, [] as typeof projects]),
-		);
-		const ungroupedProjects: typeof projects = [];
-
-		for (const project of projects) {
-			const groupId = project.group_id ?? null;
-			if (groupId && knownGroupIds.has(groupId)) {
-				projectsByGroup.get(groupId)?.push(project);
-			} else {
-				ungroupedProjects.push(project);
-			}
-		}
-
-		return {
-			groups: projectGroups
-				.map((group) => ({
-					group,
-					projects: projectsByGroup.get(group.id) ?? [],
-				}))
-				.filter((group) => group.projects.length > 0),
-			ungroupedProjects,
-		};
-	}, [projectGroups, projects]);
+	const groupedProjects = useMemo(
+		() => groupSidebarProjects(projectGroups, projects),
+		[projectGroups, projects],
+	);
 
 	const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
 		if (e.key !== "ArrowUp" && e.key !== "ArrowDown") return;


### PR DESCRIPTION
## Summary

- extract sidebar project grouping into a focused helper
- avoid building a separate known-group `Set`
- avoid `map(...).filter(...)` intermediate grouping arrays

## Benchmark

```bash
bunx vitest bench src/layout/AppSidebar.bench.ts --run
```

Result:

```text
map-only grouping ... 1.98x faster than set plus map/filter grouping
```

## Validation

```bash
bunx vitest run src/layout/AppSidebar.test.ts
bunx tsc --noEmit
```

Result:

```text
Test Files  1 passed (1)
Tests       2 passed (2)
```
