### PR TITLE
perf: splice project template drafts

### DIFF
--- a/src/features/projects/components/ProjectTemplatesEditor.tsx
+++ b/src/features/projects/components/ProjectTemplatesEditor.tsx
@@ -16,6 +16,10 @@ import {
 } from "@/features/terminal/templates";
 import { TerminalTemplateDraftDialog } from "@/features/terminal/TerminalTemplateDraftDialog";
 import * as m from "@/paraglide/messages.js";
+import {
+	removeProjectTemplateDraft,
+	replaceProjectTemplateDraft,
+} from "./projectTemplateDraftList";
 
 interface ProjectTemplatesEditorProps {
 	templateDrafts: ProjectTerminalTemplateDraft[];
@@ -52,7 +56,7 @@ export function ProjectTemplatesEditor({
 	function handleCommit() {
 		if (!draft) return;
 		if (editingId) {
-			onChange(templateDrafts.map((t) => (t.id === editingId ? draft : t)));
+			onChange(replaceProjectTemplateDraft(templateDrafts, editingId, draft));
 		} else {
 			onChange([...templateDrafts, draft]);
 		}
@@ -61,7 +65,7 @@ export function ProjectTemplatesEditor({
 
 	function handleDelete() {
 		if (!editingId) return;
-		onChange(templateDrafts.filter((t) => t.id !== editingId));
+		onChange(removeProjectTemplateDraft(templateDrafts, editingId));
 		closeDialog();
 	}
 
@@ -148,7 +152,7 @@ export function ProjectTemplatesEditor({
 										colorPalette="red"
 										aria-label={m.deleteTerminalTemplate()}
 										onClick={() =>
-											onChange(templateDrafts.filter((x) => x.id !== t.id))
+											onChange(removeProjectTemplateDraft(templateDrafts, t.id))
 										}
 									>
 										<FiTrash2 />

--- a/src/features/projects/components/projectTemplateDraftList.bench.ts
+++ b/src/features/projects/components/projectTemplateDraftList.bench.ts
@@ -1,0 +1,50 @@
+import { bench, describe } from "vitest";
+import type { ProjectTerminalTemplateDraft } from "@/features/terminal/templates";
+import {
+	removeProjectTemplateDraft,
+	replaceProjectTemplateDraft,
+} from "./projectTemplateDraftList";
+
+const drafts: ProjectTerminalTemplateDraft[] = Array.from(
+	{ length: 2_000 },
+	(_, index) => ({
+		id: `template-${index}`,
+		name: `Template ${index}`,
+		commandsText: `echo ${index}`,
+		cwd: `packages/app-${index}`,
+	}),
+);
+
+const targetId = "template-1500";
+const replacement: ProjectTerminalTemplateDraft = {
+	id: targetId,
+	name: "Updated",
+	commandsText: "bun run dev",
+	cwd: "apps/web",
+};
+
+function replaceWithMap() {
+	return drafts.map((draft) => (draft.id === targetId ? replacement : draft));
+}
+
+function removeWithFilter() {
+	return drafts.filter((draft) => draft.id !== targetId);
+}
+
+describe("project template draft list updates", () => {
+	bench("map replace by id", () => {
+		replaceWithMap();
+	});
+
+	bench("findIndex replace by id", () => {
+		replaceProjectTemplateDraft(drafts, targetId, replacement);
+	});
+
+	bench("filter remove by id", () => {
+		removeWithFilter();
+	});
+
+	bench("findIndex splice remove by id", () => {
+		removeProjectTemplateDraft(drafts, targetId);
+	});
+});

--- a/src/features/projects/components/projectTemplateDraftList.test.ts
+++ b/src/features/projects/components/projectTemplateDraftList.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import type { ProjectTerminalTemplateDraft } from "@/features/terminal/templates";
+import {
+	removeProjectTemplateDraft,
+	replaceProjectTemplateDraft,
+} from "./projectTemplateDraftList";
+
+const drafts: ProjectTerminalTemplateDraft[] = [
+	{ id: "a", name: "A", commandsText: "a", cwd: "" },
+	{ id: "b", name: "B", commandsText: "b", cwd: "apps/web" },
+	{ id: "c", name: "C", commandsText: "c", cwd: "" },
+];
+
+describe("project template draft list updates", () => {
+	it("replaces a draft by id", () => {
+		const replacement = {
+			id: "b",
+			name: "Updated",
+			commandsText: "dev",
+			cwd: "apps/api",
+		};
+		expect(replaceProjectTemplateDraft(drafts, "b", replacement)).toEqual([
+			drafts[0],
+			replacement,
+			drafts[2],
+		]);
+	});
+
+	it("returns a copied array when replacement id is missing", () => {
+		const result = replaceProjectTemplateDraft(drafts, "x", {
+			id: "x",
+			name: "X",
+			commandsText: "",
+			cwd: "",
+		});
+		expect(result).toEqual(drafts);
+		expect(result).not.toBe(drafts);
+	});
+
+	it("removes a draft by id", () => {
+		expect(removeProjectTemplateDraft(drafts, "b")).toEqual([
+			drafts[0],
+			drafts[2],
+		]);
+	});
+
+	it("returns a copied array when removal id is missing", () => {
+		const result = removeProjectTemplateDraft(drafts, "x");
+		expect(result).toEqual(drafts);
+		expect(result).not.toBe(drafts);
+	});
+});

--- a/src/features/projects/components/projectTemplateDraftList.ts
+++ b/src/features/projects/components/projectTemplateDraftList.ts
@@ -1,0 +1,26 @@
+import type { ProjectTerminalTemplateDraft } from "@/features/terminal/templates";
+
+export function replaceProjectTemplateDraft(
+	templateDrafts: readonly ProjectTerminalTemplateDraft[],
+	templateId: string,
+	draft: ProjectTerminalTemplateDraft,
+): ProjectTerminalTemplateDraft[] {
+	const index = templateDrafts.findIndex((template) => template.id === templateId);
+	if (index === -1) return templateDrafts.slice();
+
+	const nextDrafts = templateDrafts.slice();
+	nextDrafts[index] = draft;
+	return nextDrafts;
+}
+
+export function removeProjectTemplateDraft(
+	templateDrafts: readonly ProjectTerminalTemplateDraft[],
+	templateId: string,
+): ProjectTerminalTemplateDraft[] {
+	const index = templateDrafts.findIndex((template) => template.id === templateId);
+	if (index === -1) return templateDrafts.slice();
+
+	const nextDrafts = templateDrafts.slice();
+	nextDrafts.splice(index, 1);
+	return nextDrafts;
+}


### PR DESCRIPTION
## Stack Context

Ongoing performance pass over narrow hot paths, with each change kept as an independently benchmarked PR.

## What?

- Replaces project terminal template draft `map` replacement with `findIndex` plus direct replacement on a copied array.
- Replaces project template removal `filter` with `findIndex` plus `splice`.
- Adds focused helper coverage and a Vitest benchmark for both paths.

## Benchmark

```bash
bunx vitest bench src/features/projects/components/projectTemplateDraftList.bench.ts --run
```

Result:

```text
findIndex replace by id: 7.74x faster than map replace by id
findIndex splice remove by id: 3.50x faster than filter remove by id
```

## Validation

```bash
bunx vitest run src/features/projects/components/projectTemplateDraftList.test.ts
bunx tsc --noEmit
```
