### PR TITLE
perf: preallocate restored sessions

### DIFF
--- a/src/features/terminal/restorationCollections.bench.ts
+++ b/src/features/terminal/restorationCollections.bench.ts
@@ -1,0 +1,51 @@
+import { bench, describe } from "vitest";
+import type { ProjectWithProfiles, PtySessionRecord } from "@/generated";
+import { collectProjectSessions } from "./restorationCollections";
+
+const projects: ProjectWithProfiles[] = Array.from(
+	{ length: 500 },
+	(_, projectIndex) => ({
+		id: `project-${projectIndex}`,
+		name: `Project ${projectIndex}`,
+		folder: `/repo/project-${projectIndex}`,
+		created_at: "2026-01-01T00:00:00Z",
+		group_id: null,
+		profiles: Array.from({ length: 6 }, (_, profileIndex) => ({
+			id: `profile-${projectIndex}-${profileIndex}`,
+			project_id: `project-${projectIndex}`,
+			branch_name: `branch-${profileIndex}`,
+			worktree_path: `/workspace/${projectIndex}/${profileIndex}`,
+			created_at: "2026-01-01T00:00:00Z",
+			is_default: profileIndex === 0,
+		})),
+	}),
+);
+
+const projectSessions = projects.map((project) => ({
+	project,
+	sessions: Array.from({ length: 4 }, (_, index): PtySessionRecord => ({
+		id: `session-${project.id}-${index}`,
+		profile_id: project.profiles[index % project.profiles.length].id,
+		title: `Session ${index}`,
+		shell: "/bin/zsh",
+		cwd: project.folder,
+		cols: 120,
+		rows: 30,
+		created_at: "2026-01-01T00:00:00Z",
+		closed_at: null,
+	})),
+}));
+
+function collectSessionsWithFlatMap() {
+	return projectSessions.flatMap(({ sessions }) => sessions);
+}
+
+describe("terminal restoration collection building", () => {
+	bench("flatMap sessions", () => {
+		collectSessionsWithFlatMap();
+	});
+
+	bench("preallocated sessions", () => {
+		collectProjectSessions(projectSessions);
+	});
+});

--- a/src/features/terminal/restorationCollections.test.ts
+++ b/src/features/terminal/restorationCollections.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import type { PtySessionRecord } from "@/generated";
+import { collectProjectSessions } from "./restorationCollections";
+
+const session: PtySessionRecord = {
+	id: "session-1",
+	profile_id: "profile-1",
+	title: "Terminal",
+	shell: "/bin/zsh",
+	cwd: "/repo/project-1",
+	cols: 120,
+	rows: 30,
+	created_at: "2026-01-01T00:00:00Z",
+	closed_at: null,
+};
+
+describe("terminal restoration collections", () => {
+	it("flattens project sessions", () => {
+		expect(collectProjectSessions([{ sessions: [session] }])).toEqual([
+			session,
+		]);
+	});
+});

--- a/src/features/terminal/restorationCollections.ts
+++ b/src/features/terminal/restorationCollections.ts
@@ -1,0 +1,20 @@
+import type { PtySessionRecord } from "@/generated";
+
+export function collectProjectSessions(
+	projectSessions: readonly { sessions: readonly PtySessionRecord[] }[],
+): PtySessionRecord[] {
+	let sessionCount = 0;
+	for (const item of projectSessions) {
+		sessionCount += item.sessions.length;
+	}
+
+	const sessions = new Array<PtySessionRecord>(sessionCount);
+	let index = 0;
+	for (const item of projectSessions) {
+		for (const session of item.sessions) {
+			sessions[index] = session;
+			index += 1;
+		}
+	}
+	return sessions;
+}

--- a/src/features/terminal/state.ts
+++ b/src/features/terminal/state.ts
@@ -8,6 +8,7 @@ import {
 } from "@/generated";
 import { queryClient } from "@/shared/lib/queryClient";
 import { queryKeys } from "@/shared/lib/queryKeys";
+import { collectProjectSessions } from "./restorationCollections";
 import { useTerminalStore } from "./store";
 
 /**
@@ -70,7 +71,7 @@ async function restoreTerminals(projects: ProjectWithProfiles[]) {
 		})),
 	);
 
-	const allSessions = projectSessions.flatMap(({ sessions }) => sessions);
+	const allSessions = collectProjectSessions(projectSessions);
 	consola.info(`[pty-restore] found ${allSessions.length} sessions`);
 	if (allSessions.length === 0) return;
 


### PR DESCRIPTION
## Stack Context

Ongoing performance pass over narrow hot paths, with each change kept as an independently benchmarked PR.

## What?

- Flattens restored PTY session batches into a preallocated array.
- Avoids `flatMap` allocation/callback overhead in terminal restoration startup.
- Adds focused helper coverage and a Vitest benchmark.

## Benchmark

```bash
bunx vitest bench src/features/terminal/restorationCollections.bench.ts --run
```

Result:

```text
preallocated sessions: 6.65x faster than flatMap sessions
```

## Validation

```bash
bunx vitest run src/features/terminal/restorationCollections.test.ts
bunx tsc --noEmit
```
