### PR TITLE
perf: update profile cache by index

### DIFF
--- a/src/features/profiles/hooks.ts
+++ b/src/features/profiles/hooks.ts
@@ -8,6 +8,7 @@ import {
 } from "@/generated";
 import type { ProjectWithProfiles } from "@/generated";
 import { queryKeys } from "@/shared/lib/queryKeys";
+import { removeProjectProfile, upsertProjectProfile } from "./profileCache";
 
 function hasDiffStats(stats: GitDiffStats | null) {
 	return (
@@ -30,21 +31,7 @@ export function useCreateProfile() {
 		onSuccess: (profile) => {
 			queryClient.setQueryData<ProjectWithProfiles[]>(
 				queryKeys.projects.all,
-				(projects) =>
-					projects?.map((project) => {
-						if (project.id !== profile.project_id) return project;
-						const hasProfile = project.profiles.some(
-							(item) => item.id === profile.id,
-						);
-						return {
-							...project,
-							profiles: hasProfile
-								? project.profiles.map((item) =>
-										item.id === profile.id ? profile : item,
-									)
-								: [...project.profiles, profile],
-						};
-					}),
+				(projects) => upsertProjectProfile(projects, profile),
 			);
 			queryClient.invalidateQueries({ queryKey: queryKeys.projects.all });
 		},
@@ -56,15 +43,11 @@ export function useDeleteProfile() {
 	return useMutation({
 		mutationFn: ({ id }: { id: string; projectId: string }) =>
 			deleteProfile({ id }),
-		onSuccess: (_data, { id }) => {
+		onSuccess: (_data, { id, projectId }) => {
 			useTerminalStore.getState().removeProfile(id);
 			queryClient.setQueryData<ProjectWithProfiles[]>(
 				queryKeys.projects.all,
-				(projects) =>
-					projects?.map((project) => ({
-						...project,
-						profiles: project.profiles.filter((profile) => profile.id !== id),
-					})),
+				(projects) => removeProjectProfile(projects, projectId, id),
 			);
 			queryClient.invalidateQueries({ queryKey: queryKeys.projects.all });
 		},

--- a/src/features/profiles/profileCache.bench.ts
+++ b/src/features/profiles/profileCache.bench.ts
@@ -1,0 +1,84 @@
+import { bench, describe } from "vitest";
+import type { Profile, ProjectWithProfiles } from "@/generated";
+import { removeProjectProfile, upsertProjectProfile } from "./profileCache";
+
+const projects: ProjectWithProfiles[] = Array.from(
+	{ length: 500 },
+	(_, projectIndex) => ({
+		id: `project-${projectIndex}`,
+		name: `Project ${projectIndex}`,
+		folder: `/repo/project-${projectIndex}`,
+		created_at: "2026-01-01T00:00:00Z",
+		group_id: null,
+		profiles: Array.from({ length: 8 }, (_, profileIndex) => ({
+			id: `profile-${projectIndex}-${profileIndex}`,
+			project_id: `project-${projectIndex}`,
+			branch_name: `branch-${profileIndex}`,
+			worktree_path: `/workspace/${projectIndex}/${profileIndex}`,
+			created_at: "2026-01-01T00:00:00Z",
+			is_default: profileIndex === 0,
+		})),
+	}),
+);
+
+const existingProfile: Profile = {
+	...projects[350].profiles[6],
+	branch_name: "updated",
+};
+
+const newProfile: Profile = {
+	id: "profile-new",
+	project_id: "project-350",
+	branch_name: "new",
+	worktree_path: "/workspace/new",
+	created_at: "2026-01-01T00:00:00Z",
+	is_default: false,
+};
+
+function upsertWithMap(profile: Profile) {
+	return projects.map((project) => {
+		if (project.id !== profile.project_id) return project;
+		const hasProfile = project.profiles.some((item) => item.id === profile.id);
+		return {
+			...project,
+			profiles: hasProfile
+				? project.profiles.map((item) =>
+						item.id === profile.id ? profile : item,
+					)
+				: [...project.profiles, profile],
+		};
+	});
+}
+
+function removeWithMapFilter(profileId: string) {
+	return projects.map((project) => ({
+		...project,
+		profiles: project.profiles.filter((profile) => profile.id !== profileId),
+	}));
+}
+
+describe("profile project cache updates", () => {
+	bench("map upsert existing profile", () => {
+		upsertWithMap(existingProfile);
+	});
+
+	bench("indexed upsert existing profile", () => {
+		upsertProjectProfile(projects, existingProfile);
+	});
+
+	bench("map append new profile", () => {
+		upsertWithMap(newProfile);
+	});
+
+	bench("indexed append new profile", () => {
+		upsertProjectProfile(projects, newProfile);
+	});
+
+	bench("map filter remove profile", () => {
+		removeWithMapFilter(existingProfile.id);
+	});
+
+	bench("indexed splice remove profile", () => {
+		removeProjectProfile(projects, existingProfile.project_id, existingProfile.id);
+	});
+});

--- a/src/features/profiles/profileCache.test.ts
+++ b/src/features/profiles/profileCache.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import type { Profile, ProjectWithProfiles } from "@/generated";
+import { removeProjectProfile, upsertProjectProfile } from "./profileCache";
+
+const profileA: Profile = {
+	id: "profile-a",
+	project_id: "project-1",
+	branch_name: "main",
+	worktree_path: "/workspace/a",
+	created_at: "2026-01-01T00:00:00Z",
+	is_default: true,
+};
+
+const profileB: Profile = {
+	id: "profile-b",
+	project_id: "project-1",
+	branch_name: "feature",
+	worktree_path: "/workspace/b",
+	created_at: "2026-01-01T00:00:00Z",
+	is_default: false,
+};
+
+const projects: ProjectWithProfiles[] = [
+	{
+		id: "project-1",
+		name: "Project",
+		folder: "/repo",
+		created_at: "2026-01-01T00:00:00Z",
+		group_id: null,
+		profiles: [profileA],
+	},
+];
+
+describe("profile project cache updates", () => {
+	it("appends a new profile to its project", () => {
+		expect(upsertProjectProfile(projects, profileB)?.[0].profiles).toEqual([
+			profileA,
+			profileB,
+		]);
+	});
+
+	it("replaces an existing profile", () => {
+		const updated = { ...profileA, branch_name: "updated" };
+		expect(upsertProjectProfile(projects, updated)?.[0].profiles).toEqual([
+			updated,
+		]);
+	});
+
+	it("removes a profile from its project", () => {
+		expect(
+			removeProjectProfile(
+				[{ ...projects[0], profiles: [profileA, profileB] }],
+				"project-1",
+				"profile-a",
+			)?.[0].profiles,
+		).toEqual([profileB]);
+	});
+});

--- a/src/features/profiles/profileCache.ts
+++ b/src/features/profiles/profileCache.ts
@@ -1,0 +1,58 @@
+import type { Profile, ProjectWithProfiles } from "@/generated";
+
+export function upsertProjectProfile(
+	projects: ProjectWithProfiles[] | undefined,
+	profile: Profile,
+): ProjectWithProfiles[] | undefined {
+	if (!projects) return projects;
+
+	const projectIndex = projects.findIndex(
+		(project) => project.id === profile.project_id,
+	);
+	if (projectIndex === -1) return projects.slice();
+
+	const nextProjects = projects.slice();
+	const project = nextProjects[projectIndex];
+	const profileIndex = project.profiles.findIndex(
+		(item) => item.id === profile.id,
+	);
+	const nextProfiles = project.profiles.slice();
+
+	if (profileIndex === -1) {
+		nextProfiles.push(profile);
+	} else {
+		nextProfiles[profileIndex] = profile;
+	}
+
+	nextProjects[projectIndex] = {
+		...project,
+		profiles: nextProfiles,
+	};
+	return nextProjects;
+}
+
+export function removeProjectProfile(
+	projects: ProjectWithProfiles[] | undefined,
+	projectId: string,
+	profileId: string,
+): ProjectWithProfiles[] | undefined {
+	if (!projects) return projects;
+
+	const projectIndex = projects.findIndex((project) => project.id === projectId);
+	if (projectIndex === -1) return projects.slice();
+
+	const nextProjects = projects.slice();
+	const project = nextProjects[projectIndex];
+	const profileIndex = project.profiles.findIndex(
+		(profile) => profile.id === profileId,
+	);
+	if (profileIndex === -1) return nextProjects;
+
+	const nextProfiles = project.profiles.slice();
+	nextProfiles.splice(profileIndex, 1);
+	nextProjects[projectIndex] = {
+		...project,
+		profiles: nextProfiles,
+	};
+	return nextProjects;
+}


### PR DESCRIPTION
## Stack Context

Ongoing performance pass over narrow hot paths, with each change kept as an independently benchmarked PR.

## What?

- Updates cached project profiles by locating the target project/profile index first.
- Avoids mapping every project and repeatedly filtering profile lists on delete.
- Adds focused helper coverage and a Vitest benchmark for existing upsert, append, and remove paths.

## Benchmark

```bash
bunx vitest bench src/features/profiles/profileCache.bench.ts --run
```

Result:

```text
indexed upsert existing profile: 2.85x faster than map upsert existing profile
indexed append new profile: 2.64x faster than map append new profile
indexed splice remove profile: 33.54x faster than map filter remove profile
```

## Validation

```bash
bunx vitest run src/features/profiles/profileCache.test.ts src/features/profiles/hooks.test.tsx
bunx tsc --noEmit
```
