### PR TITLE
perf: splice dirty file removals

### DIFF
--- a/src/features/projects/fileViewerTabsStore.bench.ts
+++ b/src/features/projects/fileViewerTabsStore.bench.ts
@@ -2,6 +2,7 @@ import { bench, describe } from "vitest";
 import {
 	closeFileViewerTab,
 	type ProfileFileViewerState,
+	updateDirtyFileList,
 } from "./fileViewerTabsStore";
 
 const tabs = Array.from({ length: 5_000 }, (_, index) => ({
@@ -9,6 +10,11 @@ const tabs = Array.from({ length: 5_000 }, (_, index) => ({
 	title: `file-${index}.ts`,
 }));
 const targetPath = tabs[3_750].filePath;
+const dirtyFiles = Array.from(
+	{ length: 5_000 },
+	(_, index) => `/repo/src/file-${index}.ts`,
+);
+const dirtyTargetPath = dirtyFiles[3_750];
 let sink = 0;
 
 function makeProfile(): ProfileFileViewerState {
@@ -36,6 +42,22 @@ function closeFileViewerTabWithFilter(
 	}
 }
 
+function updateDirtyFileListWithFilter(
+	dirtyFiles: string[],
+	filePath: string,
+	isDirty: boolean,
+) {
+	const alreadyDirty = dirtyFiles.includes(filePath);
+
+	if (isDirty) {
+		return alreadyDirty ? dirtyFiles : [...dirtyFiles, filePath];
+	}
+
+	if (!alreadyDirty) return dirtyFiles;
+	const nextDirtyFiles = dirtyFiles.filter((path) => path !== filePath);
+	return nextDirtyFiles.length > 0 ? nextDirtyFiles : null;
+}
+
 describe("file viewer tab closing", () => {
 	bench("findIndex plus filter close", () => {
 		const profile = makeProfile();
@@ -48,6 +70,28 @@ describe("file viewer tab closing", () => {
 		const profile = makeProfile();
 		closeFileViewerTab(profile, targetPath);
 		sink = profile.tabs.length;
+		if (sink === Number.NEGATIVE_INFINITY) throw new Error("unreachable");
+	});
+});
+
+describe("file viewer dirty list updates", () => {
+	bench("includes plus filter dirty removal", () => {
+		const nextDirtyFiles = updateDirtyFileListWithFilter(
+			dirtyFiles,
+			dirtyTargetPath,
+			false,
+		);
+		sink = nextDirtyFiles?.length ?? 0;
+		if (sink === Number.NEGATIVE_INFINITY) throw new Error("unreachable");
+	});
+
+	bench("indexOf plus splice dirty removal", () => {
+		const nextDirtyFiles = updateDirtyFileList(
+			dirtyFiles,
+			dirtyTargetPath,
+			false,
+		);
+		sink = nextDirtyFiles?.length ?? 0;
 		if (sink === Number.NEGATIVE_INFINITY) throw new Error("unreachable");
 	});
 });

--- a/src/features/projects/fileViewerTabsStore.test.ts
+++ b/src/features/projects/fileViewerTabsStore.test.ts
@@ -112,6 +112,20 @@ describe("fileViewerTabsStore", () => {
 		expect(useFileViewerDirtyStore.getState().profiles["profile-1"]).toBeUndefined();
 	});
 
+	it("ignores clearing a file that is not dirty", () => {
+		useFileViewerDirtyStore
+			.getState()
+			.setFileDirty("profile-1", "/repo/src/a.ts", true);
+
+		useFileViewerDirtyStore
+			.getState()
+			.setFileDirty("profile-1", "/repo/src/missing.ts", false);
+
+		expect(useFileViewerDirtyStore.getState().profiles["profile-1"]).toEqual([
+			"/repo/src/a.ts",
+		]);
+	});
+
 	it("switches between file and terminal focus for a profile", () => {
 		useFileViewerTabsStore
 			.getState()

--- a/src/features/projects/fileViewerTabsStore.ts
+++ b/src/features/projects/fileViewerTabsStore.ts
@@ -33,6 +33,25 @@ interface FileViewerDirtyStore {
 	) => void;
 }
 
+export function updateDirtyFileList(
+	dirtyFiles: string[],
+	filePath: string,
+	isDirty: boolean,
+) {
+	const index = dirtyFiles.indexOf(filePath);
+
+	if (isDirty) {
+		return index === -1 ? [...dirtyFiles, filePath] : dirtyFiles;
+	}
+
+	if (index === -1) return dirtyFiles;
+	if (dirtyFiles.length === 1) return null;
+
+	const nextDirtyFiles = [...dirtyFiles];
+	nextDirtyFiles.splice(index, 1);
+	return nextDirtyFiles;
+}
+
 export const useFileViewerDirtyStore = create<FileViewerDirtyStore>()(
 	immer((set) => ({
 		profiles: {},
@@ -40,18 +59,13 @@ export const useFileViewerDirtyStore = create<FileViewerDirtyStore>()(
 		setFileDirty(profileId, filePath, isDirty) {
 			set((state) => {
 				const dirtyFiles = state.profiles[profileId] ?? [];
-				const alreadyDirty = dirtyFiles.includes(filePath);
-
-				if (isDirty) {
-					if (!alreadyDirty) {
-						state.profiles[profileId] = [...dirtyFiles, filePath];
-					}
-					return;
-				}
-
-				if (!alreadyDirty) return;
-				const nextDirtyFiles = dirtyFiles.filter((path) => path !== filePath);
-				if (nextDirtyFiles.length > 0) {
+				const nextDirtyFiles = updateDirtyFileList(
+					dirtyFiles,
+					filePath,
+					isDirty,
+				);
+				if (nextDirtyFiles === dirtyFiles) return;
+				if (nextDirtyFiles) {
 					state.profiles[profileId] = nextDirtyFiles;
 				} else {
 					delete state.profiles[profileId];


### PR DESCRIPTION
## Summary

- update dirty-file removals with `indexOf` plus `splice`
- avoid scanning once for `includes` and again for `filter`
- keep no-op dirty clearing behavior covered by tests
- extend the existing file viewer store benchmark with dirty-list removal cases

## Benchmark

```bash
bunx vitest bench src/features/projects/fileViewerTabsStore.bench.ts --run
```

Result:

```text
indexOf plus splice dirty removal ... 1.76x faster than includes plus filter dirty removal
```

## Validation

```bash
bunx vitest run src/features/projects/fileViewerTabsStore.test.ts
bunx tsc --noEmit
```

Result:

```text
Test Files  1 passed (1)
Tests       8 passed (8)
```
