### PR TITLE
perf: collect supported topbar controls once

### DIFF
--- a/src/features/topbar/registry.bench.ts
+++ b/src/features/topbar/registry.bench.ts
@@ -1,0 +1,51 @@
+import { bench } from "vitest";
+import { getSupportedControlIds } from "./registry";
+import type { ControlId, LaunchAppControlId } from "./types";
+
+const CONTROL_DEFS: { id: ControlId; kind: "app" | "static" }[] = [
+	{ id: "github-desktop", kind: "app" },
+	{ id: "vscode", kind: "app" },
+	{ id: "windsurf", kind: "app" },
+	{ id: "cursor", kind: "app" },
+	{ id: "zed", kind: "app" },
+	{ id: "sublime-text", kind: "app" },
+	{ id: "ghostty", kind: "app" },
+	{ id: "iterm2", kind: "app" },
+	{ id: "kitty", kind: "app" },
+	{ id: "warp", kind: "app" },
+	{ id: "git-diff", kind: "static" },
+	{ id: "pr-status", kind: "static" },
+	{ id: "reveal-in-finder", kind: "static" },
+];
+
+const SUPPORTED_APP_IDS: LaunchAppControlId[] = [
+	"github-desktop",
+	"vscode",
+	"cursor",
+	"zed",
+	"ghostty",
+	"warp",
+];
+
+function getSupportedControlIdsWithFilterMap(
+	supportedAppIds: readonly LaunchAppControlId[],
+) {
+	const supportedAppIdSet = new Set(supportedAppIds);
+	return CONTROL_DEFS
+		.filter(
+			(def) =>
+				def.kind === "static" ||
+				supportedAppIdSet.has(def.id as LaunchAppControlId),
+		)
+		.map((def) => def.id);
+}
+
+bench("filter map supported controls", () => {
+	const ids = getSupportedControlIdsWithFilterMap(SUPPORTED_APP_IDS);
+	if (ids.length === 0) throw new Error("unreachable");
+});
+
+bench("single pass supported controls", () => {
+	const ids = getSupportedControlIds(SUPPORTED_APP_IDS);
+	if (ids.length === 0) throw new Error("unreachable");
+});

--- a/src/features/topbar/registry.ts
+++ b/src/features/topbar/registry.ts
@@ -150,11 +150,14 @@ export function getSupportedControlIds(
 	supportedAppIds: readonly LaunchAppControlId[],
 ) {
 	const supportedAppIdSet = new Set(supportedAppIds);
-	return definitions
-		.filter(
-			(def) =>
-				def.kind === "static" ||
-				supportedAppIdSet.has(def.id as LaunchAppControlId),
-		)
-		.map((def) => def.id);
+	const supportedControlIds: ControlId[] = [];
+	for (const def of definitions) {
+		if (
+			def.kind === "static" ||
+			supportedAppIdSet.has(def.id as LaunchAppControlId)
+		) {
+			supportedControlIds.push(def.id);
+		}
+	}
+	return supportedControlIds;
 }


### PR DESCRIPTION
## Summary
- Replace the topbar supported-control filter/map pipeline with one pass that pushes matching ids directly.
- Preserve the registry order and existing static-control behavior.
- Add a Vitest benchmark for the old filter/map shape versus the new collector.

## Benchmark
```
bunx vitest bench src/features/topbar/registry.bench.ts --run
single pass supported controls: 6,037,041.77 hz
filter map supported controls: 5,371,541.19 hz
single pass supported controls is 1.12x faster
```

## Validation
```
bunx vitest run src/features/topbar/registry.test.ts
bunx tsc --noEmit
```
