### PR TITLE
perf: read avatar fallback first char directly

### DIFF
--- a/src/layout/sidebar/ProjectAvatar.bench.ts
+++ b/src/layout/sidebar/ProjectAvatar.bench.ts
@@ -1,0 +1,38 @@
+import { bench } from "vitest";
+import { getProjectAvatarFallback } from "./ProjectAvatar";
+
+const PROJECT_NAMES = [
+	"2code",
+	"  developer-tools",
+	"🚀 Launch Pad",
+	"中文项目",
+	"performance-workbench",
+	"Open Source Repository",
+	"🧪 Experiments",
+	"   ",
+];
+
+function getProjectAvatarFallbackWithArray(name: string) {
+	const trimmed = name.trim();
+	if (!trimmed) {
+		return "?";
+	}
+
+	return Array.from(trimmed)[0]?.toUpperCase() ?? "?";
+}
+
+bench("array project avatar fallback", () => {
+	let total = 0;
+	for (const name of PROJECT_NAMES) {
+		total += getProjectAvatarFallbackWithArray(name).length;
+	}
+	if (total === 0) throw new Error("unreachable");
+});
+
+bench("loop project avatar fallback", () => {
+	let total = 0;
+	for (const name of PROJECT_NAMES) {
+		total += getProjectAvatarFallback(name).length;
+	}
+	if (total === 0) throw new Error("unreachable");
+});

--- a/src/layout/sidebar/ProjectAvatar.test.ts
+++ b/src/layout/sidebar/ProjectAvatar.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { getProjectAvatarFallback } from "./ProjectAvatar";
+
+describe("getProjectAvatarFallback", () => {
+	it("uses the first visible character", () => {
+		expect(getProjectAvatarFallback("  code  ")).toBe("C");
+	});
+
+	it("falls back for blank names", () => {
+		expect(getProjectAvatarFallback("   ")).toBe("?");
+	});
+
+	it("preserves first-codepoint behavior for emoji names", () => {
+		expect(getProjectAvatarFallback("🚀 Launch")).toBe("🚀");
+	});
+});

--- a/src/layout/sidebar/ProjectAvatar.tsx
+++ b/src/layout/sidebar/ProjectAvatar.tsx
@@ -3,13 +3,17 @@ import { useState } from "react";
 import { useProjectAvatar } from "@/features/projects/hooks";
 import { useSidebarSettingsStore } from "@/features/settings/stores/sidebarSettingsStore";
 
-function getProjectAvatarFallback(name: string) {
+export function getProjectAvatarFallback(name: string) {
 	const trimmed = name.trim();
 	if (!trimmed) {
 		return "?";
 	}
 
-	return Array.from(trimmed)[0]?.toUpperCase() ?? "?";
+	for (const character of trimmed) {
+		return character.toUpperCase();
+	}
+
+	return "?";
 }
 
 export function ProjectAvatar({


### PR DESCRIPTION
## Summary
- Read the first fallback avatar character with a `for...of` loop instead of `Array.from(trimmed)[0]`.
- Preserve blank-name fallback and first-codepoint behavior for emoji/non-ASCII names.
- Add focused unit coverage plus a Vitest benchmark.

## Benchmark
```
bunx vitest bench src/layout/sidebar/ProjectAvatar.bench.ts --run
loop project avatar fallback: 2,931,863.68 hz
array project avatar fallback: 1,235,007.86 hz
loop project avatar fallback is 2.37x faster
```

## Validation
```
bunx vitest run src/layout/sidebar/ProjectAvatar.test.ts
bunx tsc --noEmit
```
