### PR TITLE
perf: splice terminal template drafts

### DIFF
--- a/src/features/terminal/TerminalTemplateListEditor.tsx
+++ b/src/features/terminal/TerminalTemplateListEditor.tsx
@@ -10,6 +10,10 @@ import {
 	Textarea,
 } from "@chakra-ui/react";
 import * as m from "@/paraglide/messages.js";
+import {
+	removeTemplateDraft,
+	updateTemplateDraft,
+} from "./templateDraftList";
 
 interface BaseTemplateDraft {
 	id: string;
@@ -36,17 +40,11 @@ export function TerminalTemplateListEditor<T extends BaseTemplateDraft>({
 	showCwd = false,
 }: TerminalTemplateListEditorProps<T>) {
 	function updateTemplate(index: number, patch: Partial<T>) {
-		onChange(
-			templates.map((template, templateIndex) =>
-				templateIndex === index
-					? { ...template, ...patch }
-					: template,
-			),
-		);
+		onChange(updateTemplateDraft(templates, index, patch));
 	}
 
 	function removeTemplate(index: number) {
-		onChange(templates.filter((_, templateIndex) => templateIndex !== index));
+		onChange(removeTemplateDraft(templates, index));
 	}
 
 	return (

--- a/src/features/terminal/templateDraftList.bench.ts
+++ b/src/features/terminal/templateDraftList.bench.ts
@@ -1,0 +1,50 @@
+import { bench, describe } from "vitest";
+import {
+	removeTemplateDraft,
+	updateTemplateDraft,
+} from "./templateDraftList";
+
+interface Draft {
+	id: string;
+	name: string;
+	commandsText: string;
+}
+
+const templates: Draft[] = Array.from({ length: 2_000 }, (_, index) => ({
+	id: `template-${index}`,
+	name: `Template ${index}`,
+	commandsText: `echo ${index}`,
+}));
+
+const updateIndex = 1_500;
+const removeIndex = 1_500;
+
+function updateWithMap() {
+	return templates.map((template, templateIndex) =>
+		templateIndex === updateIndex
+			? { ...template, name: "Updated" }
+			: template,
+	);
+}
+
+function removeWithFilter() {
+	return templates.filter((_, templateIndex) => templateIndex !== removeIndex);
+}
+
+describe("template draft list updates", () => {
+	bench("map update by index", () => {
+		updateWithMap();
+	});
+
+	bench("slice update by index", () => {
+		updateTemplateDraft(templates, updateIndex, { name: "Updated" });
+	});
+
+	bench("filter remove by index", () => {
+		removeWithFilter();
+	});
+
+	bench("splice remove by index", () => {
+		removeTemplateDraft(templates, removeIndex);
+	});
+});

--- a/src/features/terminal/templateDraftList.test.ts
+++ b/src/features/terminal/templateDraftList.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+	removeTemplateDraft,
+	updateTemplateDraft,
+} from "./templateDraftList";
+
+const templates = [
+	{ id: "a", name: "A" },
+	{ id: "b", name: "B" },
+	{ id: "c", name: "C" },
+];
+
+describe("template draft list updates", () => {
+	it("updates a template at an index", () => {
+		expect(updateTemplateDraft(templates, 1, { name: "Updated" })).toEqual([
+			templates[0],
+			{ id: "b", name: "Updated" },
+			templates[2],
+		]);
+	});
+
+	it("returns a copied array for an invalid update index", () => {
+		const result = updateTemplateDraft(templates, 99, { name: "Updated" });
+		expect(result).toEqual(templates);
+		expect(result).not.toBe(templates);
+	});
+
+	it("removes a template at an index", () => {
+		expect(removeTemplateDraft(templates, 1)).toEqual([
+			templates[0],
+			templates[2],
+		]);
+	});
+
+	it("returns a copied array for an invalid remove index", () => {
+		const result = removeTemplateDraft(templates, -1);
+		expect(result).toEqual(templates);
+		expect(result).not.toBe(templates);
+	});
+});

--- a/src/features/terminal/templateDraftList.ts
+++ b/src/features/terminal/templateDraftList.ts
@@ -1,0 +1,25 @@
+interface TemplateDraft {
+	id: string;
+}
+
+export function updateTemplateDraft<T extends TemplateDraft>(
+	templates: readonly T[],
+	index: number,
+	patch: Partial<T>,
+): T[] {
+	const nextTemplates = templates.slice();
+	const template = nextTemplates[index];
+	if (!template) return nextTemplates;
+	nextTemplates[index] = { ...template, ...patch };
+	return nextTemplates;
+}
+
+export function removeTemplateDraft<T extends TemplateDraft>(
+	templates: readonly T[],
+	index: number,
+): T[] {
+	if (index < 0 || index >= templates.length) return templates.slice();
+	const nextTemplates = templates.slice();
+	nextTemplates.splice(index, 1);
+	return nextTemplates;
+}


### PR DESCRIPTION
## Stack Context

Ongoing performance pass over narrow hot paths, with each change kept as an independently benchmarked PR.

## What?

- Replaces terminal template draft `map` updates with `slice` plus direct indexed replacement.
- Replaces draft removal `filter` with `slice` plus `splice`.
- Adds helper coverage and a Vitest benchmark for update and remove paths.

## Benchmark

```bash
bunx vitest bench src/features/terminal/templateDraftList.bench.ts --run
```

Result:

```text
slice update by index: 14.48x faster than map update by index
splice remove by index: 23.76x faster than filter remove by index
```

## Validation

```bash
bunx vitest run src/features/terminal/templateDraftList.test.ts src/features/terminal/templates.test.ts
bunx tsc --noEmit
```
