### PR TITLE
perf: drop immer from debug log store

### DIFF
--- a/src/features/debug/debugLogStore.bench.ts
+++ b/src/features/debug/debugLogStore.bench.ts
@@ -1,0 +1,38 @@
+import { produce } from "immer";
+import { bench, describe } from "vitest";
+import type { LogEntry } from "@/generated/types";
+import { appendDebugLog } from "./debugLogStore";
+
+const MAX_LOGS = 1000;
+
+function appendDebugLogWithImmer(logs: LogEntry[], entry: LogEntry) {
+	return produce(logs, (draft) => {
+		draft.push(entry);
+		if (draft.length > MAX_LOGS) {
+			draft.splice(0, draft.length - MAX_LOGS);
+		}
+	});
+}
+
+const entries = Array.from({ length: 2_000 }, (_, index) => ({
+	timestamp: index,
+	level: "INFO",
+	source: "bench",
+	message: `log ${index}`,
+})) satisfies LogEntry[];
+
+describe("appendDebugLog", () => {
+	bench("immer push and splice", () => {
+		let logs: LogEntry[] = [];
+		for (const entry of entries) {
+			logs = appendDebugLogWithImmer(logs, entry);
+		}
+	});
+
+	bench("manual bounded append", () => {
+		let logs: LogEntry[] = [];
+		for (const entry of entries) {
+			logs = appendDebugLog(logs, entry);
+		}
+	});
+});

--- a/src/features/debug/debugLogStore.ts
+++ b/src/features/debug/debugLogStore.ts
@@ -1,5 +1,4 @@
 import { create } from "zustand";
-import { immer } from "zustand/middleware/immer";
 import type { LogEntry } from "@/generated/types";
 
 const MAX_LOGS = 1000;
@@ -10,16 +9,17 @@ interface DebugLogStore {
 	clear: () => void;
 }
 
-export const useDebugLogStore = create<DebugLogStore>()(
-	immer((set) => ({
-		logs: [],
-		addLog: (entry) =>
-			set((state) => {
-				state.logs.push(entry);
-				if (state.logs.length > MAX_LOGS) {
-					state.logs.splice(0, state.logs.length - MAX_LOGS);
-				}
-			}),
-		clear: () => set({ logs: [] }),
-	})),
-);
+export function appendDebugLog(logs: LogEntry[], entry: LogEntry) {
+	return logs.length < MAX_LOGS
+		? [...logs, entry]
+		: [...logs.slice(1), entry];
+}
+
+export const useDebugLogStore = create<DebugLogStore>()((set) => ({
+	logs: [],
+	addLog: (entry) =>
+		set((state) => ({
+			logs: appendDebugLog(state.logs, entry),
+		})),
+	clear: () => set({ logs: [] }),
+}));


### PR DESCRIPTION
## Summary
- Replace the debug log store Immer wrapper with an explicit bounded append helper.
- Avoid proxy/splice overhead for each log entry delivered over the debug log channel.

## Benchmark
- `bunx vitest bench src/features/debug/debugLogStore.bench.ts --run`
- Result: `manual bounded append` was `443.67x` faster than `immer push and splice` in the latest run.

## Tests
- `bunx vitest run src/features/debug/debugLogStore.test.ts`
- `bunx eslint src/features/debug/debugLogStore.ts src/features/debug/debugLogStore.test.ts src/features/debug/debugLogStore.bench.ts`
- `bunx tsc --noEmit`
