### PR TITLE
perf: reuse topbar drag indexes

### DIFF
--- a/src/features/topbar/TopBarSettings.bench.ts
+++ b/src/features/topbar/TopBarSettings.bench.ts
@@ -1,0 +1,74 @@
+import { arrayMove } from "@dnd-kit/sortable";
+import { bench, describe } from "vitest";
+import { getNextTopbarControlsAfterDrag } from "./TopBarSettings";
+import type { ControlId } from "./types";
+
+const visibleActiveControls = Array.from(
+	{ length: 2_000 },
+	(_, index) => `control-${index}` as ControlId,
+);
+const activeControlId = visibleActiveControls[1_650];
+const overControlId = visibleActiveControls[120];
+let sink = 0;
+
+function getNextTopbarControlsAfterDragWithIncludes(
+	visibleActiveControls: ControlId[],
+	activeControlId: ControlId,
+	overControlId: string,
+) {
+	const isActiveInPreview = visibleActiveControls.includes(activeControlId);
+	const isOverPreviewArea =
+		overControlId === "preview-area" ||
+		visibleActiveControls.includes(overControlId as ControlId);
+	const isOverAvailableArea =
+		overControlId === "available-area" ||
+		(!visibleActiveControls.includes(overControlId as ControlId) &&
+			overControlId !== "preview-area");
+
+	if (isActiveInPreview && isOverPreviewArea) {
+		if (activeControlId === overControlId) return null;
+		const oldIndex = visibleActiveControls.indexOf(activeControlId);
+		const newIndex = visibleActiveControls.indexOf(
+			overControlId as ControlId,
+		);
+		if (newIndex !== -1) {
+			return arrayMove(visibleActiveControls, oldIndex, newIndex);
+		}
+	} else if (isActiveInPreview && isOverAvailableArea) {
+		return visibleActiveControls.filter((id) => id !== activeControlId);
+	} else if (!isActiveInPreview && isOverPreviewArea) {
+		if (overControlId === "preview-area") {
+			return [...visibleActiveControls, activeControlId];
+		}
+		const overIndex = visibleActiveControls.indexOf(
+			overControlId as ControlId,
+		);
+		const newList = [...visibleActiveControls];
+		newList.splice(overIndex, 0, activeControlId);
+		return newList;
+	}
+
+	return null;
+}
+
+describe("topbar drag result", () => {
+	bench("includes/indexOf drag result", () => {
+		const nextControls = getNextTopbarControlsAfterDragWithIncludes(
+			visibleActiveControls,
+			activeControlId,
+			overControlId,
+		);
+		sink = nextControls?.length ?? 0;
+		if (sink === Number.NEGATIVE_INFINITY) throw new Error("unreachable");
+	});
+
+	bench("reused index drag result", () => {
+		const nextControls = getNextTopbarControlsAfterDrag(
+			visibleActiveControls,
+			activeControlId,
+			overControlId,
+		);
+		sink = nextControls?.length ?? 0;
+		if (sink === Number.NEGATIVE_INFINITY) throw new Error("unreachable");
+	});
+});

--- a/src/features/topbar/TopBarSettings.test.ts
+++ b/src/features/topbar/TopBarSettings.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { getNextTopbarControlsAfterDrag } from "./TopBarSettings";
+import type { ControlId } from "./types";
+
+describe("getNextTopbarControlsAfterDrag", () => {
+	const controls: ControlId[] = ["github-desktop", "vscode", "git-diff"];
+
+	it("reorders active controls", () => {
+		expect(
+			getNextTopbarControlsAfterDrag(controls, "git-diff", "github-desktop"),
+		).toEqual(["git-diff", "github-desktop", "vscode"]);
+	});
+
+	it("removes active controls dropped into available controls", () => {
+		expect(
+			getNextTopbarControlsAfterDrag(controls, "vscode", "available-area"),
+		).toEqual(["github-desktop", "git-diff"]);
+	});
+
+	it("adds inactive controls into the preview area", () => {
+		expect(
+			getNextTopbarControlsAfterDrag(controls, "pr-status", "preview-area"),
+		).toEqual(["github-desktop", "vscode", "git-diff", "pr-status"]);
+	});
+
+	it("returns null when nothing changes", () => {
+		expect(
+			getNextTopbarControlsAfterDrag(controls, "vscode", "vscode"),
+		).toBeNull();
+	});
+});

--- a/src/features/topbar/TopBarSettings.tsx
+++ b/src/features/topbar/TopBarSettings.tsx
@@ -21,6 +21,47 @@ import { useTopBarStore } from "./store";
 import { TopBarPreview } from "./TopBarPreview";
 import type { ControlId } from "./types";
 
+export function getNextTopbarControlsAfterDrag(
+	visibleActiveControls: ControlId[],
+	activeControlId: ControlId,
+	overControlId: string,
+) {
+	const activeIndex = visibleActiveControls.indexOf(activeControlId);
+	const overIndex =
+		overControlId === "preview-area" || overControlId === "available-area"
+			? -1
+			: visibleActiveControls.indexOf(overControlId as ControlId);
+	const isActiveInPreview = activeIndex !== -1;
+	const isOverPreviewArea =
+		overControlId === "preview-area" || overIndex !== -1;
+	const isOverAvailableArea =
+		overControlId === "available-area" ||
+		(overIndex === -1 && overControlId !== "preview-area");
+
+	if (isActiveInPreview && isOverPreviewArea) {
+		if (activeControlId === overControlId || overIndex === -1) {
+			return null;
+		}
+		return arrayMove(visibleActiveControls, activeIndex, overIndex);
+	}
+
+	if (isActiveInPreview && isOverAvailableArea) {
+		return visibleActiveControls.filter((id) => id !== activeControlId);
+	}
+
+	if (!isActiveInPreview && isOverPreviewArea) {
+		if (overControlId === "preview-area") {
+			return [...visibleActiveControls, activeControlId];
+		}
+
+		const nextControls = [...visibleActiveControls];
+		nextControls.splice(overIndex, 0, activeControlId);
+		return nextControls;
+	}
+
+	return null;
+}
+
 export function TopBarSettings() {
 	const activeControls = useTopBarStore((s) => s.activeControls);
 	const setActiveControls = useTopBarStore((s) => s.setActiveControls);
@@ -77,46 +118,12 @@ export function TopBarSettings() {
 
 		const activeControlId = active.id as ControlId;
 		const overControlId = over.id as string;
-		const isActiveInPreview =
-			visibleActiveControls.includes(activeControlId);
-		const isOverPreviewArea =
-			overControlId === "preview-area" ||
-			visibleActiveControls.includes(overControlId as ControlId);
-		const isOverAvailableArea =
-			overControlId === "available-area" ||
-			(!visibleActiveControls.includes(overControlId as ControlId) &&
-				overControlId !== "preview-area");
-
-		if (isActiveInPreview && isOverPreviewArea) {
-			// Reorder within preview
-			if (activeControlId === overControlId) return;
-			const oldIndex = visibleActiveControls.indexOf(activeControlId);
-			const newIndex = visibleActiveControls.indexOf(
-				overControlId as ControlId,
-			);
-			if (newIndex !== -1) {
-				setActiveControls(
-					arrayMove(visibleActiveControls, oldIndex, newIndex),
-				);
-			}
-		} else if (isActiveInPreview && isOverAvailableArea) {
-			// Remove from preview
-			setActiveControls(
-				visibleActiveControls.filter((id) => id !== activeControlId),
-			);
-		} else if (!isActiveInPreview && isOverPreviewArea) {
-			// Add to preview
-			if (overControlId === "preview-area") {
-				setActiveControls([...visibleActiveControls, activeControlId]);
-			} else {
-				const overIndex = visibleActiveControls.indexOf(
-					overControlId as ControlId,
-				);
-				const newList = [...visibleActiveControls];
-				newList.splice(overIndex, 0, activeControlId);
-				setActiveControls(newList);
-			}
-		}
+		const nextControls = getNextTopbarControlsAfterDrag(
+			visibleActiveControls,
+			activeControlId,
+			overControlId,
+		);
+		if (nextControls) setActiveControls(nextControls);
 	}
 
 	const activeDef = activeId ? controlRegistry.get(activeId) : null;


### PR DESCRIPTION
## Summary

- compute topbar drag outcomes with reusable active/over indexes
- avoid repeated `includes`/`indexOf` scans during drag-end handling
- extract the drag result logic into a tested pure helper
- add a Vitest benchmark for old repeated scans vs reused indexes

## Benchmark

```bash
bunx vitest bench src/features/topbar/TopBarSettings.bench.ts --run
```

Result:

```text
reused index drag result ... 2.18x faster than includes/indexOf drag result
```

## Validation

```bash
bunx vitest run src/features/topbar/TopBarSettings.test.ts
bunx tsc --noEmit
```

Result:

```text
Test Files  1 passed (1)
Tests       4 passed (4)
```
