### PR TITLE
perf: upsert project groups once

### DIFF
--- a/src/features/projects/hooks.ts
+++ b/src/features/projects/hooks.ts
@@ -9,6 +9,7 @@ import {
 	getCachedProjectAvatar,
 	setCachedProjectAvatar,
 } from "@/features/projects/projectAvatarCache";
+import { upsertProjectGroup } from "@/features/projects/projectGroupCache";
 import type {
 	ProjectConfig,
 	ProjectGroup,
@@ -154,15 +155,7 @@ export function useCreateProjectGroup() {
 		onSuccess: (group) => {
 			queryClient.setQueryData<ProjectGroup[]>(
 				queryKeys.projectGroups.all,
-				(groups) => {
-					if (!groups) return [group];
-					if (groups.some((item) => item.id === group.id)) {
-						return groups.map((item) =>
-							item.id === group.id ? group : item,
-						);
-					}
-					return [...groups, group];
-				},
+				(groups) => upsertProjectGroup(groups, group),
 			);
 			queryClient.invalidateQueries({
 				queryKey: queryKeys.projectGroups.all,

--- a/src/features/projects/projectGroupCache.bench.ts
+++ b/src/features/projects/projectGroupCache.bench.ts
@@ -1,0 +1,45 @@
+import { bench, describe } from "vitest";
+import type { ProjectGroup } from "@/generated";
+import { upsertProjectGroup } from "./projectGroupCache";
+
+const groups: ProjectGroup[] = Array.from({ length: 2_000 }, (_, index) => ({
+	id: `group-${index}`,
+	name: `Group ${index}`,
+	created_at: "2026-01-01T00:00:00Z",
+}));
+
+const existingGroup: ProjectGroup = {
+	...groups[1_500],
+	name: "Updated group",
+};
+
+const newGroup: ProjectGroup = {
+	id: "group-new",
+	name: "New group",
+	created_at: "2026-01-01T00:00:00Z",
+};
+
+function upsertWithSomeAndMap(group: ProjectGroup) {
+	if (groups.some((item) => item.id === group.id)) {
+		return groups.map((item) => (item.id === group.id ? group : item));
+	}
+	return [...groups, group];
+}
+
+describe("project group cache upsert", () => {
+	bench("some plus map existing group", () => {
+		upsertWithSomeAndMap(existingGroup);
+	});
+
+	bench("single pass existing group", () => {
+		upsertProjectGroup(groups, existingGroup);
+	});
+
+	bench("some plus spread new group", () => {
+		upsertWithSomeAndMap(newGroup);
+	});
+
+	bench("single pass new group", () => {
+		upsertProjectGroup(groups, newGroup);
+	});
+});

--- a/src/features/projects/projectGroupCache.test.ts
+++ b/src/features/projects/projectGroupCache.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import type { ProjectGroup } from "@/generated";
+import { upsertProjectGroup } from "./projectGroupCache";
+
+const groupA: ProjectGroup = {
+	id: "a",
+	name: "A",
+	created_at: "2026-01-01T00:00:00Z",
+};
+
+const groupB: ProjectGroup = {
+	id: "b",
+	name: "B",
+	created_at: "2026-01-01T00:00:00Z",
+};
+
+describe("upsertProjectGroup", () => {
+	it("creates the first cached group", () => {
+		expect(upsertProjectGroup(undefined, groupA)).toEqual([groupA]);
+	});
+
+	it("replaces an existing group", () => {
+		const updated = { ...groupB, name: "Updated" };
+		expect(upsertProjectGroup([groupA, groupB], updated)).toEqual([
+			groupA,
+			updated,
+		]);
+	});
+
+	it("appends a new group", () => {
+		expect(upsertProjectGroup([groupA], groupB)).toEqual([groupA, groupB]);
+	});
+});

--- a/src/features/projects/projectGroupCache.ts
+++ b/src/features/projects/projectGroupCache.ts
@@ -1,0 +1,19 @@
+import type { ProjectGroup } from "@/generated";
+
+export function upsertProjectGroup(
+	groups: ProjectGroup[] | undefined,
+	group: ProjectGroup,
+): ProjectGroup[] {
+	if (!groups) return [group];
+
+	const nextGroups = groups.slice();
+	for (let index = 0; index < nextGroups.length; index++) {
+		if (nextGroups[index].id === group.id) {
+			nextGroups[index] = group;
+			return nextGroups;
+		}
+	}
+
+	nextGroups.push(group);
+	return nextGroups;
+}


### PR DESCRIPTION
## Stack Context

Ongoing performance pass over narrow hot paths, with each change kept as an independently benchmarked PR.

## What?

- Replaces project group cache upsert `some` + `map` / spread logic with a single helper.
- Copies the cached array once, updates in place when the group exists, or appends when it does not.
- Adds focused helper coverage and a Vitest benchmark for both existing and new group paths.

## Benchmark

```bash
bunx vitest bench src/features/projects/projectGroupCache.bench.ts --run
```

Result:

```text
single pass existing group: 11.57x faster than some plus map existing group
single pass new group: 2.15x faster than some plus spread new group
```

## Validation

```bash
bunx vitest run src/features/projects/projectGroupCache.test.ts src/features/projects/hooks.test.tsx
bunx tsc --noEmit
```
