### PR TITLE
perf: select fallback profile once

### DIFF
--- a/src/features/profiles/DeleteProfileDialog.bench.ts
+++ b/src/features/profiles/DeleteProfileDialog.bench.ts
@@ -1,0 +1,39 @@
+import type { Profile } from "@/generated";
+import { bench, describe } from "vitest";
+import { getFallbackProfile } from "./DeleteProfileDialog";
+
+const profiles: Profile[] = Array.from({ length: 10_000 }, (_, index) => ({
+	id: `profile-${index}`,
+	project_id: "project-1",
+	branch_name: `branch-${index}`,
+	worktree_path: `/repo/profile-${index}`,
+	created_at: "2026-05-15T00:00:00Z",
+	is_default: index === 8_500,
+}));
+const deletedProfileId = "profile-2_500".replace("_", "");
+let sink = "";
+
+function getFallbackProfileWithFind(
+	profiles: readonly Profile[] | undefined,
+	deletedProfileId: string,
+) {
+	return (
+		profiles?.find(
+			(item) => item.id !== deletedProfileId && item.is_default,
+		) ?? profiles?.find((item) => item.id !== deletedProfileId)
+	);
+}
+
+describe("delete profile fallback profile", () => {
+	bench("two find fallback", () => {
+		const profile = getFallbackProfileWithFind(profiles, deletedProfileId);
+		sink = profile?.id ?? "";
+		if (sink === "__never__") throw new Error("unreachable");
+	});
+
+	bench("single pass fallback", () => {
+		const profile = getFallbackProfile(profiles, deletedProfileId);
+		sink = profile?.id ?? "";
+		if (sink === "__never__") throw new Error("unreachable");
+	});
+});

--- a/src/features/profiles/DeleteProfileDialog.test.ts
+++ b/src/features/profiles/DeleteProfileDialog.test.ts
@@ -1,0 +1,32 @@
+import type { Profile } from "@/generated";
+import { describe, expect, it } from "vitest";
+import { getFallbackProfile } from "./DeleteProfileDialog";
+
+function makeProfile(id: string, isDefault = false): Profile {
+	return {
+		id,
+		project_id: "project-1",
+		branch_name: id,
+		worktree_path: `/repo/${id}`,
+		created_at: "2026-05-15T00:00:00Z",
+		is_default: isDefault,
+	};
+}
+
+describe("getFallbackProfile", () => {
+	it("prefers a remaining default profile", () => {
+		const profiles = [
+			makeProfile("delete-me"),
+			makeProfile("first"),
+			makeProfile("default", true),
+		];
+
+		expect(getFallbackProfile(profiles, "delete-me")).toBe(profiles[2]);
+	});
+
+	it("falls back to the first remaining profile", () => {
+		const profiles = [makeProfile("delete-me"), makeProfile("first")];
+
+		expect(getFallbackProfile(profiles, "delete-me")).toBe(profiles[1]);
+	});
+});

--- a/src/features/profiles/DeleteProfileDialog.tsx
+++ b/src/features/profiles/DeleteProfileDialog.tsx
@@ -10,7 +10,7 @@ import {
 	Text,
 } from "@chakra-ui/react";
 import { useMatch, useNavigate } from "react-router";
-import type { GitDiffStats } from "@/generated";
+import type { GitDiffStats, Profile } from "@/generated";
 import { useProjects } from "@/features/projects/hooks";
 import * as m from "@/paraglide/messages.js";
 import { useDeleteProfile, useProfileDeleteCheck } from "./hooks";
@@ -29,6 +29,23 @@ function hasDiffStats(stats: GitDiffStats | null) {
 	);
 }
 
+export function getFallbackProfile(
+	profiles: readonly Profile[] | undefined,
+	deletedProfileId: string,
+) {
+	let firstFallback: Profile | undefined;
+	for (const profile of profiles ?? []) {
+		if (profile.id === deletedProfileId) {
+			continue;
+		}
+		if (profile.is_default) {
+			return profile;
+		}
+		firstFallback ??= profile;
+	}
+	return firstFallback;
+}
+
 export default function DeleteProfileDialog({
 	isOpen,
 	onClose,
@@ -44,10 +61,10 @@ export default function DeleteProfileDialog({
 		const isDeletingActiveProfile =
 			profileMatch?.params.profileId === profile.id;
 		const project = projects.find((item) => item.id === profile.project_id);
-		const fallbackProfile =
-			project?.profiles.find(
-				(item) => item.id !== profile.id && item.is_default,
-			) ?? project?.profiles.find((item) => item.id !== profile.id);
+		const fallbackProfile = getFallbackProfile(
+			project?.profiles,
+			profile.id,
+		);
 
 		await deleteProfile.mutateAsync({
 			id: profile.id,


### PR DESCRIPTION
## Summary

- select the fallback profile after deletion in one pass
- avoid scanning profiles once for the default fallback and again for any fallback
- add focused tests for default and first-remaining selection
- add a Vitest benchmark for two `find` calls vs single-pass selection

## Benchmark

```bash
bunx vitest bench src/features/profiles/DeleteProfileDialog.bench.ts --run
```

Result:

```text
single pass fallback ... 1.77x faster than two find fallback
```

## Validation

```bash
bunx vitest run src/features/profiles/DeleteProfileDialog.test.ts
bunx tsc --noEmit
```

Result:

```text
Test Files  1 passed (1)
Tests       2 passed (2)
```
