### PR TITLE
perf(terminal): scan history overlap linearly

### DIFF
--- a/src/features/terminal/Terminal.tsx
+++ b/src/features/terminal/Terminal.tsx
@@ -22,6 +22,7 @@ import { TerminalLinkConfirmDialog } from "./TerminalLinkConfirmDialog";
 import { useTerminalTheme } from "./hooks";
 import { getTerminalShortcutAction } from "./keybindings";
 import { shouldBypassTerminalLinkConfirm } from "./linkOpening";
+import { getSuffixPrefixOverlapLength } from "./overlap";
 import { sessionHistory } from "./state";
 import { useTerminalStore } from "./store";
 import "@xterm/xterm/css/xterm.css";
@@ -30,16 +31,6 @@ interface TerminalProps {
 	profileId: string;
 	sessionId: string;
 	isActive: boolean;
-}
-
-function getSuffixPrefixOverlapLength(text: string, prefixSource: string) {
-	const maxLength = Math.min(text.length, prefixSource.length);
-	for (let length = maxLength; length > 0; length -= 1) {
-		if (text.endsWith(prefixSource.slice(0, length))) {
-			return length;
-		}
-	}
-	return 0;
 }
 
 export function Terminal({ profileId, sessionId, isActive }: TerminalProps) {

--- a/src/features/terminal/overlap.test.ts
+++ b/src/features/terminal/overlap.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { getSuffixPrefixOverlapLength } from "./overlap";
+
+describe("getSuffixPrefixOverlapLength", () => {
+	it("finds the longest text suffix that matches the prefix source", () => {
+		expect(getSuffixPrefixOverlapLength("hello world", "world!")).toBe(5);
+		expect(getSuffixPrefixOverlapLength("abcabc", "abcxyz")).toBe(3);
+		expect(getSuffixPrefixOverlapLength("terminal", "stream")).toBe(0);
+	});
+
+	it("handles empty and shorter inputs", () => {
+		expect(getSuffixPrefixOverlapLength("", "pending")).toBe(0);
+		expect(getSuffixPrefixOverlapLength("history", "")).toBe(0);
+		expect(getSuffixPrefixOverlapLength("abc", "abcdef")).toBe(3);
+	});
+
+	it("matches UTF-16 code unit behavior", () => {
+		expect(getSuffixPrefixOverlapLength("prompt 🧪", "🧪 done")).toBe(2);
+	});
+});

--- a/src/features/terminal/overlap.ts
+++ b/src/features/terminal/overlap.ts
@@ -1,0 +1,44 @@
+export function getSuffixPrefixOverlapLength(
+	text: string,
+	prefixSource: string,
+) {
+	const maxLength = Math.min(text.length, prefixSource.length);
+	if (maxLength === 0) return 0;
+
+	// KMP prefix table: scan only the relevant text suffix once, instead of
+	// repeatedly slicing prefixSource and asking text.endsWith(...) for every
+	// possible overlap length.
+	const prefixTable = buildPrefixTable(prefixSource, maxLength);
+	const startIndex = text.length - maxLength;
+	let matchedLength = 0;
+
+	for (let index = startIndex; index < text.length; index += 1) {
+		const current = text[index];
+		while (matchedLength > 0 && current !== prefixSource[matchedLength]) {
+			matchedLength = prefixTable[matchedLength - 1] ?? 0;
+		}
+		if (current === prefixSource[matchedLength]) {
+			matchedLength += 1;
+		}
+	}
+
+	return matchedLength;
+}
+
+function buildPrefixTable(pattern: string, length: number) {
+	const table = Array.from<number>({ length }).fill(0);
+	let matchedLength = 0;
+
+	for (let index = 1; index < length; index += 1) {
+		const current = pattern[index];
+		while (matchedLength > 0 && current !== pattern[matchedLength]) {
+			matchedLength = table[matchedLength - 1] ?? 0;
+		}
+		if (current === pattern[matchedLength]) {
+			matchedLength += 1;
+		}
+		table[index] = matchedLength;
+	}
+
+	return table;
+}


### PR DESCRIPTION
## Summary
- move terminal history/pending-stream overlap detection into a focused utility
- replace repeated slice + endsWith probing with a documented linear prefix-table scan
- cover basic overlap, shorter inputs, and UTF-16 code-unit behavior

## Verification
- bunx vitest run src/features/terminal/overlap.test.ts
- bunx eslint src/features/terminal/Terminal.tsx src/features/terminal/overlap.ts src/features/terminal/overlap.test.ts