### PR TITLE
perf: build mono font items once

### DIFF
--- a/src/features/settings/FontPicker.tsx
+++ b/src/features/settings/FontPicker.tsx
@@ -10,6 +10,7 @@ import type { SystemFont } from "@/generated";
 import { listSystemFonts } from "@/generated";
 import * as m from "@/paraglide/messages.js";
 import { createCachedPromise } from "@/shared/lib/cachedPromise";
+import { buildMonoFontSelectItems } from "./fontOptions";
 import { useTerminalSettingsStore } from "./stores/terminalSettingsStore";
 
 const getFontsPromise = createCachedPromise<SystemFont[]>(() =>
@@ -21,20 +22,17 @@ export function FontPicker() {
 	const { fontFamily, showAllFonts, setFontFamily, setShowAllFonts } =
 		useTerminalSettingsStore();
 
-	const visibleFonts = useMemo(
-		() => (showAllFonts ? fonts : fonts.filter((f) => f.is_mono)),
-		[fonts, showAllFonts],
-	);
-
 	const fontCollection = useMemo(
 		() =>
 			createListCollection({
-				items: visibleFonts.map((f) => ({
-					value: f.family,
-					label: f.family,
-				})),
+				items: showAllFonts
+					? fonts.map((font) => ({
+							value: font.family,
+							label: font.family,
+						}))
+					: buildMonoFontSelectItems(fonts),
 			}),
-		[visibleFonts],
+		[fonts, showAllFonts],
 	);
 
 	return (

--- a/src/features/settings/fontOptions.bench.ts
+++ b/src/features/settings/fontOptions.bench.ts
@@ -1,0 +1,26 @@
+import { bench, describe } from "vitest";
+import type { SystemFont } from "@/generated";
+import { buildMonoFontSelectItems } from "./fontOptions";
+
+const fonts: SystemFont[] = Array.from({ length: 3_000 }, (_, index) => ({
+	family: `Font ${index}`,
+	is_mono: index % 4 === 0,
+}));
+
+function buildWithFilterAndMap(showAllFonts: boolean) {
+	const visibleFonts = showAllFonts ? fonts : fonts.filter((font) => font.is_mono);
+	return visibleFonts.map((font) => ({
+		value: font.family,
+		label: font.family,
+	}));
+}
+
+describe("font select item construction", () => {
+	bench("filter plus map mono fonts", () => {
+		buildWithFilterAndMap(false);
+	});
+
+	bench("single pass mono fonts", () => {
+		buildMonoFontSelectItems(fonts);
+	});
+});

--- a/src/features/settings/fontOptions.test.ts
+++ b/src/features/settings/fontOptions.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import type { SystemFont } from "@/generated";
+import { buildMonoFontSelectItems } from "./fontOptions";
+
+const fonts: SystemFont[] = [
+	{ family: "Mono", is_mono: true },
+	{ family: "Sans", is_mono: false },
+];
+
+describe("buildMonoFontSelectItems", () => {
+	it("keeps only mono fonts", () => {
+		expect(buildMonoFontSelectItems(fonts)).toEqual([
+			{ value: "Mono", label: "Mono" },
+		]);
+	});
+});

--- a/src/features/settings/fontOptions.ts
+++ b/src/features/settings/fontOptions.ts
@@ -1,0 +1,15 @@
+import type { SystemFont } from "@/generated";
+
+export interface FontSelectItem {
+	value: string;
+	label: string;
+}
+
+export function buildMonoFontSelectItems(fonts: SystemFont[]): FontSelectItem[] {
+	const items: FontSelectItem[] = [];
+	for (const font of fonts) {
+		if (!font.is_mono) continue;
+		items.push({ value: font.family, label: font.family });
+	}
+	return items;
+}


### PR DESCRIPTION
## Stack Context

Ongoing performance pass over narrow hot paths, with each change kept as an independently benchmarked PR.

## What?

- Builds mono-only font picker items in one pass instead of filtering and then mapping.
- Leaves the show-all path on the original direct `map` shape.
- Adds focused helper coverage and a Vitest benchmark for the optimized mono path.

## Benchmark

```bash
bunx vitest bench src/features/settings/fontOptions.bench.ts --run
```

Result:

```text
single pass mono fonts: 7.15x faster than filter plus map mono fonts
```

## Validation

```bash
bunx vitest run src/features/settings/fontOptions.test.ts
bunx tsc --noEmit
```
