### PR TITLE
perf: splice collapsed sidebar groups

### DIFF
--- a/src/layout/sidebarStore.bench.ts
+++ b/src/layout/sidebarStore.bench.ts
@@ -1,0 +1,39 @@
+import { bench, describe } from "vitest";
+import { toggleCollapsedProjectGroupId } from "./sidebarStore";
+
+const collapsedProjectGroupIds = Array.from(
+	{ length: 10_000 },
+	(_, index) => `group-${index}`,
+);
+const targetGroupId = collapsedProjectGroupIds[7_500];
+let sink = 0;
+
+function toggleCollapsedProjectGroupIdWithFilter(
+	collapsedProjectGroupIds: readonly string[],
+	groupId: string,
+) {
+	const collapsed = collapsedProjectGroupIds.includes(groupId);
+	return collapsed
+		? collapsedProjectGroupIds.filter((id) => id !== groupId)
+		: [...collapsedProjectGroupIds, groupId];
+}
+
+describe("sidebar collapsed project group toggles", () => {
+	bench("includes plus filter toggle", () => {
+		const nextIds = toggleCollapsedProjectGroupIdWithFilter(
+			collapsedProjectGroupIds,
+			targetGroupId,
+		);
+		sink = nextIds.length;
+		if (sink === Number.NEGATIVE_INFINITY) throw new Error("unreachable");
+	});
+
+	bench("indexOf plus splice toggle", () => {
+		const nextIds = toggleCollapsedProjectGroupId(
+			collapsedProjectGroupIds,
+			targetGroupId,
+		);
+		sink = nextIds.length;
+		if (sink === Number.NEGATIVE_INFINITY) throw new Error("unreachable");
+	});
+});

--- a/src/layout/sidebarStore.test.ts
+++ b/src/layout/sidebarStore.test.ts
@@ -3,6 +3,7 @@ import {
 	APP_SIDEBAR_DEFAULT_WIDTH,
 	APP_SIDEBAR_MAX_WIDTH,
 	APP_SIDEBAR_MIN_WIDTH,
+	toggleCollapsedProjectGroupId,
 	useAppSidebarStore,
 } from "./sidebarStore";
 
@@ -48,5 +49,17 @@ describe("useAppSidebarStore", () => {
 
 		getState().toggleProjectGroup("group-1");
 		expect(getState().collapsedProjectGroupIds).toEqual([]);
+	});
+
+	it("toggles collapsed project group ids without changing order", () => {
+		expect(toggleCollapsedProjectGroupId(["a", "b", "c"], "b")).toEqual([
+			"a",
+			"c",
+		]);
+		expect(toggleCollapsedProjectGroupId(["a", "c"], "b")).toEqual([
+			"a",
+			"c",
+			"b",
+		]);
 	});
 });

--- a/src/layout/sidebarStore.ts
+++ b/src/layout/sidebarStore.ts
@@ -12,6 +12,20 @@ export function clampAppSidebarWidth(width: number) {
 	);
 }
 
+export function toggleCollapsedProjectGroupId(
+	collapsedProjectGroupIds: readonly string[],
+	groupId: string,
+) {
+	const index = collapsedProjectGroupIds.indexOf(groupId);
+	if (index === -1) {
+		return [...collapsedProjectGroupIds, groupId];
+	}
+
+	const nextIds = [...collapsedProjectGroupIds];
+	nextIds.splice(index, 1);
+	return nextIds;
+}
+
 interface AppSidebarStore {
 	width: number;
 	collapsedProjectGroupIds: string[];
@@ -26,17 +40,12 @@ export const useAppSidebarStore = create<AppSidebarStore>()(
 			collapsedProjectGroupIds: [],
 			setWidth: (width) => set({ width: clampAppSidebarWidth(width) }),
 			toggleProjectGroup: (groupId) =>
-				set((state) => {
-					const collapsed =
-						state.collapsedProjectGroupIds.includes(groupId);
-					return {
-						collapsedProjectGroupIds: collapsed
-							? state.collapsedProjectGroupIds.filter(
-									(id) => id !== groupId,
-								)
-							: [...state.collapsedProjectGroupIds, groupId],
-					};
-				}),
+				set((state) => ({
+					collapsedProjectGroupIds: toggleCollapsedProjectGroupId(
+						state.collapsedProjectGroupIds,
+						groupId,
+					),
+				})),
 		}),
 		{
 			name: "app-sidebar-width",


### PR DESCRIPTION
## Summary

- toggle collapsed sidebar group ids with one `indexOf` lookup
- remove collapsed ids via `splice` instead of `includes` plus `filter`
- add focused order-preservation coverage
- add a Vitest benchmark for the old and new toggle paths

## Benchmark

```bash
bunx vitest bench src/layout/sidebarStore.bench.ts --run
```

Result:

```text
indexOf plus splice toggle ... 5.29x faster than includes plus filter toggle
```

## Validation

```bash
bunx vitest run src/layout/sidebarStore.test.ts
bunx tsc --noEmit
```

Result:

```text
Test Files  1 passed (1)
Tests       6 passed (6)
```
