### PR TITLE
perf: check exact tree paths first

### DIFF
--- a/src/features/projects/FileTreePanel.bench.ts
+++ b/src/features/projects/FileTreePanel.bench.ts
@@ -1,0 +1,31 @@
+import { bench } from "vitest";
+import { hasTreePath } from "./FileTreePanel";
+
+const PATHS = Array.from({ length: 1_000 }, (_, index) =>
+	index % 4 === 0 ? `src/module-${index}/` : `src/module-${index}/index.ts`,
+);
+const PATH_SET = new Set(PATHS);
+
+function hasTreePathWithEagerDirectory(
+	pathSet: ReadonlySet<string>,
+	path: string,
+) {
+	const directoryPath = `${path.replace(/[\\/]+$/, "")}/`;
+	return pathSet.has(path) || pathSet.has(directoryPath);
+}
+
+bench("eager directory tree path lookup", () => {
+	let count = 0;
+	for (const path of PATHS) {
+		if (hasTreePathWithEagerDirectory(PATH_SET, path)) count += 1;
+	}
+	if (count === 0) throw new Error("unreachable");
+});
+
+bench("exact first tree path lookup", () => {
+	let count = 0;
+	for (const path of PATHS) {
+		if (hasTreePath(PATH_SET, path)) count += 1;
+	}
+	if (count === 0) throw new Error("unreachable");
+});

--- a/src/features/projects/FileTreePanel.tsx
+++ b/src/features/projects/FileTreePanel.tsx
@@ -204,9 +204,10 @@ function getContextMenuActionPaths(
 	return selectedPaths.includes(itemPath) ? selectedPaths : [itemPath];
 }
 
-function hasTreePath(pathSet: ReadonlySet<string>, path: string) {
+export function hasTreePath(pathSet: ReadonlySet<string>, path: string) {
+	if (pathSet.has(path)) return true;
 	const directoryPath = `${path.replace(TRAILING_PATH_SEPARATOR_RE, "")}/`;
-	return pathSet.has(path) || pathSet.has(directoryPath);
+	return pathSet.has(directoryPath);
 }
 
 function buildExistingPathSet(


### PR DESCRIPTION
## Summary
- Check exact file-tree paths before constructing the directory fallback path.
- Avoid the eager `replace` and template allocation on exact path hits.
- Add a Vitest benchmark for the old eager directory lookup versus the exact-first lookup.

## Benchmark
```
bunx vitest bench src/features/projects/FileTreePanel.bench.ts --run
exact first tree path lookup: 55,036.36 hz
eager directory tree path lookup: 17,336.78 hz
exact first tree path lookup is 3.17x faster
```

## Validation
```
bunx vitest run src/features/projects/FileTreePanel.test.tsx
bunx tsc --noEmit
```
