### PR TITLE
perf(git): preallocate parsed patch files

### DIFF
--- a/src/features/git/hooks.ts
+++ b/src/features/git/hooks.ts
@@ -19,6 +19,7 @@ import {
 	gitPush,
 } from "@/generated";
 import { queryKeys } from "@/shared/lib/queryKeys";
+import { collectPatchFiles } from "./patchFiles";
 import type { GitBinaryPreviewSource } from "./utils";
 
 const GIT_STATUS_REFRESH_INTERVAL_MS = 1_000;
@@ -173,13 +174,13 @@ export function useDiscardGitFileChanges(profileId: string) {
 
 export function useGitDiffFiles(profileId: string) {
 	const { data: diff } = useGitDiff(profileId);
-	return useMemo(() => parsePatchFiles(diff).flatMap((p) => p.files), [diff]);
+	return useMemo(() => collectPatchFiles(parsePatchFiles(diff)), [diff]);
 }
 
 export function useCommitDiffFiles(profileId: string, commitHash: string) {
 	const { data: commitDiff } = useCommitDiff(profileId, commitHash);
 	return useMemo(
-		() => parsePatchFiles(commitDiff).flatMap((p) => p.files),
+		() => collectPatchFiles(parsePatchFiles(commitDiff)),
 		[commitDiff],
 	);
 }

--- a/src/features/git/patchFiles.bench.ts
+++ b/src/features/git/patchFiles.bench.ts
@@ -1,0 +1,30 @@
+import { bench, describe } from "vitest";
+import type { FileDiffMetadata } from "@pierre/diffs";
+import { collectPatchFiles } from "./patchFiles";
+
+const patches = Array.from({ length: 500 }, (_, patchIndex) => ({
+	files: Array.from(
+		{ length: 6 },
+		(_, fileIndex) =>
+			({
+				name: `src/patch-${patchIndex}/file-${fileIndex}.ts`,
+				additionLines: [],
+				deletionLines: [],
+				hunks: [],
+			}) as unknown as FileDiffMetadata,
+	),
+}));
+
+function collectWithFlatMap() {
+	return patches.flatMap((patch) => patch.files);
+}
+
+describe("parsed patch file collection", () => {
+	bench("flatMap patch files", () => {
+		collectWithFlatMap();
+	});
+
+	bench("preallocated patch files", () => {
+		collectPatchFiles(patches);
+	});
+});

--- a/src/features/git/patchFiles.test.ts
+++ b/src/features/git/patchFiles.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import type { FileDiffMetadata } from "@pierre/diffs";
+import { collectPatchFiles } from "./patchFiles";
+
+const fileA = { name: "a.ts" } as FileDiffMetadata;
+const fileB = { name: "b.ts" } as FileDiffMetadata;
+
+describe("collectPatchFiles", () => {
+	it("flattens patch files in order", () => {
+		expect(
+			collectPatchFiles([
+				{ files: [fileA] },
+				{ files: [] },
+				{ files: [fileB] },
+			]),
+		).toEqual([fileA, fileB]);
+	});
+});

--- a/src/features/git/patchFiles.ts
+++ b/src/features/git/patchFiles.ts
@@ -1,0 +1,22 @@
+import type { FileDiffMetadata } from "@pierre/diffs";
+
+interface PatchWithFiles {
+	files: FileDiffMetadata[];
+}
+
+export function collectPatchFiles(patches: readonly PatchWithFiles[]) {
+	let fileCount = 0;
+	for (const patch of patches) {
+		fileCount += patch.files.length;
+	}
+
+	const files = new Array<FileDiffMetadata>(fileCount);
+	let index = 0;
+	for (const patch of patches) {
+		for (const file of patch.files) {
+			files[index] = file;
+			index += 1;
+		}
+	}
+	return files;
+}


### PR DESCRIPTION
## Summary
- flatten parsed diff patch files into a preallocated array
- avoid flatMap allocation/callback overhead after parsePatchFiles returns parsed patches
- keep focused helper coverage for file order and empty patch entries

## Verification
- bunx vitest run src/features/git/patchFiles.test.ts src/features/git/components/GitDiffPane.test.tsx
- bunx eslint src/features/git/hooks.ts src/features/git/patchFiles.ts src/features/git/patchFiles.test.ts src/features/git/components/GitDiffPane.test.tsx