### PR TITLE
perf: borrow plain release tags

### DIFF
--- a/src-tauri/src/handler/updater.rs
+++ b/src-tauri/src/handler/updater.rs
@@ -1,4 +1,5 @@
 use std::process::Command;
+use std::borrow::Cow;
 use std::sync::Mutex;
 
 use model::error::AppError;
@@ -48,8 +49,12 @@ fn updater_error(error: impl std::fmt::Display) -> AppError {
 	AppError::PtyError(format!("Updater error: {error}"))
 }
 
-fn encode_release_tag(tag: &str) -> String {
-	tag.replace('/', "%2F")
+fn encode_release_tag(tag: &str) -> Cow<'_, str> {
+	if tag.contains('/') {
+		Cow::Owned(tag.replace('/', "%2F"))
+	} else {
+		Cow::Borrowed(tag)
+	}
 }
 
 fn update_metadata(update: &Update) -> UpdateMetadata {
@@ -189,4 +194,56 @@ pub async fn install_update(
 		.map_err(updater_error)?;
 
 	app.restart();
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use std::borrow::Cow;
+	use std::time::Instant;
+
+	#[test]
+	fn encode_release_tag_borrows_plain_tags_and_encodes_slashes() {
+		assert!(matches!(encode_release_tag("v1.0.0"), Cow::Borrowed("v1.0.0")));
+		assert_eq!(encode_release_tag("beta/v1.0.0"), "beta%2Fv1.0.0");
+	}
+
+	#[test]
+	#[ignore]
+	fn bench_encode_release_tags_without_replacing_plain_tags() {
+		let tags: Vec<String> = (0..10_000)
+			.map(|index| {
+				if index % 20 == 0 {
+					format!("channel/beta-{index}")
+				} else {
+					format!("v1.{index}.0")
+				}
+			})
+			.collect();
+		let iterations = 1_000;
+
+		let started = Instant::now();
+		let mut replace_len = 0;
+		for _ in 0..iterations {
+			for tag in &tags {
+				replace_len += std::hint::black_box(tag).replace('/', "%2F").len();
+			}
+		}
+		let replace = started.elapsed();
+
+		let started = Instant::now();
+		let mut cow_len = 0;
+		for _ in 0..iterations {
+			for tag in &tags {
+				cow_len += encode_release_tag(std::hint::black_box(tag)).len();
+			}
+		}
+		let cow = started.elapsed();
+
+		assert_eq!(replace_len, cow_len);
+		println!(
+			"replace={replace:?} cow={cow:?} speedup={:.2}x",
+			replace.as_secs_f64() / cow.as_secs_f64()
+		);
+	}
 }


### PR DESCRIPTION
## Summary
- Return `Cow<str>` from release tag encoding so normal slash-free tags are borrowed.
- Only allocate and replace when a release tag actually contains `/`.
- Add an ignored release benchmark for mostly plain release tags.

## Benchmark
```
cd src-tauri && cargo test bench_encode_release_tags_without_replacing_plain_tags --release -- --ignored --nocapture
replace=260.718333ms cow=103.306125ms speedup=2.52x
```

## Validation
```
cd src-tauri && cargo test updater
```

Note: the macOS test build still emits the pre-existing `windows_commands` dead_code warning in the topbar handler.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized release tag handling in the updater to reduce memory allocations and improve performance efficiency.

* **Tests**
  * Added unit tests to verify tag encoding behavior and performance benchmarks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AkaraChen/2code/pull/228)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->