### PR TITLE
perf: drop immer from git diff reducer

### DIFF
--- a/src/features/git/gitDiffReducer.bench.ts
+++ b/src/features/git/gitDiffReducer.bench.ts
@@ -1,0 +1,110 @@
+import { produce } from "immer";
+import { bench, describe } from "vitest";
+import type { GitCommit } from "@/generated";
+import {
+	type GitDiffAction,
+	type GitDiffState,
+	gitDiffReducer,
+	initialState,
+} from "./gitDiffReducer";
+
+const mockCommit: GitCommit = {
+	hash: "abc1234",
+	full_hash: "abc1234567890abcdef",
+	author: { name: "Test User", email: "test@test.com" },
+	date: "2026-01-01T00:00:00Z",
+	message: "test commit",
+	files_changed: 3,
+	insertions: 10,
+	deletions: 5,
+};
+
+const immerReducer = produce(
+	(draft: GitDiffState, action: GitDiffAction) => {
+		switch (action.type) {
+			case "switchTab":
+				draft.activeTab = action.tab;
+				draft.selectedCommit = null;
+				draft.selectedFileIndex = 0;
+				draft.selectedCommitIndex = 0;
+				draft.selectedCommitFileIndex = 0;
+				draft.commitFileCount = 0;
+				break;
+			case "setViewMode":
+				draft.viewMode = action.viewMode;
+				break;
+			case "selectFile":
+				draft.selectedFileIndex = action.index;
+				break;
+			case "selectCommit":
+				draft.selectedCommit = action.commit;
+				draft.selectedCommitIndex = action.index;
+				draft.selectedCommitFileIndex = 0;
+				break;
+			case "selectCommitFile":
+				draft.selectedCommitFileIndex = action.index;
+				break;
+			case "commitBack":
+				draft.selectedCommit = null;
+				draft.selectedCommitFileIndex = 0;
+				draft.commitFileCount = 0;
+				break;
+			case "setCommitFileCount":
+				draft.commitFileCount = action.count;
+				break;
+			case "stepIndex": {
+				const max = action.count - 1;
+				const value =
+					action.target === "file"
+						? draft.selectedFileIndex
+						: action.target === "commit"
+							? draft.selectedCommitIndex
+							: draft.selectedCommitFileIndex;
+				const next = Math.max(0, Math.min(value + action.delta, max));
+				if (action.target === "file") {
+					draft.selectedFileIndex = next;
+				} else if (action.target === "commit") {
+					draft.selectedCommitIndex = next;
+				} else {
+					draft.selectedCommitFileIndex = next;
+				}
+				break;
+			}
+		}
+	},
+);
+
+const actions: GitDiffAction[] = [
+	{ type: "switchTab", tab: "history" },
+	{ type: "selectCommit", commit: mockCommit, index: 3 },
+	{ type: "setCommitFileCount", count: 8 },
+	{ type: "stepIndex", target: "commitFile", delta: 1, count: 8 },
+	{ type: "stepIndex", target: "commitFile", delta: 1, count: 8 },
+	{ type: "commitBack" },
+	{ type: "switchTab", tab: "changes" },
+	{ type: "stepIndex", target: "file", delta: 1, count: 50 },
+	{ type: "stepIndex", target: "file", delta: 1, count: 50 },
+	{ type: "setViewMode", viewMode: "split" },
+	{ type: "selectFile", index: 12 },
+	{ type: "selectCommitFile", index: 2 },
+];
+
+function runReducer(
+	reducer: (state: GitDiffState, action: GitDiffAction) => GitDiffState,
+) {
+	let state = initialState;
+	for (let index = 0; index < 5_000; index += 1) {
+		state = reducer(state, actions[index % actions.length]);
+	}
+	return state;
+}
+
+describe("gitDiffReducer", () => {
+	bench("immer reducer", () => {
+		runReducer(immerReducer);
+	});
+
+	bench("manual reducer", () => {
+		runReducer(gitDiffReducer);
+	});
+});

--- a/src/features/git/gitDiffReducer.ts
+++ b/src/features/git/gitDiffReducer.ts
@@ -1,5 +1,4 @@
 import type { FileDiffMetadata, FileDiffOptions } from "@pierre/diffs";
-import { produce } from "immer";
 import { createContext } from "react";
 import type { GitCommit } from "@/generated";
 
@@ -45,57 +44,83 @@ function clamp(value: number, min: number, max: number): number {
 	return Math.max(min, Math.min(value, max));
 }
 
-const stepKeyMap = {
-	file: "selectedFileIndex",
-	commit: "selectedCommitIndex",
-	commitFile: "selectedCommitFileIndex",
-} as const;
+export function gitDiffReducer(
+	state: GitDiffState,
+	action: GitDiffAction,
+): GitDiffState {
+	switch (action.type) {
+		case "switchTab":
+			return {
+				...state,
+				activeTab: action.tab,
+				selectedCommit: null,
+				selectedFileIndex: 0,
+				selectedCommitIndex: 0,
+				selectedCommitFileIndex: 0,
+				commitFileCount: 0,
+			};
+		case "setViewMode":
+			return { ...state, viewMode: action.viewMode };
+		case "selectFile":
+			return { ...state, selectedFileIndex: action.index };
+		case "selectCommit":
+			return {
+				...state,
+				selectedCommit: action.commit,
+				selectedCommitIndex: action.index,
+				selectedCommitFileIndex: 0,
+			};
+		case "selectCommitFile":
+			return { ...state, selectedCommitFileIndex: action.index };
+		case "commitBack":
+			return {
+				...state,
+				selectedCommit: null,
+				selectedCommitFileIndex: 0,
+				commitFileCount: 0,
+			};
+		case "setCommitFileCount":
+			return { ...state, commitFileCount: action.count };
+		case "stepIndex":
+			return stepIndex(state, action);
+	}
+}
 
-export const gitDiffReducer = produce(
-	(draft: GitDiffState, action: GitDiffAction) => {
-		switch (action.type) {
-			case "switchTab":
-				draft.activeTab = action.tab;
-				draft.selectedCommit = null;
-				draft.selectedFileIndex = 0;
-				draft.selectedCommitIndex = 0;
-				draft.selectedCommitFileIndex = 0;
-				draft.commitFileCount = 0;
-				break;
-			case "setViewMode":
-				draft.viewMode = action.viewMode;
-				break;
-			case "selectFile":
-				draft.selectedFileIndex = action.index;
-				break;
-			case "selectCommit":
-				draft.selectedCommit = action.commit;
-				draft.selectedCommitIndex = action.index;
-				draft.selectedCommitFileIndex = 0;
-				break;
-			case "selectCommitFile":
-				draft.selectedCommitFileIndex = action.index;
-				break;
-			case "commitBack":
-				draft.selectedCommit = null;
-				draft.selectedCommitFileIndex = 0;
-				draft.commitFileCount = 0;
-				break;
-			case "setCommitFileCount":
-				draft.commitFileCount = action.count;
-				break;
-			case "stepIndex": {
-				const key = stepKeyMap[action.target];
-				draft[key] = clamp(
-					draft[key] + action.delta,
+function stepIndex(
+	state: GitDiffState,
+	action: Extract<GitDiffAction, { type: "stepIndex" }>,
+) {
+	const max = action.count - 1;
+	switch (action.target) {
+		case "file":
+			return {
+				...state,
+				selectedFileIndex: clamp(
+					state.selectedFileIndex + action.delta,
 					0,
-					action.count - 1,
-				);
-				break;
-			}
-		}
-	},
-);
+					max,
+				),
+			};
+		case "commit":
+			return {
+				...state,
+				selectedCommitIndex: clamp(
+					state.selectedCommitIndex + action.delta,
+					0,
+					max,
+				),
+			};
+		case "commitFile":
+			return {
+				...state,
+				selectedCommitFileIndex: clamp(
+					state.selectedCommitFileIndex + action.delta,
+					0,
+					max,
+				),
+			};
+	}
+}
 
 interface GitDiffContextValue {
 	state: GitDiffState;


### PR DESCRIPTION
## Summary
- Replace the Git diff dialog reducer Immer wrapper with explicit immutable state returns.
- Avoid proxy/produce overhead on high-frequency navigation actions while preserving reducer behavior.

## Benchmark
- `bunx vitest bench src/features/git/gitDiffReducer.bench.ts --run`
- Result: `manual reducer` was `30.77x` faster than `immer reducer` in the latest run.

## Tests
- `bunx vitest run src/features/git/gitDiffReducer.test.ts`
- `bunx eslint src/features/git/gitDiffReducer.ts src/features/git/gitDiffReducer.test.ts src/features/git/gitDiffReducer.bench.ts`
- `bunx tsc --noEmit`
