### PR TITLE
perf: split sidebar profiles once

### DIFF
--- a/src/layout/sidebar/ProjectMenuItem.bench.ts
+++ b/src/layout/sidebar/ProjectMenuItem.bench.ts
@@ -1,0 +1,33 @@
+import { bench, describe } from "vitest";
+import { splitDefaultProfile } from "./ProjectMenuItem";
+
+const profiles = Array.from({ length: 10_000 }, (_, index) => ({
+	id: `profile-${index}`,
+	is_default: index === 5_000,
+}));
+let sink = 0;
+
+function splitDefaultProfileWithFindFilter<
+	TProfile extends { is_default: boolean },
+>(profiles: readonly TProfile[]) {
+	return {
+		defaultProfile: profiles.find((profile) => profile.is_default),
+		nonDefaultProfiles: profiles.filter((profile) => !profile.is_default),
+	};
+}
+
+describe("project menu profile split", () => {
+	bench("find plus filter split", () => {
+		const result = splitDefaultProfileWithFindFilter(profiles);
+		sink =
+			(result.defaultProfile ? 1 : 0) + result.nonDefaultProfiles.length;
+		if (sink === Number.NEGATIVE_INFINITY) throw new Error("unreachable");
+	});
+
+	bench("single pass split", () => {
+		const result = splitDefaultProfile(profiles);
+		sink =
+			(result.defaultProfile ? 1 : 0) + result.nonDefaultProfiles.length;
+		if (sink === Number.NEGATIVE_INFINITY) throw new Error("unreachable");
+	});
+});

--- a/src/layout/sidebar/ProjectMenuItem.test.ts
+++ b/src/layout/sidebar/ProjectMenuItem.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { splitDefaultProfile } from "./ProjectMenuItem";
+
+describe("splitDefaultProfile", () => {
+	it("returns the default profile and preserves non-default order", () => {
+		const defaultProfile = { id: "default", is_default: true };
+		const profiles = [
+			{ id: "one", is_default: false },
+			defaultProfile,
+			{ id: "two", is_default: false },
+		];
+
+		expect(splitDefaultProfile(profiles)).toEqual({
+			defaultProfile,
+			nonDefaultProfiles: [
+				{ id: "one", is_default: false },
+				{ id: "two", is_default: false },
+			],
+		});
+	});
+});

--- a/src/layout/sidebar/ProjectMenuItem.tsx
+++ b/src/layout/sidebar/ProjectMenuItem.tsx
@@ -33,6 +33,23 @@ import { ProfileList } from "./ProfileList";
 import { ProjectAvatar } from "./ProjectAvatar";
 import { ProjectGroupMenu } from "./ProjectGroupMenu";
 
+export function splitDefaultProfile<
+	TProfile extends { is_default: boolean },
+>(profiles: readonly TProfile[]) {
+	let defaultProfile: TProfile | undefined;
+	const nonDefaultProfiles: TProfile[] = [];
+
+	for (const profile of profiles) {
+		if (profile.is_default && !defaultProfile) {
+			defaultProfile = profile;
+		} else {
+			nonDefaultProfiles.push(profile);
+		}
+	}
+
+	return { defaultProfile, nonDefaultProfiles };
+}
+
 export function ProjectMenuItem({
 	project,
 	projectGroups,
@@ -40,12 +57,8 @@ export function ProjectMenuItem({
 	project: ProjectWithProfiles;
 	projectGroups: ProjectGroup[];
 }) {
-	const defaultProfile = useMemo(
-		() => project.profiles.find((p) => p.is_default),
-		[project.profiles],
-	);
-	const nonDefaultProfiles = useMemo(
-		() => project.profiles.filter((p) => !p.is_default),
+	const { defaultProfile, nonDefaultProfiles } = useMemo(
+		() => splitDefaultProfile(project.profiles),
 		[project.profiles],
 	);
 


### PR DESCRIPTION
## Summary

- split default and non-default project profiles in one pass
- avoid separate `find` and `filter` scans during sidebar project rendering
- add focused coverage for the split helper
- add a Vitest benchmark for the old and new split paths

## Benchmark

```bash
bunx vitest bench src/layout/sidebar/ProjectMenuItem.bench.ts --run
```

Result:

```text
single pass split ... 3.71x faster than find plus filter split
```

## Validation

```bash
bunx vitest run src/layout/sidebar/ProjectMenuItem.test.ts
bunx tsc --noEmit
```

Result:

```text
Test Files  1 passed (1)
Tests       1 passed (1)
```
