### PR TITLE
perf: build discard paths directly

### DIFF
--- a/src/features/git/components/GitDiffContent.tsx
+++ b/src/features/git/components/GitDiffContent.tsx
@@ -35,6 +35,7 @@ import {
 import { reconcileIncludedFiles } from "../utils";
 import { ChangesDiffPane, ChangesSidebar } from "./GitDiffChangesPanel";
 import { HistoryDiffPane, HistorySidebar } from "./GitDiffHistoryPanel";
+import { buildDiscardFilePaths } from "./discardFilePaths";
 
 const SIDEBAR_TAB_CONTENT_PROPS = {
 	position: "absolute",
@@ -162,21 +163,16 @@ export default function GitDiffContent({
 	};
 
 	const handleDiscardFile = async (file: FileDiffMetadata) => {
-		const relativePaths = Array.from(
-			new Set(
-				[file.name, file.prevName].filter((path): path is string =>
-					Boolean(path),
-				),
-			),
-		);
-		const absolutePaths = relativePaths.map((path) =>
-			resolveWorktreeFilePath(worktreePath, path),
+		const { relativePaths, filePathsToRefresh } = buildDiscardFilePaths(
+			file,
+			worktreePath,
+			resolveWorktreeFilePath,
 		);
 
 		try {
 			await discardGitFileChanges.mutateAsync({
 				paths: relativePaths,
-				filePathsToRefresh: absolutePaths,
+				filePathsToRefresh,
 			});
 			toaster.create({
 				title: m.gitDiscardFileSuccessTitle(),

--- a/src/features/git/components/discardFilePaths.bench.ts
+++ b/src/features/git/components/discardFilePaths.bench.ts
@@ -1,0 +1,48 @@
+import { bench, describe } from "vitest";
+import { buildDiscardFilePaths } from "./discardFilePaths";
+
+const renamedFile = {
+	name: "src/new/path/File.tsx",
+	prevName: "src/old/path/File.tsx",
+};
+
+const unchangedFile = {
+	name: "src/path/File.tsx",
+	prevName: "src/path/File.tsx",
+};
+
+function resolvePath(worktreePath: string, relativePath: string) {
+	return `${worktreePath}/${relativePath}`;
+}
+
+function buildWithSet(file: { name: string; prevName?: string | null }) {
+	const relativePaths = Array.from(
+		new Set(
+			[file.name, file.prevName].filter((path): path is string =>
+				Boolean(path),
+			),
+		),
+	);
+	const absolutePaths = relativePaths.map((path) =>
+		resolvePath("/repo", path),
+	);
+	return { relativePaths, filePathsToRefresh: absolutePaths };
+}
+
+describe("discard file path construction", () => {
+	bench("set plus map renamed file", () => {
+		buildWithSet(renamedFile);
+	});
+
+	bench("direct renamed file paths", () => {
+		buildDiscardFilePaths(renamedFile, "/repo", resolvePath);
+	});
+
+	bench("set plus map unchanged file", () => {
+		buildWithSet(unchangedFile);
+	});
+
+	bench("direct unchanged file paths", () => {
+		buildDiscardFilePaths(unchangedFile, "/repo", resolvePath);
+	});
+});

--- a/src/features/git/components/discardFilePaths.test.ts
+++ b/src/features/git/components/discardFilePaths.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { buildDiscardFilePaths } from "./discardFilePaths";
+
+function resolvePath(worktreePath: string, relativePath: string) {
+	return `${worktreePath}/${relativePath}`;
+}
+
+describe("buildDiscardFilePaths", () => {
+	it("returns current and previous paths for renamed files", () => {
+		expect(
+			buildDiscardFilePaths(
+				{ name: "src/new.ts", prevName: "src/old.ts" },
+				"/repo",
+				resolvePath,
+			),
+		).toEqual({
+			relativePaths: ["src/new.ts", "src/old.ts"],
+			filePathsToRefresh: ["/repo/src/new.ts", "/repo/src/old.ts"],
+		});
+	});
+
+	it("deduplicates unchanged previous paths", () => {
+		expect(
+			buildDiscardFilePaths(
+				{ name: "src/file.ts", prevName: "src/file.ts" },
+				"/repo",
+				resolvePath,
+			),
+		).toEqual({
+			relativePaths: ["src/file.ts"],
+			filePathsToRefresh: ["/repo/src/file.ts"],
+		});
+	});
+
+	it("ignores empty previous paths", () => {
+		expect(
+			buildDiscardFilePaths(
+				{ name: "src/file.ts", prevName: undefined },
+				"/repo",
+				resolvePath,
+			),
+		).toEqual({
+			relativePaths: ["src/file.ts"],
+			filePathsToRefresh: ["/repo/src/file.ts"],
+		});
+	});
+});

--- a/src/features/git/components/discardFilePaths.ts
+++ b/src/features/git/components/discardFilePaths.ts
@@ -1,0 +1,24 @@
+import type { FileDiffMetadata } from "@pierre/diffs";
+
+export interface DiscardFilePaths {
+	relativePaths: string[];
+	filePathsToRefresh: string[];
+}
+
+export function buildDiscardFilePaths(
+	file: Pick<FileDiffMetadata, "name" | "prevName">,
+	worktreePath: string,
+	resolvePath: (worktreePath: string, relativePath: string) => string,
+): DiscardFilePaths {
+	const relativePaths =
+		file.prevName && file.prevName !== file.name
+			? [file.name, file.prevName]
+			: [file.name];
+	const filePathsToRefresh = new Array<string>(relativePaths.length);
+
+	for (let index = 0; index < relativePaths.length; index++) {
+		filePathsToRefresh[index] = resolvePath(worktreePath, relativePaths[index]);
+	}
+
+	return { relativePaths, filePathsToRefresh };
+}


### PR DESCRIPTION
## Stack Context

Ongoing performance pass over narrow hot paths, with each change kept as an independently benchmarked PR.

## What?

- Builds discard relative paths and refresh paths directly for git diff file actions.
- Avoids allocating a temporary array, filtering it, wrapping it in a Set, converting it back to an array, then mapping.
- Preserves rename-path deduplication for unchanged previous names.

## Benchmark

```bash
bunx vitest bench src/features/git/components/discardFilePaths.bench.ts --run
```

Result:

```text
direct renamed file paths: 2.37x faster than set plus map renamed file
direct unchanged file paths: 2.52x faster than set plus map unchanged file
```

## Validation

```bash
bunx vitest run src/features/git/components/discardFilePaths.test.ts src/features/git/components/GitDiffPane.test.tsx
bunx tsc --noEmit
```
