### PR TITLE
perf(git): slice image preview extensions

### DIFF
--- a/src/features/git/utils.test.ts
+++ b/src/features/git/utils.test.ts
@@ -340,6 +340,7 @@ describe("getPreviewableImageMimeType", () => {
 	it("returns null for unsupported formats", () => {
 		expect(getPreviewableImageMimeType("document.pdf")).toBeNull();
 		expect(getPreviewableImageMimeType("README")).toBeNull();
+		expect(getPreviewableImageMimeType("image.")).toBeNull();
 	});
 });
 

--- a/src/features/git/utils.ts
+++ b/src/features/git/utils.ts
@@ -68,11 +68,12 @@ export function isLargeGitDiffFile(
 }
 
 export function getPreviewableImageMimeType(fileName: string) {
-	const extension = fileName.split(".").pop()?.toLowerCase();
-	if (!extension) {
+	const extensionStart = fileName.lastIndexOf(".") + 1;
+	if (extensionStart === 0 || extensionStart === fileName.length) {
 		return null;
 	}
 
+	const extension = fileName.slice(extensionStart).toLowerCase();
 	return previewableImageMimeTypes[extension] ?? null;
 }
 


### PR DESCRIPTION
## Summary
- parse Git binary preview image extensions with lastIndexOf + slice instead of split
- avoid allocating path segment arrays while preserving case-insensitive MIME detection
- cover trailing-dot filenames as unsupported

## Verification
- bunx vitest run src/features/git/utils.test.ts
- bunx eslint src/features/git/utils.ts src/features/git/utils.test.ts