### PR TITLE
perf: derive path basenames without split

### DIFF
--- a/src/features/projects/FileViewerPane.tsx
+++ b/src/features/projects/FileViewerPane.tsx
@@ -17,6 +17,7 @@ import { useFileViewerDirtyStore } from "@/features/projects/fileViewerTabsStore
 import { useTerminalSettingsStore } from "@/features/settings/stores/terminalSettingsStore";
 import { useTerminalThemeId } from "@/features/terminal/hooks";
 import { detectMonacoLanguage } from "@/shared/lib/languageDetection";
+import { getPathBasename } from "@/shared/lib/path";
 import { useFileContent, useSaveFileContent } from "./hooks";
 
 interface FileViewerPaneProps {
@@ -54,7 +55,7 @@ export default function FileViewerPane({
 		mutate: saveFileContent,
 	} = useSaveFileContent(profileId);
 
-	const filename = filePath.split("/").pop() ?? "";
+	const filename = getPathBasename(filePath);
 	const language = detectMonacoLanguage(filename);
 	const monacoTheme = getMonacoTheme(themeId);
 	const draftValue = draftsByPath[filePath];

--- a/src/features/projects/fileViewerTabsStore.ts
+++ b/src/features/projects/fileViewerTabsStore.ts
@@ -4,6 +4,7 @@ import { persist } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
 import { useShallow } from "zustand/react/shallow";
 import { useTerminalStore } from "@/features/terminal/store";
+import { getPathBasename } from "@/shared/lib/path";
 
 export interface FileViewerTab {
 	filePath: string;
@@ -68,7 +69,7 @@ export const useFileViewerTabsStore = create<FileViewerTabsStore>()(
 
 			openFile(profileId, filePath) {
 				set((state) => {
-					const title = filePath.split("/").pop() ?? filePath;
+					const title = getPathBasename(filePath);
 					const existing = state.profiles[profileId] ?? {
 						tabs: [],
 						activeFilePath: null,

--- a/src/features/projects/hooks.ts
+++ b/src/features/projects/hooks.ts
@@ -9,6 +9,7 @@ import {
 	getCachedProjectAvatar,
 	setCachedProjectAvatar,
 } from "@/features/projects/projectAvatarCache";
+import { getPathBasename } from "@/shared/lib/path";
 import type {
 	ProjectConfig,
 	ProjectGroup,
@@ -116,7 +117,7 @@ export function useCreateProject(options?: {
 	return useMutation({
 		mutationFn: (opts: { name?: string; folder: string }) =>
 			createProjectFromFolder({
-				name: opts.name || opts.folder.split("/").pop() || "Untitled",
+				name: opts.name || getPathBasename(opts.folder) || "Untitled",
 				folder: opts.folder,
 			}),
 		onSuccess: async (project) => {

--- a/src/shared/lib/path.bench.ts
+++ b/src/shared/lib/path.bench.ts
@@ -1,0 +1,31 @@
+import { bench } from "vitest";
+import { getPathBasename } from "./path";
+
+const PATHS = [
+	"/repo/src/index.ts",
+	"/repo/src/features/projects/FileViewerPane.tsx",
+	"README.md",
+	"/Users/example/Developer/2code/src-tauri/src/lib.rs",
+	"/repo/src/",
+	"",
+];
+
+function getPathBasenameWithSplit(path: string) {
+	return path.split("/").pop() ?? path;
+}
+
+bench("split path basename", () => {
+	let total = 0;
+	for (const path of PATHS) {
+		total += getPathBasenameWithSplit(path).length;
+	}
+	if (total < 0) throw new Error("unreachable");
+});
+
+bench("lastIndexOf path basename", () => {
+	let total = 0;
+	for (const path of PATHS) {
+		total += getPathBasename(path).length;
+	}
+	if (total < 0) throw new Error("unreachable");
+});

--- a/src/shared/lib/path.test.ts
+++ b/src/shared/lib/path.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { getPathBasename } from "./path";
+
+describe("getPathBasename", () => {
+	it("returns the path segment after the last slash", () => {
+		expect(getPathBasename("/repo/src/index.ts")).toBe("index.ts");
+	});
+
+	it("returns the original path when it has no slash", () => {
+		expect(getPathBasename("index.ts")).toBe("index.ts");
+	});
+
+	it("matches split pop behavior for trailing slashes", () => {
+		expect(getPathBasename("/repo/src/")).toBe("");
+	});
+});

--- a/src/shared/lib/path.ts
+++ b/src/shared/lib/path.ts
@@ -1,0 +1,4 @@
+export function getPathBasename(path: string) {
+	const lastSlash = path.lastIndexOf("/");
+	return lastSlash === -1 ? path : path.slice(lastSlash + 1);
+}


### PR DESCRIPTION
## Summary
- Add a small `getPathBasename` helper using `lastIndexOf` instead of `split("/").pop()`.
- Use it for file viewer tab titles, Monaco filename detection, and default project names.
- Preserve existing trailing-slash behavior and cover it with unit tests.

## Benchmark
```
bunx vitest bench src/shared/lib/path.bench.ts --run
lastIndexOf path basename: 5,813,940.51 hz
split path basename: 4,438,867.01 hz
lastIndexOf path basename is 1.31x faster
```

## Validation
```
bunx vitest run src/shared/lib/path.test.ts src/features/projects/fileViewerTabsStore.test.ts src/features/projects/FileViewerPane.test.tsx src/features/projects/hooks.test.tsx
bunx tsc --noEmit
```
