### PR TITLE
perf: build valid profile ids directly

### DIFF
--- a/src/features/terminal/state.bench.ts
+++ b/src/features/terminal/state.bench.ts
@@ -1,0 +1,37 @@
+import { bench } from "vitest";
+import type { ProjectWithProfiles } from "@/generated";
+import { buildValidProfileIds } from "./state";
+
+function createProjects(): ProjectWithProfiles[] {
+	return Array.from({ length: 400 }, (_, projectIndex) => ({
+		id: `project-${projectIndex}`,
+		name: `Project ${projectIndex}`,
+		folder: `/repo/${projectIndex}`,
+		created_at: "now",
+		group_id: null,
+		profiles: Array.from({ length: 8 }, (_, profileIndex) => ({
+			id: `profile-${projectIndex}-${profileIndex}`,
+			project_id: `project-${projectIndex}`,
+			branch_name: `branch-${profileIndex}`,
+			worktree_path: `/repo/${projectIndex}/${profileIndex}`,
+			created_at: "now",
+			is_default: profileIndex === 0,
+		})),
+	}));
+}
+
+const PROJECTS = createProjects();
+
+function buildValidProfileIdsWithFlatMap(projects: ProjectWithProfiles[]) {
+	return new Set(projects.flatMap((p) => p.profiles.map((pr) => pr.id)));
+}
+
+bench("flatMap valid profile ids", () => {
+	const ids = buildValidProfileIdsWithFlatMap(PROJECTS);
+	if (ids.size === 0) throw new Error("unreachable");
+});
+
+bench("direct valid profile ids", () => {
+	const ids = buildValidProfileIds(PROJECTS);
+	if (ids.size === 0) throw new Error("unreachable");
+});

--- a/src/features/terminal/state.test.ts
+++ b/src/features/terminal/state.test.ts
@@ -1,5 +1,31 @@
 import { describe, expect, it } from "vitest";
-import { mapWithLimit } from "./state";
+import { buildValidProfileIds, mapWithLimit } from "./state";
+
+describe("buildValidProfileIds", () => {
+	it("collects profile ids without intermediate arrays", () => {
+		expect(
+			buildValidProfileIds([
+				{
+					id: "project-1",
+					name: "Project 1",
+					folder: "/repo/1",
+					created_at: "now",
+					group_id: null,
+					profiles: [
+						{
+							id: "profile-1",
+							project_id: "project-1",
+							branch_name: "main",
+							worktree_path: "/repo/1",
+							created_at: "now",
+							is_default: true,
+						},
+					],
+				},
+			]),
+		).toEqual(new Set(["profile-1"]));
+	});
+});
 
 describe("mapWithLimit", () => {
 	it("processes all items", async () => {

--- a/src/features/terminal/state.ts
+++ b/src/features/terminal/state.ts
@@ -39,9 +39,7 @@ function createRestorationPipeline(): Promise<void> {
 			if (!result.data) return;
 
 			// Stale profile cleanup
-			const validIds = new Set(
-				result.data.flatMap((p) => p.profiles.map((pr) => pr.id)),
-			);
+			const validIds = buildValidProfileIds(result.data);
 			useTerminalStore.getState().removeStaleProfiles(validIds);
 			consola.info("[pty-restore] cleaned up stale profiles", {
 				validCount: validIds.size,
@@ -58,6 +56,16 @@ function createRestorationPipeline(): Promise<void> {
 			}
 		});
 	});
+}
+
+export function buildValidProfileIds(projects: ProjectWithProfiles[]) {
+	const validIds = new Set<string>();
+	for (const project of projects) {
+		for (const profile of project.profiles) {
+			validIds.add(profile.id);
+		}
+	}
+	return validIds;
 }
 
 async function restoreTerminals(projects: ProjectWithProfiles[]) {


### PR DESCRIPTION
## Summary
- Build terminal restoration valid profile ids directly into a Set.
- Avoid the `flatMap` and nested `map` intermediate arrays during stale profile cleanup.
- Add a focused unit test and a Vitest benchmark for the old flatMap path versus direct Set fill.

## Benchmark
```
bunx vitest bench src/features/terminal/state.bench.ts --run
direct valid profile ids: 9,719.94 hz
flatMap valid profile ids: 7,056.26 hz
direct valid profile ids is 1.38x faster
```

## Validation
```
bunx vitest run src/features/terminal/state.test.ts
bunx tsc --noEmit
```
