### PR TITLE
perf: build shell picker options once

### DIFF
--- a/src/features/settings/ShellPicker.tsx
+++ b/src/features/settings/ShellPicker.tsx
@@ -7,11 +7,13 @@ import {
 	Stack,
 	Text,
 } from "@chakra-ui/react";
-import { use } from "react";
+import { use, useMemo } from "react";
 import type { AvailableShell } from "@/generated";
 import { listAvailableShells } from "@/generated";
 import * as m from "@/paraglide/messages.js";
 import { createCachedPromise } from "@/shared/lib/cachedPromise";
+import { useLocale } from "@/shared/lib/locale";
+import { buildShellSelectOptions } from "./shellOptions";
 import { useTerminalSettingsStore } from "./stores/terminalSettingsStore";
 
 const CUSTOM_SHELL_VALUE = "__custom__";
@@ -23,21 +25,22 @@ const getShellsPromise = createCachedPromise<AvailableShell[]>(() =>
 export function ShellPicker() {
 	const shells = use(getShellsPromise());
 	const { defaultShell, setDefaultShell } = useTerminalSettingsStore();
+	const locale = useLocale();
 
-	const shellCollection = createListCollection({
-		items: [
-			...shells.map((shell) => ({
-				value: shell.command,
-				label: shell.is_default
-					? `${shell.label} (${m.defaultOption()})`
-					: shell.label,
-			})),
-			{ value: CUSTOM_SHELL_VALUE, label: m.customShell() },
-		],
-	});
-
-	const isKnownShell = shells.some((shell) => shell.command === defaultShell);
-	const selectValue = isKnownShell ? defaultShell : CUSTOM_SHELL_VALUE;
+	const { shellCollection, selectValue } = useMemo(() => {
+		void locale;
+		const shellOptions = buildShellSelectOptions(
+			shells,
+			defaultShell,
+			CUSTOM_SHELL_VALUE,
+			m.defaultOption(),
+			m.customShell(),
+		);
+		return {
+			shellCollection: createListCollection({ items: shellOptions.items }),
+			selectValue: shellOptions.selectValue,
+		};
+	}, [defaultShell, locale, shells]);
 
 	return (
 		<Field.Root>

--- a/src/features/settings/shellOptions.bench.ts
+++ b/src/features/settings/shellOptions.bench.ts
@@ -1,0 +1,42 @@
+import { bench, describe } from "vitest";
+import type { AvailableShell } from "@/generated";
+import { buildShellSelectOptions } from "./shellOptions";
+
+const CUSTOM_SHELL_VALUE = "__custom__";
+
+const shells: AvailableShell[] = Array.from({ length: 400 }, (_, index) => ({
+	command: `/opt/homebrew/bin/shell-${index}`,
+	label: `Shell ${index}`,
+	is_default: index === 42,
+}));
+
+const defaultShell = shells[350].command;
+
+function buildWithMapAndSome() {
+	const items = [
+		...shells.map((shell) => ({
+			value: shell.command,
+			label: shell.is_default ? `${shell.label} (Default)` : shell.label,
+		})),
+		{ value: CUSTOM_SHELL_VALUE, label: "Custom" },
+	];
+	const isKnownShell = shells.some((shell) => shell.command === defaultShell);
+	const selectValue = isKnownShell ? defaultShell : CUSTOM_SHELL_VALUE;
+	return { items, selectValue };
+}
+
+describe("shell select option construction", () => {
+	bench("map plus some shell options", () => {
+		buildWithMapAndSome();
+	});
+
+	bench("single pass shell options", () => {
+		buildShellSelectOptions(
+			shells,
+			defaultShell,
+			CUSTOM_SHELL_VALUE,
+			"Default",
+			"Custom",
+		);
+	});
+});

--- a/src/features/settings/shellOptions.test.ts
+++ b/src/features/settings/shellOptions.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import type { AvailableShell } from "@/generated";
+import { buildShellSelectOptions } from "./shellOptions";
+
+const shells: AvailableShell[] = [
+	{ command: "/bin/zsh", label: "Zsh", is_default: true },
+	{ command: "/bin/bash", label: "Bash", is_default: false },
+];
+
+describe("buildShellSelectOptions", () => {
+	it("selects a known shell and appends the custom option", () => {
+		const options = buildShellSelectOptions(
+			shells,
+			"/bin/bash",
+			"__custom__",
+			"Default",
+			"Custom",
+		);
+
+		expect(options.selectValue).toBe("/bin/bash");
+		expect(options.items).toEqual([
+			{ value: "/bin/zsh", label: "Zsh (Default)" },
+			{ value: "/bin/bash", label: "Bash" },
+			{ value: "__custom__", label: "Custom" },
+		]);
+	});
+
+	it("selects the custom option for an unknown shell", () => {
+		const options = buildShellSelectOptions(
+			shells,
+			"/opt/custom-shell",
+			"__custom__",
+			"Default",
+			"Custom",
+		);
+
+		expect(options.selectValue).toBe("__custom__");
+	});
+});

--- a/src/features/settings/shellOptions.ts
+++ b/src/features/settings/shellOptions.ts
@@ -1,0 +1,42 @@
+import type { AvailableShell } from "@/generated";
+
+export interface ShellSelectItem {
+	value: string;
+	label: string;
+}
+
+export interface ShellSelectOptions {
+	items: ShellSelectItem[];
+	selectValue: string;
+}
+
+export function buildShellSelectOptions(
+	shells: AvailableShell[],
+	defaultShell: string,
+	customShellValue: string,
+	defaultLabel: string,
+	customLabel: string,
+): ShellSelectOptions {
+	const items: ShellSelectItem[] = new Array(shells.length + 1);
+	let isKnownShell = false;
+
+	for (let index = 0; index < shells.length; index++) {
+		const shell = shells[index];
+		if (shell.command === defaultShell) {
+			isKnownShell = true;
+		}
+		items[index] = {
+			value: shell.command,
+			label: shell.is_default
+				? `${shell.label} (${defaultLabel})`
+				: shell.label,
+		};
+	}
+
+	items[shells.length] = { value: customShellValue, label: customLabel };
+
+	return {
+		items,
+		selectValue: isKnownShell ? defaultShell : customShellValue,
+	};
+}


### PR DESCRIPTION
## Stack Context

Ongoing performance pass over narrow hot paths, with each change kept as an independently benchmarked PR.

## What?

- Builds shell picker items and known-shell selection in one pass.
- Memoizes the Chakra collection so it is rebuilt only when shells, locale text, or the selected shell changes.
- Adds a focused helper test and Vitest benchmark.

## Benchmark

```bash
bunx vitest bench src/features/settings/shellOptions.bench.ts --run
```

Result:

```text
single pass shell options: 2.08x faster than map plus some shell options
```

## Validation

```bash
bunx vitest run src/features/settings/shellOptions.test.ts
bunx tsc --noEmit
```
