### PR TITLE
perf: index active topbar controls

### DIFF
--- a/src/features/topbar/AvailableControls.bench.ts
+++ b/src/features/topbar/AvailableControls.bench.ts
@@ -1,0 +1,37 @@
+import { bench, describe } from "vitest";
+import { getAvailableControlIds } from "./AvailableControls";
+import type { ControlId } from "./types";
+
+const supportedControls = Array.from(
+	{ length: 2_000 },
+	(_, index) => `control-${index}` as ControlId,
+);
+const activeControls = supportedControls.filter((_, index) => index % 3 !== 0);
+let sink = 0;
+
+function getAvailableControlIdsWithIncludes(
+	activeControls: readonly ControlId[],
+	supportedControls: readonly ControlId[],
+) {
+	return supportedControls.filter((id) => !activeControls.includes(id));
+}
+
+describe("topbar available controls", () => {
+	bench("filter with includes", () => {
+		const available = getAvailableControlIdsWithIncludes(
+			activeControls,
+			supportedControls,
+		);
+		sink = available.length;
+		if (sink === Number.NEGATIVE_INFINITY) throw new Error("unreachable");
+	});
+
+	bench("filter with active set", () => {
+		const available = getAvailableControlIds(
+			activeControls,
+			supportedControls,
+		);
+		sink = available.length;
+		if (sink === Number.NEGATIVE_INFINITY) throw new Error("unreachable");
+	});
+});

--- a/src/features/topbar/AvailableControls.test.ts
+++ b/src/features/topbar/AvailableControls.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { getAvailableControlIds } from "./AvailableControls";
+import type { ControlId } from "./types";
+
+describe("getAvailableControlIds", () => {
+	it("returns supported controls that are not active", () => {
+		expect(
+			getAvailableControlIds(
+				["github-desktop", "git-diff"] as ControlId[],
+				["pr-status", "git-diff", "reveal-in-finder"] as ControlId[],
+			),
+		).toEqual(["pr-status", "reveal-in-finder"]);
+	});
+
+	it("preserves supported control order", () => {
+		expect(
+			getAvailableControlIds(
+				["git-diff"] as ControlId[],
+				["pr-status", "git-diff", "reveal-in-finder"] as ControlId[],
+			),
+		).toEqual(["pr-status", "reveal-in-finder"]);
+	});
+});

--- a/src/features/topbar/AvailableControls.tsx
+++ b/src/features/topbar/AvailableControls.tsx
@@ -14,13 +14,19 @@ interface AvailableControlsProps {
 	supportedControls: ControlId[];
 }
 
+export function getAvailableControlIds(
+	activeControls: readonly ControlId[],
+	supportedControls: readonly ControlId[],
+) {
+	const activeControlSet = new Set(activeControls);
+	return supportedControls.filter((id) => !activeControlSet.has(id));
+}
+
 export function AvailableControls({
 	activeControls,
 	supportedControls,
 }: AvailableControlsProps) {
-	const available = supportedControls.filter(
-		(id) => !activeControls.includes(id),
-	);
+	const available = getAvailableControlIds(activeControls, supportedControls);
 	const { setNodeRef } = useDroppable({ id: "available-area" });
 
 	return (


### PR DESCRIPTION
## Summary

- compute available topbar controls with an active-control `Set`
- avoid `supportedControls.filter(... activeControls.includes(...))` quadratic scans
- add focused tests for order and exclusion behavior
- add a Vitest benchmark for includes vs set lookup

## Benchmark

```bash
bunx vitest bench src/features/topbar/AvailableControls.bench.ts --run
```

Result:

```text
filter with active set ... 45.88x faster than filter with includes
```

## Validation

```bash
bunx vitest run src/features/topbar/AvailableControls.test.ts
bunx tsc --noEmit
```

Result:

```text
Test Files  1 passed (1)
Tests       2 passed (2)
```
