### PR TITLE
perf: collect change file names once

### DIFF
--- a/src/features/git/components/GitDiffContent.tsx
+++ b/src/features/git/components/GitDiffContent.tsx
@@ -35,6 +35,7 @@ import {
 import { reconcileIncludedFiles } from "../utils";
 import { ChangesDiffPane, ChangesSidebar } from "./GitDiffChangesPanel";
 import { HistoryDiffPane, HistorySidebar } from "./GitDiffHistoryPanel";
+import { collectChangeFileNames } from "./changeFileNames";
 
 const SIDEBAR_TAB_CONTENT_PROPS = {
 	position: "absolute",
@@ -320,9 +321,9 @@ export default function GitDiffContent({
 	}, [state.selectedCommit]);
 
 	useEffect(() => {
-		const nextFileNames = changesFiles.map((file) => file.name);
+		const nextFileNames = collectChangeFileNames(changesFiles);
 		const nextIncluded = reconcileIncludedFiles(
-			nextFileNames,
+			nextFileNames.names,
 			includedFileNames,
 			previousChangeFileNamesRef.current,
 		);
@@ -331,7 +332,7 @@ export default function GitDiffContent({
 			setIncludedFileNames(nextIncluded);
 		}
 
-		previousChangeFileNamesRef.current = new Set(nextFileNames);
+		previousChangeFileNamesRef.current = nextFileNames.nameSet;
 	}, [changesFiles, includedFileNames]);
 
 	useEffect(() => {

--- a/src/features/git/components/changeFileNames.bench.ts
+++ b/src/features/git/components/changeFileNames.bench.ts
@@ -1,0 +1,22 @@
+import { bench, describe } from "vitest";
+import { collectChangeFileNames } from "./changeFileNames";
+
+const files = Array.from({ length: 5_000 }, (_, index) => ({
+	name: `src/file-${index}.ts`,
+}));
+
+function collectWithMapThenSet() {
+	const names = files.map((file) => file.name);
+	const nameSet = new Set(names);
+	return { names, nameSet };
+}
+
+describe("git change file name collection", () => {
+	bench("map then set file names", () => {
+		collectWithMapThenSet();
+	});
+
+	bench("single pass file names and set", () => {
+		collectChangeFileNames(files);
+	});
+});

--- a/src/features/git/components/changeFileNames.test.ts
+++ b/src/features/git/components/changeFileNames.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { collectChangeFileNames } from "./changeFileNames";
+
+describe("collectChangeFileNames", () => {
+	it("returns ordered names and a matching set", () => {
+		const result = collectChangeFileNames([
+			{ name: "a.ts" },
+			{ name: "b.ts" },
+		]);
+
+		expect(result.names).toEqual(["a.ts", "b.ts"]);
+		expect(result.nameSet).toEqual(new Set(["a.ts", "b.ts"]));
+	});
+});

--- a/src/features/git/components/changeFileNames.ts
+++ b/src/features/git/components/changeFileNames.ts
@@ -1,0 +1,21 @@
+import type { FileDiffMetadata } from "@pierre/diffs";
+
+export interface ChangeFileNames {
+	names: string[];
+	nameSet: Set<string>;
+}
+
+export function collectChangeFileNames(
+	files: readonly Pick<FileDiffMetadata, "name">[],
+): ChangeFileNames {
+	const names = new Array<string>(files.length);
+	const nameSet = new Set<string>();
+
+	for (let index = 0; index < files.length; index++) {
+		const name = files[index].name;
+		names[index] = name;
+		nameSet.add(name);
+	}
+
+	return { names, nameSet };
+}


### PR DESCRIPTION
## Stack Context

Ongoing performance pass over narrow hot paths, with each change kept as an independently benchmarked PR.

## What?

- Collects git diff file names and the previous-file-name set in one pass.
- Avoids mapping file names and then constructing a Set from that mapped array.
- Adds focused helper coverage and a Vitest benchmark.

## Benchmark

```bash
bunx vitest bench src/features/git/components/changeFileNames.bench.ts --run
```

Result:

```text
single pass file names and set: 1.21x faster than map then set file names
```

## Validation

```bash
bunx vitest run src/features/git/components/changeFileNames.test.ts src/features/git/components/GitDiffPane.test.tsx
bunx tsc --noEmit
```
