### PR TITLE
perf: update profile cache by project

### DIFF
--- a/src/features/profiles/hooks.bench.ts
+++ b/src/features/profiles/hooks.bench.ts
@@ -1,0 +1,51 @@
+import { bench, describe } from "vitest";
+import type { ProjectWithProfiles } from "@/generated";
+import { removeProfileFromProjectCache } from "./hooks";
+
+function makeProjects(
+	projectCount: number,
+	profilesPerProject: number,
+): ProjectWithProfiles[] {
+	return Array.from({ length: projectCount }, (_, projectIndex) => {
+		const projectId = `project-${projectIndex}`;
+		return {
+			id: projectId,
+			name: projectId,
+			folder: `/tmp/${projectId}`,
+			created_at: "2026-01-01T00:00:00Z",
+			group_id: null,
+			profiles: Array.from({ length: profilesPerProject }, (_, profileIndex) => ({
+				id: `${projectId}-profile-${profileIndex}`,
+				project_id: projectId,
+				branch_name: profileIndex === 0 ? "main" : `branch-${profileIndex}`,
+				worktree_path: `/tmp/${projectId}/profile-${profileIndex}`,
+				created_at: "2026-01-01T00:00:00Z",
+				is_default: profileIndex === 0,
+			})),
+		};
+	});
+}
+
+function removeProfileFromEveryProject(
+	projects: ProjectWithProfiles[] | undefined,
+	profileId: string,
+) {
+	return projects?.map((project) => ({
+		...project,
+		profiles: project.profiles.filter((profile) => profile.id !== profileId),
+	}));
+}
+
+describe("removeProfileFromProjectCache", () => {
+	const projects = makeProjects(1_000, 8);
+	const projectId = "project-777";
+	const profileId = `${projectId}-profile-4`;
+
+	bench("clone and filter every project", () => {
+		removeProfileFromEveryProject(projects, profileId);
+	});
+
+	bench("clone only owning project", () => {
+		removeProfileFromProjectCache(projects, projectId, profileId);
+	});
+});

--- a/src/features/profiles/hooks.test.tsx
+++ b/src/features/profiles/hooks.test.tsx
@@ -5,7 +5,7 @@ import {
 import { renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { useProfileDeleteCheck } from "./hooks";
+import { removeProfileFromProjectCache, useProfileDeleteCheck } from "./hooks";
 
 const {
 	createProfileMock,
@@ -28,6 +28,24 @@ vi.mock("@/generated", async () => {
 		getProfileDeleteCheck: getProfileDeleteCheckMock,
 	};
 });
+
+function project(id: string, profileIds: string[]) {
+	return {
+		id,
+		name: id,
+		folder: `/tmp/${id}`,
+		created_at: "2026-01-01T00:00:00Z",
+		group_id: null,
+		profiles: profileIds.map((profileId, index) => ({
+			id: profileId,
+			project_id: id,
+			branch_name: index === 0 ? "main" : `branch-${index}`,
+			worktree_path: `/tmp/${id}/${profileId}`,
+			created_at: "2026-01-01T00:00:00Z",
+			is_default: index === 0,
+		})),
+	};
+}
 
 function createWrapper() {
 	const queryClient = new QueryClient({
@@ -111,5 +129,38 @@ describe("useProfileDeleteCheck", () => {
 		});
 
 		expect(getProfileDeleteCheckMock).not.toHaveBeenCalled();
+	});
+});
+
+describe("removeProfileFromProjectCache", () => {
+	it("only clones the project that owns the removed profile", () => {
+		const projects = [
+			project("project-1", ["profile-1", "profile-2"]),
+			project("project-2", ["profile-3", "profile-4"]),
+		];
+
+		const next = removeProfileFromProjectCache(
+			projects,
+			"project-2",
+			"profile-4",
+		);
+
+		expect(next).not.toBe(projects);
+		expect(next?.[0]).toBe(projects[0]);
+		expect(next?.[1]).not.toBe(projects[1]);
+		expect(next?.[1].profiles.map((profile) => profile.id)).toEqual([
+			"profile-3",
+		]);
+	});
+
+	it("returns the original cache when the project or profile is missing", () => {
+		const projects = [project("project-1", ["profile-1"])];
+
+		expect(
+			removeProfileFromProjectCache(projects, "missing", "profile-1"),
+		).toBe(projects);
+		expect(
+			removeProfileFromProjectCache(projects, "project-1", "missing"),
+		).toBe(projects);
 	});
 });

--- a/src/features/profiles/hooks.ts
+++ b/src/features/profiles/hooks.ts
@@ -17,6 +17,28 @@ function hasDiffStats(stats: GitDiffStats | null) {
 	);
 }
 
+export function removeProfileFromProjectCache(
+	projects: ProjectWithProfiles[] | undefined,
+	projectId: string,
+	profileId: string,
+) {
+	if (!projects) return projects;
+
+	const projectIndex = projects.findIndex((project) => project.id === projectId);
+	if (projectIndex === -1) return projects;
+
+	const project = projects[projectIndex];
+	const profiles = project.profiles.filter((profile) => profile.id !== profileId);
+	if (profiles.length === project.profiles.length) return projects;
+
+	const nextProjects = projects.slice();
+	nextProjects[projectIndex] = {
+		...project,
+		profiles,
+	};
+	return nextProjects;
+}
+
 export function useCreateProfile() {
 	const queryClient = useQueryClient();
 	return useMutation({
@@ -56,15 +78,12 @@ export function useDeleteProfile() {
 	return useMutation({
 		mutationFn: ({ id }: { id: string; projectId: string }) =>
 			deleteProfile({ id }),
-		onSuccess: (_data, { id }) => {
+		onSuccess: (_data, { id, projectId }) => {
 			useTerminalStore.getState().removeProfile(id);
 			queryClient.setQueryData<ProjectWithProfiles[]>(
 				queryKeys.projects.all,
 				(projects) =>
-					projects?.map((project) => ({
-						...project,
-						profiles: project.profiles.filter((profile) => profile.id !== id),
-					})),
+					removeProfileFromProjectCache(projects, projectId, id),
 			);
 			queryClient.invalidateQueries({ queryKey: queryKeys.projects.all });
 		},


### PR DESCRIPTION
## Summary
- update the projects cache for profile deletion by `projectId` instead of cloning every project
- return the original cache when the target project/profile is absent
- add focused cache helper tests and a Vitest benchmark

## Benchmark
`bunx vitest bench src/features/profiles/hooks.bench.ts --run`

Latest run:
`clone only owning project` was `29.34x` faster than `clone and filter every project` (`45,155.24 hz` vs `1,538.80 hz`).

The benchmark uses 1,000 projects with 8 profiles each and deletes one profile. The new path only clones the owning project instead of filtering profiles for every project.

## Tests
- `bunx vitest run src/features/profiles/hooks.test.tsx`
- `bunx eslint src/features/profiles/hooks.ts src/features/profiles/hooks.test.tsx src/features/profiles/hooks.bench.ts`
- `bunx tsc --noEmit`
- `bunx vitest bench src/features/profiles/hooks.bench.ts --run`