### PR TITLE
perf: splice global terminal templates

### DIFF
--- a/src/features/settings/GlobalTerminalTemplatesSettings.tsx
+++ b/src/features/settings/GlobalTerminalTemplatesSettings.tsx
@@ -19,6 +19,10 @@ import {
 } from "@/features/terminal/templates";
 import { TerminalTemplateDraftDialog } from "@/features/terminal/TerminalTemplateDraftDialog";
 import * as m from "@/paraglide/messages.js";
+import {
+	removeGlobalTerminalTemplate,
+	replaceGlobalTerminalTemplate,
+} from "./globalTerminalTemplateList";
 import { useTerminalTemplatesStore } from "./stores/terminalTemplatesStore";
 
 export function GlobalTerminalTemplatesSettings() {
@@ -60,8 +64,10 @@ export function GlobalTerminalTemplatesSettings() {
 
 		if (editingTemplateId) {
 			await replaceTemplates.mutateAsync(
-				templates.map((template) =>
-					template.id === editingTemplateId ? normalizedTemplate : template,
+				replaceGlobalTerminalTemplate(
+					templates,
+					editingTemplateId,
+					normalizedTemplate,
 				),
 			);
 		} else {
@@ -74,7 +80,7 @@ export function GlobalTerminalTemplatesSettings() {
 	async function handleDelete() {
 		if (!editingTemplateId) return;
 		await replaceTemplates.mutateAsync(
-			templates.filter((template) => template.id !== editingTemplateId),
+			removeGlobalTerminalTemplate(templates, editingTemplateId),
 		);
 		closeDialog();
 	}

--- a/src/features/settings/globalTerminalTemplateList.bench.ts
+++ b/src/features/settings/globalTerminalTemplateList.bench.ts
@@ -1,0 +1,50 @@
+import { bench, describe } from "vitest";
+import type { GlobalTerminalTemplate } from "@/features/terminal/templates";
+import {
+	removeGlobalTerminalTemplate,
+	replaceGlobalTerminalTemplate,
+} from "./globalTerminalTemplateList";
+
+const templates: GlobalTerminalTemplate[] = Array.from(
+	{ length: 2_000 },
+	(_, index) => ({
+		id: `template-${index}`,
+		name: `Template ${index}`,
+		commands: [`echo ${index}`],
+	}),
+);
+
+const targetId = "template-1500";
+const replacement: GlobalTerminalTemplate = {
+	id: targetId,
+	name: "Updated",
+	commands: ["bun run dev"],
+};
+
+function replaceWithMap() {
+	return templates.map((template) =>
+		template.id === targetId ? replacement : template,
+	);
+}
+
+function removeWithFilter() {
+	return templates.filter((template) => template.id !== targetId);
+}
+
+describe("global terminal template list updates", () => {
+	bench("map replace by id", () => {
+		replaceWithMap();
+	});
+
+	bench("findIndex replace by id", () => {
+		replaceGlobalTerminalTemplate(templates, targetId, replacement);
+	});
+
+	bench("filter remove by id", () => {
+		removeWithFilter();
+	});
+
+	bench("findIndex splice remove by id", () => {
+		removeGlobalTerminalTemplate(templates, targetId);
+	});
+});

--- a/src/features/settings/globalTerminalTemplateList.test.ts
+++ b/src/features/settings/globalTerminalTemplateList.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import type { GlobalTerminalTemplate } from "@/features/terminal/templates";
+import {
+	removeGlobalTerminalTemplate,
+	replaceGlobalTerminalTemplate,
+} from "./globalTerminalTemplateList";
+
+const templates: GlobalTerminalTemplate[] = [
+	{ id: "a", name: "A", commands: ["a"] },
+	{ id: "b", name: "B", commands: ["b"] },
+	{ id: "c", name: "C", commands: ["c"] },
+];
+
+describe("global terminal template list updates", () => {
+	it("replaces a template by id", () => {
+		const replacement = { id: "b", name: "Updated", commands: ["dev"] };
+		expect(
+			replaceGlobalTerminalTemplate(templates, "b", replacement),
+		).toEqual([templates[0], replacement, templates[2]]);
+	});
+
+	it("returns a copied array when replacement id is missing", () => {
+		const result = replaceGlobalTerminalTemplate(templates, "x", {
+			id: "x",
+			name: "X",
+			commands: [],
+		});
+		expect(result).toEqual(templates);
+		expect(result).not.toBe(templates);
+	});
+
+	it("removes a template by id", () => {
+		expect(removeGlobalTerminalTemplate(templates, "b")).toEqual([
+			templates[0],
+			templates[2],
+		]);
+	});
+
+	it("returns a copied array when removal id is missing", () => {
+		const result = removeGlobalTerminalTemplate(templates, "x");
+		expect(result).toEqual(templates);
+		expect(result).not.toBe(templates);
+	});
+});

--- a/src/features/settings/globalTerminalTemplateList.ts
+++ b/src/features/settings/globalTerminalTemplateList.ts
@@ -1,0 +1,26 @@
+import type { GlobalTerminalTemplate } from "@/features/terminal/templates";
+
+export function replaceGlobalTerminalTemplate(
+	templates: readonly GlobalTerminalTemplate[],
+	templateId: string,
+	nextTemplate: GlobalTerminalTemplate,
+): GlobalTerminalTemplate[] {
+	const index = templates.findIndex((template) => template.id === templateId);
+	if (index === -1) return templates.slice();
+
+	const nextTemplates = templates.slice();
+	nextTemplates[index] = nextTemplate;
+	return nextTemplates;
+}
+
+export function removeGlobalTerminalTemplate(
+	templates: readonly GlobalTerminalTemplate[],
+	templateId: string,
+): GlobalTerminalTemplate[] {
+	const index = templates.findIndex((template) => template.id === templateId);
+	if (index === -1) return templates.slice();
+
+	const nextTemplates = templates.slice();
+	nextTemplates.splice(index, 1);
+	return nextTemplates;
+}


### PR DESCRIPTION
## Stack Context

Ongoing performance pass over narrow hot paths, with each change kept as an independently benchmarked PR.

## What?

- Replaces global terminal template `map` replacement with `findIndex` plus direct replacement on a copied array.
- Replaces template removal `filter` with `findIndex` plus `splice`.
- Adds focused helper coverage and a Vitest benchmark for both paths.

## Benchmark

```bash
bunx vitest bench src/features/settings/globalTerminalTemplateList.bench.ts --run
```

Result:

```text
findIndex replace by id: 2.50x faster than map replace by id
findIndex splice remove by id: 7.43x faster than filter remove by id
```

## Validation

```bash
bunx vitest run src/features/settings/globalTerminalTemplateList.test.ts src/features/settings/stores/terminalTemplatesStore.test.ts
bunx tsc --noEmit
```
