### PR TITLE
perf: splice closed terminal tabs

### DIFF
--- a/src/features/terminal/store.bench.ts
+++ b/src/features/terminal/store.bench.ts
@@ -1,0 +1,50 @@
+import { bench, describe } from "vitest";
+import {
+	closeTerminalTab,
+	type ProjectTerminalState,
+} from "./store";
+
+const tabs = Array.from({ length: 5_000 }, (_, index) => ({
+	id: `session-${index}`,
+	title: `Terminal ${index}`,
+}));
+const targetTabId = tabs[3_750].id;
+let sink = 0;
+
+function makeProfile(): ProjectTerminalState {
+	return {
+		tabs: tabs.map((tab) => ({ ...tab })),
+		activeTabId: targetTabId,
+		counter: tabs.length,
+	};
+}
+
+function closeTerminalTabWithFilter(
+	profile: ProjectTerminalState,
+	tabId: string,
+) {
+	const wasActiveTab = tabId === profile.activeTabId;
+	const idx = profile.tabs.findIndex((t) => t.id === tabId);
+	profile.tabs = profile.tabs.filter((t) => t.id !== tabId);
+
+	if (wasActiveTab && profile.tabs.length > 0) {
+		const newIdx = Math.min(idx, profile.tabs.length - 1);
+		profile.activeTabId = profile.tabs[newIdx].id;
+	}
+}
+
+describe("terminal tab closing", () => {
+	bench("findIndex plus filter close", () => {
+		const profile = makeProfile();
+		closeTerminalTabWithFilter(profile, targetTabId);
+		sink = profile.tabs.length;
+		if (sink === Number.NEGATIVE_INFINITY) throw new Error("unreachable");
+	});
+
+	bench("findIndex plus splice close", () => {
+		const profile = makeProfile();
+		closeTerminalTab(profile, targetTabId);
+		sink = profile.tabs.length;
+		if (sink === Number.NEGATIVE_INFINITY) throw new Error("unreachable");
+	});
+});

--- a/src/features/terminal/store.test.ts
+++ b/src/features/terminal/store.test.ts
@@ -142,6 +142,19 @@ describe("useTerminalStore", () => {
 			expect(() => getState().closeTab("nonexistent", "s1")).not.toThrow();
 		});
 
+		it("no-ops when tab does not exist", () => {
+			getState().addTab("p1", "s1", "T1");
+			getState().addTab("p1", "s2", "T2");
+
+			getState().closeTab("p1", "missing");
+
+			expect(getState().profiles.p1.tabs).toEqual([
+				{ id: "s1", title: "T1" },
+				{ id: "s2", title: "T2" },
+			]);
+			expect(getState().profiles.p1.activeTabId).toBe("s2");
+		});
+
 		it("handles closing second tab when active is second of two", () => {
 			// [s1, s2], active=s2, close s2
 			// tabs [s1], Math.min(1, 0)=0, active=s1

--- a/src/features/terminal/store.ts
+++ b/src/features/terminal/store.ts
@@ -6,12 +6,12 @@ import { useShallow } from "zustand/react/shallow";
 
 enableMapSet();
 
-interface TerminalTab {
+export interface TerminalTab {
 	id: string;
 	title: string;
 }
 
-interface ProjectTerminalState {
+export interface ProjectTerminalState {
 	tabs: TerminalTab[];
 	activeTabId: string | null;
 	counter: number;
@@ -46,6 +46,21 @@ function clearProfileActiveTabNotification(
 	const activeTabId = state.profiles[profileId]?.activeTabId;
 	if (activeTabId) {
 		state.notifiedTabs.delete(activeTabId);
+	}
+}
+
+export function closeTerminalTab(
+	profile: ProjectTerminalState,
+	tabId: string,
+) {
+	const wasActiveTab = tabId === profile.activeTabId;
+	const idx = profile.tabs.findIndex((t) => t.id === tabId);
+	if (idx === -1) return;
+
+	profile.tabs.splice(idx, 1);
+	if (wasActiveTab && profile.tabs.length > 0) {
+		const newIdx = Math.min(idx, profile.tabs.length - 1);
+		profile.activeTabId = profile.tabs[newIdx].id;
 	}
 }
 
@@ -95,9 +110,7 @@ export const useTerminalStore = create<TerminalStore>()(
 				const wasActiveTab = tabId === profile.activeTabId;
 
 				state.notifiedTabs.delete(tabId);
-
-				const idx = profile.tabs.findIndex((t) => t.id === tabId);
-				profile.tabs = profile.tabs.filter((t) => t.id !== tabId);
+				closeTerminalTab(profile, tabId);
 
 				if (profile.tabs.length === 0) {
 					delete state.profiles[profileId];
@@ -105,8 +118,6 @@ export const useTerminalStore = create<TerminalStore>()(
 				}
 
 				if (wasActiveTab) {
-					const newIdx = Math.min(idx, profile.tabs.length - 1);
-					profile.activeTabId = profile.tabs[newIdx].id;
 					if (getFocusedProfileId() === profileId) {
 						clearProfileActiveTabNotification(state, profileId);
 					}


### PR DESCRIPTION
## Summary

- close terminal tabs with the already-found index and `splice`
- avoid filtering the whole tab array after `findIndex`
- preserve active-tab reassignment behavior
- add no-op coverage for closing a missing tab
- add a Vitest benchmark for filter vs splice tab closing

## Benchmark

```bash
bunx vitest bench src/features/terminal/store.bench.ts --run
```

Result:

```text
findIndex plus splice close ... 1.62x faster than findIndex plus filter close
```

## Validation

```bash
bunx vitest run src/features/terminal/store.test.ts
bunx tsc --noEmit
```

Result:

```text
Test Files  1 passed (1)
Tests       59 passed (59)
```
