### PR TITLE
perf: preallocate sound picker items

### DIFF
--- a/src/features/settings/SoundPicker.tsx
+++ b/src/features/settings/SoundPicker.tsx
@@ -12,6 +12,7 @@ import { listSystemSounds, playSystemSound } from "@/generated";
 import * as m from "@/paraglide/messages.js";
 import { createCachedPromise } from "@/shared/lib/cachedPromise";
 import { useLocale } from "@/shared/lib/locale";
+import { buildSoundSelectItems } from "./soundOptions";
 import { useNotificationStore } from "./stores/notificationStore";
 
 const getSoundsPromise = createCachedPromise<string[]>(() =>
@@ -27,10 +28,10 @@ export function SoundPicker() {
 		() => {
 			void locale;
 			return createListCollection({
-				items: [
-					{ value: "", label: m.notificationSoundNone() },
-					...sounds.map((s) => ({ value: s, label: s })),
-				],
+				items: buildSoundSelectItems(
+					sounds,
+					m.notificationSoundNone(),
+				),
 			});
 		},
 		[locale, sounds],

--- a/src/features/settings/soundOptions.bench.ts
+++ b/src/features/settings/soundOptions.bench.ts
@@ -1,0 +1,21 @@
+import { bench, describe } from "vitest";
+import { buildSoundSelectItems } from "./soundOptions";
+
+const sounds = Array.from({ length: 2_000 }, (_, index) => `Sound ${index}`);
+
+function buildWithMapAndSpread() {
+	return [
+		{ value: "", label: "None" },
+		...sounds.map((sound) => ({ value: sound, label: sound })),
+	];
+}
+
+describe("sound select item construction", () => {
+	bench("map plus spread sounds", () => {
+		buildWithMapAndSpread();
+	});
+
+	bench("preallocated sounds", () => {
+		buildSoundSelectItems(sounds, "None");
+	});
+});

--- a/src/features/settings/soundOptions.test.ts
+++ b/src/features/settings/soundOptions.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { buildSoundSelectItems } from "./soundOptions";
+
+describe("buildSoundSelectItems", () => {
+	it("prepends the none option", () => {
+		expect(buildSoundSelectItems(["Glass", "Ping"], "None")).toEqual([
+			{ value: "", label: "None" },
+			{ value: "Glass", label: "Glass" },
+			{ value: "Ping", label: "Ping" },
+		]);
+	});
+});

--- a/src/features/settings/soundOptions.ts
+++ b/src/features/settings/soundOptions.ts
@@ -1,0 +1,19 @@
+export interface SoundSelectItem {
+	value: string;
+	label: string;
+}
+
+export function buildSoundSelectItems(
+	sounds: readonly string[],
+	noneLabel: string,
+): SoundSelectItem[] {
+	const items = new Array<SoundSelectItem>(sounds.length + 1);
+	items[0] = { value: "", label: noneLabel };
+
+	for (let index = 0; index < sounds.length; index++) {
+		const sound = sounds[index];
+		items[index + 1] = { value: sound, label: sound };
+	}
+
+	return items;
+}


### PR DESCRIPTION
## Stack Context

Ongoing performance pass over narrow hot paths, with each change kept as an independently benchmarked PR.

## What?

- Builds sound picker items with one preallocated array.
- Avoids allocating the mapped sounds array and spreading it into another array.
- Adds focused helper coverage and a Vitest benchmark.

## Benchmark

```bash
bunx vitest bench src/features/settings/soundOptions.bench.ts --run
```

Result:

```text
preallocated sounds: 8.64x faster than map plus spread sounds
```

## Validation

```bash
bunx vitest run src/features/settings/soundOptions.test.ts
bunx tsc --noEmit
```
