### PR TITLE
perf: splice closed file viewer tabs

### DIFF
--- a/src/features/projects/fileViewerTabsStore.bench.ts
+++ b/src/features/projects/fileViewerTabsStore.bench.ts
@@ -1,0 +1,53 @@
+import { bench, describe } from "vitest";
+import {
+	closeFileViewerTab,
+	type ProfileFileViewerState,
+} from "./fileViewerTabsStore";
+
+const tabs = Array.from({ length: 5_000 }, (_, index) => ({
+	filePath: `/repo/src/file-${index}.ts`,
+	title: `file-${index}.ts`,
+}));
+const targetPath = tabs[3_750].filePath;
+let sink = 0;
+
+function makeProfile(): ProfileFileViewerState {
+	return {
+		tabs: tabs.map((tab) => ({ ...tab })),
+		activeFilePath: targetPath,
+		fileTabActive: true,
+	};
+}
+
+function closeFileViewerTabWithFilter(
+	profile: ProfileFileViewerState,
+	filePath: string,
+) {
+	const idx = profile.tabs.findIndex((t) => t.filePath === filePath);
+	profile.tabs = profile.tabs.filter((t) => t.filePath !== filePath);
+	if (profile.activeFilePath === filePath) {
+		if (profile.tabs.length > 0) {
+			const newIdx = Math.min(idx, profile.tabs.length - 1);
+			profile.activeFilePath = profile.tabs[newIdx].filePath;
+		} else {
+			profile.activeFilePath = null;
+			profile.fileTabActive = false;
+		}
+	}
+}
+
+describe("file viewer tab closing", () => {
+	bench("findIndex plus filter close", () => {
+		const profile = makeProfile();
+		closeFileViewerTabWithFilter(profile, targetPath);
+		sink = profile.tabs.length;
+		if (sink === Number.NEGATIVE_INFINITY) throw new Error("unreachable");
+	});
+
+	bench("findIndex plus splice close", () => {
+		const profile = makeProfile();
+		closeFileViewerTab(profile, targetPath);
+		sink = profile.tabs.length;
+		if (sink === Number.NEGATIVE_INFINITY) throw new Error("unreachable");
+	});
+});

--- a/src/features/projects/fileViewerTabsStore.test.ts
+++ b/src/features/projects/fileViewerTabsStore.test.ts
@@ -78,6 +78,25 @@ describe("fileViewerTabsStore", () => {
 		expect(useFileViewerTabsStore.getState().profiles["profile-1"]).toBeUndefined();
 	});
 
+	it("ignores closing a missing tab", () => {
+		useFileViewerTabsStore.getState().openFile("profile-1", "/repo/src/a.ts");
+
+		useFileViewerTabsStore
+			.getState()
+			.closeTab("profile-1", "/repo/src/missing.ts");
+
+		expect(useFileViewerTabsStore.getState().profiles["profile-1"]).toEqual({
+			tabs: [
+				{
+					filePath: "/repo/src/a.ts",
+					title: "a.ts",
+				},
+			],
+			activeFilePath: "/repo/src/a.ts",
+			fileTabActive: true,
+		});
+	});
+
 	it("tracks dirty file tabs and clears dirty state when a tab closes", () => {
 		useFileViewerTabsStore.getState().openFile("profile-1", "/repo/src/a.ts");
 		useFileViewerDirtyStore

--- a/src/features/projects/fileViewerTabsStore.ts
+++ b/src/features/projects/fileViewerTabsStore.ts
@@ -10,7 +10,7 @@ export interface FileViewerTab {
 	title: string;
 }
 
-interface ProfileFileViewerState {
+export interface ProfileFileViewerState {
 	tabs: FileViewerTab[];
 	activeFilePath: string | null;
 	fileTabActive: boolean;
@@ -61,6 +61,25 @@ export const useFileViewerDirtyStore = create<FileViewerDirtyStore>()(
 	})),
 );
 
+export function closeFileViewerTab(
+	profile: ProfileFileViewerState,
+	filePath: string,
+) {
+	const idx = profile.tabs.findIndex((t) => t.filePath === filePath);
+	if (idx === -1) return;
+
+	profile.tabs.splice(idx, 1);
+	if (profile.activeFilePath === filePath) {
+		if (profile.tabs.length > 0) {
+			const newIdx = Math.min(idx, profile.tabs.length - 1);
+			profile.activeFilePath = profile.tabs[newIdx].filePath;
+		} else {
+			profile.activeFilePath = null;
+			profile.fileTabActive = false;
+		}
+	}
+}
+
 export const useFileViewerTabsStore = create<FileViewerTabsStore>()(
 	persist(
 		immer((set) => ({
@@ -91,21 +110,7 @@ export const useFileViewerTabsStore = create<FileViewerTabsStore>()(
 				set((state) => {
 					const profile = state.profiles[profileId];
 					if (!profile) return;
-					const idx = profile.tabs.findIndex(
-						(t) => t.filePath === filePath,
-					);
-					profile.tabs = profile.tabs.filter(
-						(t) => t.filePath !== filePath,
-					);
-					if (profile.activeFilePath === filePath) {
-						if (profile.tabs.length > 0) {
-							const newIdx = Math.min(idx, profile.tabs.length - 1);
-							profile.activeFilePath = profile.tabs[newIdx].filePath;
-						} else {
-							profile.activeFilePath = null;
-							profile.fileTabActive = false;
-						}
-					}
+					closeFileViewerTab(profile, filePath);
 					if (profile.tabs.length === 0) {
 						delete state.profiles[profileId];
 					}


### PR DESCRIPTION
## Summary

- close file viewer tabs with the already-found index and `splice`
- avoid filtering the whole tab array after `findIndex`
- add no-op coverage for closing a missing file tab
- add a Vitest benchmark for filter vs splice tab closing

## Benchmark

```bash
bunx vitest bench src/features/projects/fileViewerTabsStore.bench.ts --run
```

Result:

```text
findIndex plus splice close ... 1.68x faster than findIndex plus filter close
```

## Validation

```bash
bunx vitest run src/features/projects/fileViewerTabsStore.test.ts
bunx tsc --noEmit
```

Result:

```text
Test Files  1 passed (1)
Tests       7 passed (7)
```
