### PR TITLE
perf: fill file tree path set directly

### DIFF
--- a/src/features/projects/FileTreePanel.tsx
+++ b/src/features/projects/FileTreePanel.tsx
@@ -32,6 +32,7 @@ import {
 	FILE_TREE_PANEL_MIN_WIDTH,
 	useFileTreeStore,
 } from "./fileTreeStore";
+import { buildFilePathSet } from "./fileTreePathSets";
 import {
 	useDeleteFileTreePaths,
 	useFileTreeChildPaths,
@@ -458,8 +459,7 @@ export default function FileTreePanel({
 		[gitStatus, treePaths],
 	);
 	const filePathSet = useMemo(
-		() =>
-			new Set([...existingPathSet].filter((path) => !path.endsWith("/"))),
+		() => buildFilePathSet(existingPathSet),
 		[existingPathSet],
 	);
 	const treePathSet = existingPathSet;

--- a/src/features/projects/fileTreePathSets.bench.ts
+++ b/src/features/projects/fileTreePathSets.bench.ts
@@ -1,0 +1,25 @@
+import { bench, describe } from "vitest";
+import { buildFilePathSet } from "./fileTreePathSets";
+
+const existingPathSet = new Set<string>();
+
+for (let index = 0; index < 30_000; index++) {
+	existingPathSet.add(`src/features/module-${index}/`);
+	existingPathSet.add(`src/features/module-${index}/file-${index}.ts`);
+}
+
+function buildWithArrayFilter() {
+	return new Set(
+		[...existingPathSet].filter((path) => !path.endsWith("/")),
+	);
+}
+
+describe("file tree file path set construction", () => {
+	bench("array filter then set", () => {
+		buildWithArrayFilter();
+	});
+
+	bench("direct set fill", () => {
+		buildFilePathSet(existingPathSet);
+	});
+});

--- a/src/features/projects/fileTreePathSets.test.ts
+++ b/src/features/projects/fileTreePathSets.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { buildFilePathSet } from "./fileTreePathSets";
+
+describe("buildFilePathSet", () => {
+	it("keeps only non-directory paths", () => {
+		const filePathSet = buildFilePathSet(
+			new Set(["src/", "src/main.ts", "README.md"]),
+		);
+
+		expect([...filePathSet]).toEqual(["src/main.ts", "README.md"]);
+	});
+});

--- a/src/features/projects/fileTreePathSets.ts
+++ b/src/features/projects/fileTreePathSets.ts
@@ -1,0 +1,11 @@
+export function buildFilePathSet(
+	existingPathSet: ReadonlySet<string>,
+): ReadonlySet<string> {
+	const filePathSet = new Set<string>();
+	for (const path of existingPathSet) {
+		if (!path.endsWith("/")) {
+			filePathSet.add(path);
+		}
+	}
+	return filePathSet;
+}


### PR DESCRIPTION
## Stack Context

Ongoing performance pass over narrow hot paths, with each change kept as an independently benchmarked PR.

## What?

- Builds the file tree file-path set directly from the existing path set.
- Avoids expanding the set into an intermediate array and filtering it before constructing another set.
- Adds a focused helper test and Vitest benchmark.

## Benchmark

```bash
bunx vitest bench src/features/projects/fileTreePathSets.bench.ts --run
```

Result:

```text
direct set fill: 1.34x faster than array filter then set
```

## Validation

```bash
bunx vitest run src/features/projects/fileTreePathSets.test.ts src/features/projects/FileTreePanel.test.tsx
bunx tsc --noEmit
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test suite validating file path filtering behavior.
  * Added performance benchmark comparing file path set construction strategies.

* **Refactor**
  * Extracted file path filtering logic into a dedicated utility function to improve code organization and reduce duplication.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AkaraChen/2code/pull/194)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->