### PR TITLE
perf: splice deleted project cache

### DIFF
--- a/src/features/projects/hooks.ts
+++ b/src/features/projects/hooks.ts
@@ -37,6 +37,7 @@ import {
 	writeFileContent,
 } from "@/generated";
 import { queryKeys, queryNamespaces } from "@/shared/lib/queryKeys";
+import { removeProjectById } from "./projectCache";
 
 const GIT_STATUS_REFRESH_INTERVAL_MS = 1_000;
 interface UseProjectAvatarOptions {
@@ -251,7 +252,7 @@ export function useDeleteProject(options?: {
 				) ?? [];
 			queryClient.setQueryData<ProjectWithProfiles[]>(
 				queryKeys.projects.all,
-				(projects) => projects?.filter((project) => project.id !== id),
+				(projects) => removeProjectById(projects, id),
 			);
 			await options?.onSuccess?.(id, projectsBeforeDelete);
 			await Promise.all([

--- a/src/features/projects/projectCache.bench.ts
+++ b/src/features/projects/projectCache.bench.ts
@@ -1,0 +1,31 @@
+import { bench, describe } from "vitest";
+import type { ProjectWithProfiles } from "@/generated";
+import { removeProjectById } from "./projectCache";
+
+const projects: ProjectWithProfiles[] = Array.from(
+	{ length: 5_000 },
+	(_, index) => ({
+		id: `project-${index}`,
+		name: `Project ${index}`,
+		folder: `/repo/project-${index}`,
+		created_at: "2026-01-01T00:00:00Z",
+		group_id: null,
+		profiles: [],
+	}),
+);
+
+const projectId = "project-3500";
+
+function removeWithFilter() {
+	return projects.filter((project) => project.id !== projectId);
+}
+
+describe("project cache removal", () => {
+	bench("filter remove project", () => {
+		removeWithFilter();
+	});
+
+	bench("findIndex splice remove project", () => {
+		removeProjectById(projects, projectId);
+	});
+});

--- a/src/features/projects/projectCache.test.ts
+++ b/src/features/projects/projectCache.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import type { ProjectWithProfiles } from "@/generated";
+import { removeProjectById } from "./projectCache";
+
+const projects: ProjectWithProfiles[] = [
+	{
+		id: "project-1",
+		name: "Project 1",
+		folder: "/repo/one",
+		created_at: "2026-01-01T00:00:00Z",
+		group_id: null,
+		profiles: [],
+	},
+	{
+		id: "project-2",
+		name: "Project 2",
+		folder: "/repo/two",
+		created_at: "2026-01-01T00:00:00Z",
+		group_id: null,
+		profiles: [],
+	},
+];
+
+describe("removeProjectById", () => {
+	it("removes the matching project", () => {
+		expect(removeProjectById(projects, "project-1")).toEqual([projects[1]]);
+	});
+
+	it("returns a copied array when the project is missing", () => {
+		const result = removeProjectById(projects, "missing");
+		expect(result).toEqual(projects);
+		expect(result).not.toBe(projects);
+	});
+});

--- a/src/features/projects/projectCache.ts
+++ b/src/features/projects/projectCache.ts
@@ -1,0 +1,15 @@
+import type { ProjectWithProfiles } from "@/generated";
+
+export function removeProjectById(
+	projects: ProjectWithProfiles[] | undefined,
+	projectId: string,
+): ProjectWithProfiles[] | undefined {
+	if (!projects) return projects;
+
+	const index = projects.findIndex((project) => project.id === projectId);
+	if (index === -1) return projects.slice();
+
+	const nextProjects = projects.slice();
+	nextProjects.splice(index, 1);
+	return nextProjects;
+}


### PR DESCRIPTION
## Stack Context

Ongoing performance pass over narrow hot paths, with each change kept as an independently benchmarked PR.

## What?

- Removes deleted projects from the cached project list with `findIndex` plus `splice`.
- Avoids filtering the whole project array during delete-project cache updates.
- Adds focused helper coverage and a Vitest benchmark.

## Benchmark

```bash
bunx vitest bench src/features/projects/projectCache.bench.ts --run
```

Result:

```text
findIndex splice remove project: 3.94x faster than filter remove project
```

## Validation

```bash
bunx vitest run src/features/projects/projectCache.test.ts src/features/projects/hooks.test.tsx
bunx tsc --noEmit
```
