### PR TITLE
perf: loop terminal tab icon matches

### DIFF
--- a/src/features/terminal/TerminalTabs.tsx
+++ b/src/features/terminal/TerminalTabs.tsx
@@ -4,14 +4,6 @@ import {
 	Flex,
 	Spinner,
 } from "@chakra-ui/react";
-import claudeIconUrl from "@lobehub/icons-static-svg/icons/claude-color.svg";
-import clineIconUrl from "@lobehub/icons-static-svg/icons/cline.svg";
-import codexIconUrl from "@lobehub/icons-static-svg/icons/codex-color.svg";
-import geminiIconUrl from "@lobehub/icons-static-svg/icons/gemini-color.svg";
-import kimiIconUrl from "@lobehub/icons-static-svg/icons/kimi-color.svg";
-import openClawIconUrl from "@lobehub/icons-static-svg/icons/openclaw-color.svg";
-import opencodeIconUrl from "@lobehub/icons-static-svg/icons/opencode.svg";
-import qoderIconUrl from "@lobehub/icons-static-svg/icons/qoder-color.svg";
 import { useReducedMotion } from "motion/react";
 import { lazy, useMemo } from "react";
 import { FiTerminal } from "react-icons/fi";
@@ -25,6 +17,7 @@ import FileTreeFileIcon from "@/shared/components/FileTreeFileIcon";
 import { useCloseTerminalTab } from "./hooks";
 import { useTerminalStore } from "./store";
 import { TabStrip, type TabStripGroup } from "./TabStrip";
+import { getTerminalTabIconUrl } from "./terminalTabIcons";
 import TerminalTemplateMenu from "./TerminalTemplateMenu";
 import { Terminal } from "./Terminal";
 
@@ -43,16 +36,6 @@ const TAB_EXIT_ANIMATION = {
 	duration: 0.14,
 	ease: [0.4, 0, 1, 1],
 } as const;
-const AGENT_TAB_ICONS: { keyword: string; iconUrl: string }[] = [
-	{ keyword: "claude", iconUrl: claudeIconUrl },
-	{ keyword: "codex", iconUrl: codexIconUrl },
-	{ keyword: "gemini", iconUrl: geminiIconUrl },
-	{ keyword: "kimi", iconUrl: kimiIconUrl },
-	{ keyword: "cline", iconUrl: clineIconUrl },
-	{ keyword: "openclaw", iconUrl: openClawIconUrl },
-	{ keyword: "opencode", iconUrl: opencodeIconUrl },
-	{ keyword: "qoder", iconUrl: qoderIconUrl },
-];
 const FULL_TAB_MOTION_PROPS = {
 	initial: { opacity: 0, scale: 0.92, y: 6 },
 	animate: { opacity: 1, scale: 1, y: 0 },
@@ -61,19 +44,16 @@ const FULL_TAB_MOTION_PROPS = {
 } as const;
 
 function getTerminalTabIcon(title: string) {
-	const lowerTitle = title.toLowerCase();
-	const match = AGENT_TAB_ICONS.find(({ keyword }) =>
-		lowerTitle.includes(keyword),
-	);
+	const iconUrl = getTerminalTabIconUrl(title);
 
-	if (!match) return <FiTerminal size={14} />;
+	if (!iconUrl) return <FiTerminal size={14} />;
 
 	return (
 		<img
 			alt=""
 			aria-hidden="true"
 			draggable={false}
-			src={match.iconUrl}
+			src={iconUrl}
 			style={{ width: 14, height: 14, flexShrink: 0 }}
 		/>
 	);

--- a/src/features/terminal/terminalTabIcons.bench.ts
+++ b/src/features/terminal/terminalTabIcons.bench.ts
@@ -1,0 +1,37 @@
+import { bench } from "vitest";
+import { AGENT_TAB_ICONS, getTerminalTabIconUrl } from "./terminalTabIcons";
+
+const TITLES = [
+	"Claude Code",
+	"codex shell",
+	"Gemini session",
+	"Kimi workspace",
+	"pnpm dev",
+	"OpenCode review",
+	"Qoder agent",
+	"zsh",
+];
+
+function getTerminalTabIconUrlWithFind(title: string) {
+	const lowerTitle = title.toLowerCase();
+	const match = AGENT_TAB_ICONS.find(({ keyword }) =>
+		lowerTitle.includes(keyword),
+	);
+	return match?.iconUrl ?? null;
+}
+
+bench("find terminal tab icon", () => {
+	let count = 0;
+	for (const title of TITLES) {
+		if (getTerminalTabIconUrlWithFind(title)) count += 1;
+	}
+	if (count === 0) throw new Error("unreachable");
+});
+
+bench("loop terminal tab icon", () => {
+	let count = 0;
+	for (const title of TITLES) {
+		if (getTerminalTabIconUrl(title)) count += 1;
+	}
+	if (count === 0) throw new Error("unreachable");
+});

--- a/src/features/terminal/terminalTabIcons.ts
+++ b/src/features/terminal/terminalTabIcons.ts
@@ -1,0 +1,27 @@
+import claudeIconUrl from "@lobehub/icons-static-svg/icons/claude-color.svg";
+import clineIconUrl from "@lobehub/icons-static-svg/icons/cline.svg";
+import codexIconUrl from "@lobehub/icons-static-svg/icons/codex-color.svg";
+import geminiIconUrl from "@lobehub/icons-static-svg/icons/gemini-color.svg";
+import kimiIconUrl from "@lobehub/icons-static-svg/icons/kimi-color.svg";
+import openClawIconUrl from "@lobehub/icons-static-svg/icons/openclaw-color.svg";
+import opencodeIconUrl from "@lobehub/icons-static-svg/icons/opencode.svg";
+import qoderIconUrl from "@lobehub/icons-static-svg/icons/qoder-color.svg";
+
+export const AGENT_TAB_ICONS: { keyword: string; iconUrl: string }[] = [
+	{ keyword: "claude", iconUrl: claudeIconUrl },
+	{ keyword: "codex", iconUrl: codexIconUrl },
+	{ keyword: "gemini", iconUrl: geminiIconUrl },
+	{ keyword: "kimi", iconUrl: kimiIconUrl },
+	{ keyword: "cline", iconUrl: clineIconUrl },
+	{ keyword: "openclaw", iconUrl: openClawIconUrl },
+	{ keyword: "opencode", iconUrl: opencodeIconUrl },
+	{ keyword: "qoder", iconUrl: qoderIconUrl },
+];
+
+export function getTerminalTabIconUrl(title: string) {
+	const lowerTitle = title.toLowerCase();
+	for (const { keyword, iconUrl } of AGENT_TAB_ICONS) {
+		if (lowerTitle.includes(keyword)) return iconUrl;
+	}
+	return null;
+}


### PR DESCRIPTION
## Summary
- Move terminal agent tab icon matching into a small helper module.
- Replace the `Array.find` callback path with a direct loop used by `TerminalTabs`.
- Add a Vitest benchmark for the old find matcher versus the loop matcher.

## Benchmark
```
bunx vitest bench src/features/terminal/terminalTabIcons.bench.ts --run
loop terminal tab icon: 1,959,173.29 hz
find terminal tab icon: 1,758,106.46 hz
loop terminal tab icon is 1.11x faster
```

## Validation
```
bunx vitest run src/features/terminal/hooks.test.tsx src/features/terminal/store.test.ts
bunx tsc --noEmit
```
