### PR TITLE
perf: parse avatar cache directly

### DIFF
--- a/src/features/projects/projectAvatarCache.bench.ts
+++ b/src/features/projects/projectAvatarCache.bench.ts
@@ -1,0 +1,41 @@
+import { bench, describe } from "vitest";
+import { parseProjectAvatarCache } from "./projectAvatarCache";
+
+const parsed = Object.fromEntries(
+	Array.from({ length: 20_000 }, (_, index) => [
+		`project-${index}`,
+		index % 5 === 0 ? null : `https://example.com/avatar-${index}.png`,
+	]),
+);
+let sink = 0;
+
+function parseProjectAvatarCacheWithEntries(parsed: unknown) {
+	const cache: Record<string, string | null> = {};
+	if (
+		typeof parsed === "object" &&
+		parsed !== null &&
+		!Array.isArray(parsed)
+	) {
+		const entries = Object.entries(parsed);
+		for (const [key, value] of entries) {
+			if (typeof value === "string" || value === null) {
+				cache[key] = value;
+			}
+		}
+	}
+	return cache;
+}
+
+describe("project avatar cache parsing", () => {
+	bench("Object.entries cache parse", () => {
+		const cache = parseProjectAvatarCacheWithEntries(parsed);
+		sink = Object.keys(cache).length;
+		if (sink === Number.NEGATIVE_INFINITY) throw new Error("unreachable");
+	});
+
+	bench("for-in cache parse", () => {
+		const cache = parseProjectAvatarCache(parsed);
+		sink = Object.keys(cache).length;
+		if (sink === Number.NEGATIVE_INFINITY) throw new Error("unreachable");
+	});
+});

--- a/src/features/projects/projectAvatarCache.test.ts
+++ b/src/features/projects/projectAvatarCache.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { parseProjectAvatarCache } from "./projectAvatarCache";
+
+describe("parseProjectAvatarCache", () => {
+	it("keeps string and null avatar values", () => {
+		expect(
+			parseProjectAvatarCache({
+				"project-1": "https://example.com/avatar.png",
+				"project-2": null,
+				"project-3": 42,
+			}),
+		).toEqual({
+			"project-1": "https://example.com/avatar.png",
+			"project-2": null,
+		});
+	});
+
+	it("returns an empty cache for invalid shapes", () => {
+		expect(parseProjectAvatarCache(["invalid"])).toEqual({});
+		expect(parseProjectAvatarCache(null)).toEqual({});
+	});
+});

--- a/src/features/projects/projectAvatarCache.ts
+++ b/src/features/projects/projectAvatarCache.ts
@@ -4,6 +4,26 @@ const PROJECT_AVATAR_CACHE_KEY = "2code.project-avatar-cache";
 
 let inMemoryCache: ProjectAvatarCache | null = null;
 
+export function parseProjectAvatarCache(parsed: unknown): ProjectAvatarCache {
+	const cache: ProjectAvatarCache = {};
+	if (
+		typeof parsed !== "object" ||
+		parsed === null ||
+		Array.isArray(parsed)
+	) {
+		return cache;
+	}
+
+	for (const key in parsed) {
+		const value = parsed[key as keyof typeof parsed];
+		if (typeof value === "string" || value === null) {
+			cache[key] = value;
+		}
+	}
+
+	return cache;
+}
+
 function readCacheFromStorage(): ProjectAvatarCache {
 	if (inMemoryCache !== null) {
 		return inMemoryCache;
@@ -18,18 +38,7 @@ function readCacheFromStorage(): ProjectAvatarCache {
 		}
 
 		const parsed: unknown = JSON.parse(raw);
-		if (
-			typeof parsed === "object" &&
-			parsed !== null &&
-			!Array.isArray(parsed)
-		) {
-			const entries = Object.entries(parsed);
-			for (const [key, value] of entries) {
-				if (typeof value === "string" || value === null) {
-					inMemoryCache[key] = value;
-				}
-			}
-		}
+		inMemoryCache = parseProjectAvatarCache(parsed);
 	} catch {
 		inMemoryCache = {};
 	}


### PR DESCRIPTION
## Summary

- parse persisted project avatar cache with a direct `for...in` loop
- avoid allocating an `Object.entries(...)` array while hydrating the cache
- add focused parser coverage for valid and invalid cache shapes
- add a Vitest benchmark for entries vs direct parsing

## Benchmark

```bash
bunx vitest bench src/features/projects/projectAvatarCache.bench.ts --run
```

Result:

```text
for-in cache parse ... 1.55x faster than Object.entries cache parse
```

## Validation

```bash
bunx vitest run src/features/projects/projectAvatarCache.test.ts
bunx tsc --noEmit
```

Result:

```text
Test Files  1 passed (1)
Tests       2 passed (2)
```
