### PR TITLE
perf: reuse topbar app search roots

### DIFF
--- a/src-tauri/src/handler/topbar.rs
+++ b/src-tauri/src/handler/topbar.rs
@@ -108,17 +108,27 @@ fn app_search_roots() -> Vec<PathBuf> {
 
 #[cfg(target_os = "macos")]
 fn resolve_app_path(spec: &TopbarAppSpec) -> Option<PathBuf> {
-	app_search_roots()
-		.into_iter()
+	let roots = app_search_roots();
+	resolve_app_path_in_roots(spec, &roots)
+}
+
+#[cfg(target_os = "macos")]
+fn resolve_app_path_in_roots(
+	spec: &TopbarAppSpec,
+	roots: &[PathBuf],
+) -> Option<PathBuf> {
+	roots
+		.iter()
 		.map(|root| root.join(spec.bundle_name))
 		.find(|path| path.exists())
 }
 
 #[cfg(target_os = "macos")]
 fn list_supported_topbar_apps_macos() -> Vec<TopbarApp> {
+	let roots = app_search_roots();
 	KNOWN_TOPBAR_APPS
 		.iter()
-		.filter(|spec| resolve_app_path(spec).is_some())
+		.filter(|spec| resolve_app_path_in_roots(spec, &roots).is_some())
 		.map(|spec| TopbarApp {
 			id: spec.id.to_string(),
 		})
@@ -268,6 +278,8 @@ pub async fn open_topbar_app(
 #[cfg(test)]
 mod tests {
 	use std::collections::HashSet;
+	#[cfg(target_os = "macos")]
+	use std::time::Instant;
 
 	use super::*;
 
@@ -284,5 +296,42 @@ mod tests {
 		let roots = app_search_roots();
 		assert!(roots.contains(&PathBuf::from("/Applications")));
 		assert!(roots.contains(&PathBuf::from("/Applications/Setapp")));
+	}
+
+	#[cfg(target_os = "macos")]
+	#[test]
+	#[ignore]
+	fn bench_list_supported_topbar_apps_reusing_roots() {
+		let iterations = 20_000;
+
+		let started = Instant::now();
+		let mut repeated_roots_count = 0;
+		for _ in 0..iterations {
+			repeated_roots_count += KNOWN_TOPBAR_APPS
+				.iter()
+				.filter(|spec| {
+					let roots = app_search_roots();
+					resolve_app_path_in_roots(spec, &roots).is_some()
+				})
+				.count();
+		}
+		let repeated_roots = started.elapsed();
+
+		let started = Instant::now();
+		let mut reused_roots_count = 0;
+		for _ in 0..iterations {
+			let roots = app_search_roots();
+			reused_roots_count += KNOWN_TOPBAR_APPS
+				.iter()
+				.filter(|spec| resolve_app_path_in_roots(spec, &roots).is_some())
+				.count();
+		}
+		let reused_roots = started.elapsed();
+
+		assert_eq!(repeated_roots_count, reused_roots_count);
+		println!(
+			"repeated_roots={repeated_roots:?} reused_roots={reused_roots:?} speedup={:.2}x",
+			repeated_roots.as_secs_f64() / reused_roots.as_secs_f64()
+		);
 	}
 }


### PR DESCRIPTION
## Summary
- Reuse the macOS topbar app search roots while listing supported apps instead of rebuilding them for every known app.
- Keep `open_topbar_app` behavior unchanged by resolving roots on demand there.
- Add an ignored macOS release benchmark beside the topbar tests.

## Benchmark
```
cd src-tauri && cargo test bench_list_supported_topbar_apps_reusing_roots --release -- --ignored --nocapture
repeated_roots=403.892792ms reused_roots=327.852708ms speedup=1.23x
```

## Validation
```
cd src-tauri && cargo test topbar
```

Note: the macOS test build still emits the pre-existing `windows_commands` dead_code warning because that field is only read under the Windows cfg.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized macOS top-bar app resolution performance through improved internal app search logic.

* **Tests**
  * Added benchmark tests to measure performance improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AkaraChen/2code/pull/215)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->