### PR TITLE
perf: use set for launch app ids

### DIFF
--- a/src/features/topbar/types.bench.ts
+++ b/src/features/topbar/types.bench.ts
@@ -1,0 +1,37 @@
+import { bench } from "vitest";
+import { isLaunchAppControlId, launchAppControlIds } from "./types";
+
+const IDS = [
+	"github-desktop",
+	"vscode",
+	"windsurf",
+	"cursor",
+	"zed",
+	"sublime-text",
+	"ghostty",
+	"iterm2",
+	"kitty",
+	"warp",
+	"unknown-app",
+	"another-app",
+];
+
+function isLaunchAppControlIdWithIncludes(id: string) {
+	return launchAppControlIds.includes(id as (typeof launchAppControlIds)[number]);
+}
+
+bench("includes launch app control id", () => {
+	let count = 0;
+	for (const id of IDS) {
+		if (isLaunchAppControlIdWithIncludes(id)) count += 1;
+	}
+	if (count === 0) throw new Error("unreachable");
+});
+
+bench("set launch app control id", () => {
+	let count = 0;
+	for (const id of IDS) {
+		if (isLaunchAppControlId(id)) count += 1;
+	}
+	if (count === 0) throw new Error("unreachable");
+});

--- a/src/features/topbar/types.ts
+++ b/src/features/topbar/types.ts
@@ -24,8 +24,10 @@ export type LaunchAppControlId = (typeof launchAppControlIds)[number];
 export type StaticControlId = (typeof staticControlIds)[number];
 export type ControlId = LaunchAppControlId | StaticControlId;
 
+const launchAppControlIdSet = new Set<string>(launchAppControlIds);
+
 export function isLaunchAppControlId(id: string): id is LaunchAppControlId {
-	return launchAppControlIds.includes(id as LaunchAppControlId);
+	return launchAppControlIdSet.has(id);
 }
 
 export interface ControlOptionField {


### PR DESCRIPTION
## Summary
- Cache launch app control ids in a module-level Set.
- Keep `isLaunchAppControlId` as the same type guard while avoiding linear `includes` checks.
- Add a Vitest benchmark for includes versus Set lookup.

## Benchmark
```
bunx vitest bench src/features/topbar/types.bench.ts --run
set launch app control id: 5,594,658.98 hz
includes launch app control id: 5,118,408.61 hz
set launch app control id is 1.09x faster
```

## Validation
```
bunx vitest run src/features/topbar/types.test.ts src/features/topbar/hooks.test.ts
bunx tsc --noEmit
```
