### PR TITLE
perf: collect tab strip items once

### DIFF
--- a/src/features/terminal/TabStrip.tsx
+++ b/src/features/terminal/TabStrip.tsx
@@ -1,6 +1,7 @@
 import { Box, CloseButton, HStack } from "@chakra-ui/react";
 import { AnimatePresence, motion } from "motion/react";
 import type { KeyboardEvent, ReactNode } from "react";
+import { collectVisibleTabItems } from "./tabStripItems";
 
 const TAB_MIN_WIDTH = "140px";
 
@@ -161,7 +162,7 @@ export function TabStrip({
 	onSelect: (value: string) => void;
 	trailingControls?: ReactNode;
 }) {
-	const visibleGroups = groups.filter((group) => group.items.length > 0);
+	const visibleItems = collectVisibleTabItems(groups);
 
 	return (
 		<Box
@@ -172,16 +173,14 @@ export function TabStrip({
 			minW="max-content"
 		>
 			<AnimatePresence initial={false}>
-				{visibleGroups.flatMap((group) =>
-					group.items.map((item) => (
-						<TabMotionItem
-							key={item.key}
-							item={item}
-							motionProps={motionProps}
-							onSelect={onSelect}
-						/>
-					)),
-				)}
+				{visibleItems.map((item) => (
+					<TabMotionItem
+						key={item.key}
+						item={item}
+						motionProps={motionProps}
+						onSelect={onSelect}
+					/>
+				))}
 			</AnimatePresence>
 			{trailingControls}
 		</Box>

--- a/src/features/terminal/tabStripItems.bench.ts
+++ b/src/features/terminal/tabStripItems.bench.ts
@@ -1,0 +1,33 @@
+import { bench, describe } from "vitest";
+import type { TabStripGroup } from "./TabStrip";
+import { collectVisibleTabItems } from "./tabStripItems";
+
+const groups: TabStripGroup[] = Array.from({ length: 400 }, (_, groupIndex) => ({
+	id: `group-${groupIndex}`,
+	items:
+		groupIndex % 5 === 0
+			? []
+			: Array.from({ length: 8 }, (_, itemIndex) => ({
+					key: `tab-${groupIndex}-${itemIndex}`,
+					value: `tab-${groupIndex}-${itemIndex}`,
+					icon: null,
+					title: `Tab ${groupIndex}-${itemIndex}`,
+					maxTitleLength: 24,
+				})),
+}));
+
+function collectWithFilterFlatMap() {
+	return groups
+		.filter((group) => group.items.length > 0)
+		.flatMap((group) => group.items);
+}
+
+describe("tab strip visible item collection", () => {
+	bench("filter plus flatMap items", () => {
+		collectWithFilterFlatMap();
+	});
+
+	bench("single pass item collection", () => {
+		collectVisibleTabItems(groups);
+	});
+});

--- a/src/features/terminal/tabStripItems.test.ts
+++ b/src/features/terminal/tabStripItems.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import type { TabStripGroup } from "./TabStrip";
+import { collectVisibleTabItems } from "./tabStripItems";
+
+const groups: TabStripGroup[] = [
+	{ id: "empty", items: [] },
+	{
+		id: "terminal",
+		items: [
+			{
+				key: "a",
+				value: "a",
+				icon: null,
+				title: "A",
+				maxTitleLength: 24,
+			},
+		],
+	},
+];
+
+describe("collectVisibleTabItems", () => {
+	it("returns items from non-empty groups in order", () => {
+		expect(collectVisibleTabItems(groups)).toEqual([groups[1].items[0]]);
+	});
+});

--- a/src/features/terminal/tabStripItems.ts
+++ b/src/features/terminal/tabStripItems.ts
@@ -1,0 +1,13 @@
+import type { TabStripGroup, TabStripItem } from "./TabStrip";
+
+export function collectVisibleTabItems(
+	groups: readonly TabStripGroup[],
+): TabStripItem[] {
+	const items: TabStripItem[] = [];
+	for (const group of groups) {
+		for (const item of group.items) {
+			items.push(item);
+		}
+	}
+	return items;
+}


### PR DESCRIPTION
## Stack Context

Ongoing performance pass over narrow hot paths, with each change kept as an independently benchmarked PR.

## What?

- Collects visible tab strip items in a single pass.
- Avoids filtering groups and then flatMapping items before rendering.
- Adds focused helper coverage and a Vitest benchmark.

## Benchmark

```bash
bunx vitest bench src/features/terminal/tabStripItems.bench.ts --run
```

Result:

```text
single pass item collection: 3.24x faster than filter plus flatMap items
```

## Validation

```bash
bunx vitest run src/features/terminal/tabStripItems.test.ts
bunx tsc --noEmit
```
