### PR TITLE
perf: select replacement project once

### DIFF
--- a/src/features/projects/DeleteProjectDialog.bench.ts
+++ b/src/features/projects/DeleteProjectDialog.bench.ts
@@ -1,0 +1,69 @@
+import type { ProjectWithProfiles } from "@/generated";
+import { bench, describe } from "vitest";
+import { getReplacementProject } from "./DeleteProjectDialog";
+
+const projects: ProjectWithProfiles[] = Array.from(
+	{ length: 10_000 },
+	(_, index) => ({
+		id: `project-${index}`,
+		name: `Project ${index}`,
+		folder: `/repo/project-${index}`,
+		created_at: "2026-05-15T00:00:00Z",
+		group_id: null,
+		profiles: [
+			{
+				id: `profile-${index}`,
+				project_id: `project-${index}`,
+				branch_name: "main",
+				worktree_path: `/repo/project-${index}`,
+				created_at: "2026-05-15T00:00:00Z",
+				is_default: true,
+				config: null,
+			},
+		],
+	}),
+);
+const deletedProjectId = "project-7_500".replace("_", "");
+let sink = "";
+
+function getReplacementProjectWithFindFilter(
+	projects: ProjectWithProfiles[],
+	deletedProjectId: string,
+) {
+	const deletedIndex = projects.findIndex(
+		(item) => item.id === deletedProjectId,
+	);
+	const remainingProjects = projects.filter(
+		(item) => item.id !== deletedProjectId,
+	);
+	if (remainingProjects.length === 0) return null;
+
+	const replacementIndex =
+		deletedIndex >= 0
+			? Math.min(deletedIndex, remainingProjects.length - 1)
+			: 0;
+	const replacementProject = remainingProjects[replacementIndex];
+	const replacementProfile =
+		replacementProject.profiles.find((profile) => profile.is_default) ??
+		replacementProject.profiles[0];
+
+	if (!replacementProfile) return null;
+	return { project: replacementProject, profile: replacementProfile };
+}
+
+describe("delete project replacement", () => {
+	bench("findIndex plus filter replacement", () => {
+		const replacement = getReplacementProjectWithFindFilter(
+			projects,
+			deletedProjectId,
+		);
+		sink = replacement?.project.id ?? "";
+		if (sink === "__never__") throw new Error("unreachable");
+	});
+
+	bench("single pass replacement", () => {
+		const replacement = getReplacementProject(projects, deletedProjectId);
+		sink = replacement?.project.id ?? "";
+		if (sink === "__never__") throw new Error("unreachable");
+	});
+});

--- a/src/features/projects/DeleteProjectDialog.test.ts
+++ b/src/features/projects/DeleteProjectDialog.test.ts
@@ -1,0 +1,49 @@
+import type { ProjectWithProfiles } from "@/generated";
+import { describe, expect, it } from "vitest";
+import { getReplacementProject } from "./DeleteProjectDialog";
+
+function makeProject(id: string, profileIds: string[]): ProjectWithProfiles {
+	return {
+		id,
+		name: id,
+		folder: `/repo/${id}`,
+		created_at: "2026-05-15T00:00:00Z",
+		group_id: null,
+		profiles: profileIds.map((profileId, index) => ({
+			id: profileId,
+			project_id: id,
+			branch_name: profileId,
+			worktree_path: `/repo/${id}/${profileId}`,
+			created_at: "2026-05-15T00:00:00Z",
+			is_default: index === 0,
+			config: null,
+		})),
+	};
+}
+
+describe("getReplacementProject", () => {
+	it("selects the next project at the deleted project position", () => {
+		const projects = [
+			makeProject("one", ["one-default"]),
+			makeProject("two", ["two-default"]),
+			makeProject("three", ["three-default"]),
+		];
+
+		expect(getReplacementProject(projects, "two")).toEqual({
+			project: projects[2],
+			profile: projects[2].profiles[0],
+		});
+	});
+
+	it("falls back to the previous project when deleting the last project", () => {
+		const projects = [
+			makeProject("one", ["one-default"]),
+			makeProject("two", ["two-default"]),
+		];
+
+		expect(getReplacementProject(projects, "two")).toEqual({
+			project: projects[0],
+			profile: projects[0].profiles[0],
+		});
+	});
+});

--- a/src/features/projects/DeleteProjectDialog.tsx
+++ b/src/features/projects/DeleteProjectDialog.tsx
@@ -10,12 +10,21 @@ interface DeleteProjectDialogProps {
 	project: { id: string; name: string };
 }
 
-function getReplacementProject(
+export function getReplacementProject(
 	projects: ProjectWithProfiles[],
 	deletedProjectId: string,
 ) {
-	const deletedIndex = projects.findIndex((item) => item.id === deletedProjectId);
-	const remainingProjects = projects.filter((item) => item.id !== deletedProjectId);
+	let deletedIndex = -1;
+	const remainingProjects: ProjectWithProfiles[] = [];
+
+	for (const project of projects) {
+		if (project.id === deletedProjectId) {
+			deletedIndex = remainingProjects.length;
+		} else {
+			remainingProjects.push(project);
+		}
+	}
+
 	if (remainingProjects.length === 0) return null;
 
 	const replacementIndex = deletedIndex >= 0


### PR DESCRIPTION
## Summary

- select the replacement project after deletion with one pass through projects
- avoid `findIndex` plus `filter` over the same project list
- add focused tests for next/previous replacement selection
- add a Vitest benchmark for old and new replacement selection

## Benchmark

```bash
bunx vitest bench src/features/projects/DeleteProjectDialog.bench.ts --run
```

Result:

```text
single pass replacement ... 3.12x faster than findIndex plus filter replacement
```

## Validation

```bash
bunx vitest run src/features/projects/DeleteProjectDialog.test.ts
bunx tsc --noEmit
```

Result:

```text
Test Files  1 passed (1)
Tests       2 passed (2)
```
