### PR TITLE
refactor(config): skip cwd check for empty scripts

### DIFF
--- a/src-tauri/crates/infra/src/config.rs
+++ b/src-tauri/crates/infra/src/config.rs
@@ -39,6 +39,10 @@ pub fn write_project_config(
 }
 
 pub fn execute_scripts(scripts: &[String], cwd: &Path) {
+	if scripts.is_empty() {
+		return;
+	}
+
 	if !cwd.exists() {
 		tracing::warn!("Script cwd does not exist: {}", cwd.display());
 		return;
@@ -46,10 +50,7 @@ pub fn execute_scripts(scripts: &[String], cwd: &Path) {
 
 	for script in scripts {
 		let mut command = script_command();
-		let result = command
-			.arg(script)
-			.current_dir(cwd)
-			.output();
+		let result = command.arg(script).current_dir(cwd).output();
 
 		match result {
 			Ok(output) if !output.status.success() => {


### PR DESCRIPTION
## Summary
- return immediately when execute_scripts receives an empty script list
- avoid touching cwd when there is no script to execute
- keep existing script execution behavior unchanged for non-empty lists

## Verification
- cd src-tauri && cargo test -p infra config -- --nocapture
- cd src-tauri && rustfmt --edition 2024 --check crates/infra/src/config.rs