### PR TITLE
perf: collect topbar app ids once

### DIFF
--- a/src/features/topbar/hooks.bench.ts
+++ b/src/features/topbar/hooks.bench.ts
@@ -1,0 +1,40 @@
+import type { TopbarApp } from "@/generated";
+import { bench, describe } from "vitest";
+import { getSupportedTopbarAppIds } from "./hooks";
+import { isLaunchAppControlId } from "./types";
+
+const appIds = [
+	"github-desktop",
+	"vscode",
+	"windsurf",
+	"cursor",
+	"zed",
+	"sublime-text",
+	"ghostty",
+	"iterm2",
+	"kitty",
+	"warp",
+	"unknown",
+];
+const apps: TopbarApp[] = Array.from({ length: 10_000 }, (_, index) => ({
+	id: appIds[index % appIds.length],
+}));
+let sink = 0;
+
+function getSupportedTopbarAppIdsWithMapFilter(apps: readonly TopbarApp[]) {
+	return apps.map((app) => app.id).filter(isLaunchAppControlId);
+}
+
+describe("topbar supported app ids", () => {
+	bench("map then filter app ids", () => {
+		const ids = getSupportedTopbarAppIdsWithMapFilter(apps);
+		sink = ids.length;
+		if (sink === Number.NEGATIVE_INFINITY) throw new Error("unreachable");
+	});
+
+	bench("single pass app ids", () => {
+		const ids = getSupportedTopbarAppIds(apps);
+		sink = ids.length;
+		if (sink === Number.NEGATIVE_INFINITY) throw new Error("unreachable");
+	});
+});

--- a/src/features/topbar/hooks.test.ts
+++ b/src/features/topbar/hooks.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { getSupportedTopbarAppIds } from "./hooks";
+
+describe("getSupportedTopbarAppIds", () => {
+	it("keeps only launch app control ids in source order", () => {
+		expect(
+			getSupportedTopbarAppIds([
+				{ id: "unknown" },
+				{ id: "vscode" },
+				{ id: "git-diff" },
+				{ id: "cursor" },
+			]),
+		).toEqual(["vscode", "cursor"]);
+	});
+});

--- a/src/features/topbar/hooks.ts
+++ b/src/features/topbar/hooks.ts
@@ -1,14 +1,25 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
+import type { TopbarApp } from "@/generated";
 import { listSupportedTopbarApps, openTopbarApp } from "@/generated";
 import { queryKeys } from "@/shared/lib/queryKeys";
 import { isLaunchAppControlId, type LaunchAppControlId } from "./types";
+
+export function getSupportedTopbarAppIds(apps: readonly TopbarApp[]) {
+	const appIds: LaunchAppControlId[] = [];
+	for (const app of apps) {
+		if (isLaunchAppControlId(app.id)) {
+			appIds.push(app.id);
+		}
+	}
+	return appIds;
+}
 
 export function useSupportedTopbarAppIds() {
 	return useQuery({
 		queryKey: queryKeys.topbar.apps,
 		queryFn: async () => {
 			const apps = await listSupportedTopbarApps();
-			return apps.map((app) => app.id).filter(isLaunchAppControlId);
+			return getSupportedTopbarAppIds(apps);
 		},
 		staleTime: Number.POSITIVE_INFINITY,
 		gcTime: Number.POSITIVE_INFINITY,


### PR DESCRIPTION
## Summary

- collect supported topbar app ids in a single pass
- avoid the intermediate `apps.map(...).filter(...)` array
- add focused coverage for filtering unsupported app ids
- add a Vitest benchmark for map+filter vs single-pass collection

## Benchmark

```bash
bunx vitest bench src/features/topbar/hooks.bench.ts --run
```

Result:

```text
single pass app ids ... 1.17x faster than map then filter app ids
```

## Validation

```bash
bunx vitest run src/features/topbar/hooks.test.ts
bunx tsc --noEmit
```

Result:

```text
Test Files  1 passed (1)
Tests       1 passed (1)
```
