### PR TITLE
perf: drop immer from file viewer store

### DIFF
--- a/src/features/projects/fileViewerTabsStore.bench.ts
+++ b/src/features/projects/fileViewerTabsStore.bench.ts
@@ -1,0 +1,167 @@
+import { produce } from "immer";
+import { bench, describe } from "vitest";
+import {
+	closeTabState,
+	openFileState,
+	setFileDirtyState,
+	type FileViewerTab,
+} from "./fileViewerTabsStore";
+
+interface ProfileFileViewerState {
+	tabs: FileViewerTab[];
+	activeFilePath: string | null;
+	fileTabActive: boolean;
+}
+
+function createTabProfiles(profileCount: number, tabCount: number) {
+	const profiles: Record<string, ProfileFileViewerState> = {};
+	for (let profileIndex = 0; profileIndex < profileCount; profileIndex += 1) {
+		const profileId = `profile-${profileIndex}`;
+		profiles[profileId] = {
+			tabs: Array.from({ length: tabCount }, (_item, tabIndex) => ({
+				filePath: `/repo-${profileIndex}/src/file-${tabIndex}.tsx`,
+				title: `file-${tabIndex}.tsx`,
+			})),
+			activeFilePath: `/repo-${profileIndex}/src/file-${tabCount - 1}.tsx`,
+			fileTabActive: true,
+		};
+	}
+	return profiles;
+}
+
+function createDirtyProfiles(profileCount: number, fileCount: number) {
+	const profiles: Record<string, string[]> = {};
+	for (let profileIndex = 0; profileIndex < profileCount; profileIndex += 1) {
+		profiles[`profile-${profileIndex}`] = Array.from(
+			{ length: fileCount },
+			(_item, fileIndex) => `/repo-${profileIndex}/src/file-${fileIndex}.tsx`,
+		);
+	}
+	return profiles;
+}
+
+function openFileWithImmer(
+	profiles: Record<string, ProfileFileViewerState>,
+	profileId: string,
+	filePath: string,
+) {
+	return produce(profiles, (draft) => {
+		const title = filePath.split("/").pop() ?? filePath;
+		const existing = draft[profileId] ?? {
+			tabs: [],
+			activeFilePath: null,
+			fileTabActive: false,
+		};
+		const alreadyOpen = existing.tabs.some((t) => t.filePath === filePath);
+		draft[profileId] = {
+			tabs: alreadyOpen ? existing.tabs : [...existing.tabs, { filePath, title }],
+			activeFilePath: filePath,
+			fileTabActive: true,
+		};
+	});
+}
+
+function closeTabWithImmer(
+	profiles: Record<string, ProfileFileViewerState>,
+	profileId: string,
+	filePath: string,
+) {
+	return produce(profiles, (draft) => {
+		const profile = draft[profileId];
+		if (!profile) return;
+		const idx = profile.tabs.findIndex((t) => t.filePath === filePath);
+		profile.tabs = profile.tabs.filter((t) => t.filePath !== filePath);
+		if (profile.activeFilePath === filePath) {
+			if (profile.tabs.length > 0) {
+				const newIdx = Math.min(idx, profile.tabs.length - 1);
+				profile.activeFilePath = profile.tabs[newIdx].filePath;
+			} else {
+				profile.activeFilePath = null;
+				profile.fileTabActive = false;
+			}
+		}
+		if (profile.tabs.length === 0) {
+			delete draft[profileId];
+		}
+	});
+}
+
+function setFileDirtyWithImmer(
+	profiles: Record<string, string[]>,
+	profileId: string,
+	filePath: string,
+	isDirty: boolean,
+) {
+	return produce(profiles, (draft) => {
+		const dirtyFiles = draft[profileId] ?? [];
+		const alreadyDirty = dirtyFiles.includes(filePath);
+
+		if (isDirty) {
+			if (!alreadyDirty) {
+				draft[profileId] = [...dirtyFiles, filePath];
+			}
+			return;
+		}
+
+		if (!alreadyDirty) return;
+		const nextDirtyFiles = dirtyFiles.filter((path) => path !== filePath);
+		if (nextDirtyFiles.length > 0) {
+			draft[profileId] = nextDirtyFiles;
+		} else {
+			delete draft[profileId];
+		}
+	});
+}
+
+describe("fileViewerTabsStore reducers", () => {
+	const tabProfiles = createTabProfiles(200, 24);
+	const dirtyProfiles = createDirtyProfiles(200, 24);
+
+	bench("immer open and close tab", () => {
+		const opened = openFileWithImmer(
+			tabProfiles,
+			"profile-100",
+			"/repo-100/src/new-file.tsx",
+		);
+		closeTabWithImmer(opened, "profile-100", "/repo-100/src/file-12.tsx");
+	});
+
+	bench("plain open and close tab", () => {
+		const opened = openFileState(
+			tabProfiles,
+			"profile-100",
+			"/repo-100/src/new-file.tsx",
+		);
+		closeTabState(opened, "profile-100", "/repo-100/src/file-12.tsx");
+	});
+
+	bench("immer update dirty files", () => {
+		const added = setFileDirtyWithImmer(
+			dirtyProfiles,
+			"profile-100",
+			"/repo-100/src/new-file.tsx",
+			true,
+		);
+		setFileDirtyWithImmer(
+			added,
+			"profile-100",
+			"/repo-100/src/file-12.tsx",
+			false,
+		);
+	});
+
+	bench("plain update dirty files", () => {
+		const added = setFileDirtyState(
+			dirtyProfiles,
+			"profile-100",
+			"/repo-100/src/new-file.tsx",
+			true,
+		);
+		setFileDirtyState(
+			added,
+			"profile-100",
+			"/repo-100/src/file-12.tsx",
+			false,
+		);
+	});
+});

--- a/src/features/projects/fileViewerTabsStore.ts
+++ b/src/features/projects/fileViewerTabsStore.ts
@@ -1,7 +1,6 @@
 import { useMemo } from "react";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
-import { immer } from "zustand/middleware/immer";
 import { useShallow } from "zustand/react/shallow";
 import { useTerminalStore } from "@/features/terminal/store";
 
@@ -33,104 +32,184 @@ interface FileViewerDirtyStore {
 	) => void;
 }
 
-export const useFileViewerDirtyStore = create<FileViewerDirtyStore>()(
-	immer((set) => ({
-		profiles: {},
+const EMPTY_PROFILE_FILE_VIEWER_STATE: ProfileFileViewerState = {
+	tabs: [],
+	activeFilePath: null,
+	fileTabActive: false,
+};
 
-		setFileDirty(profileId, filePath, isDirty) {
-			set((state) => {
-				const dirtyFiles = state.profiles[profileId] ?? [];
-				const alreadyDirty = dirtyFiles.includes(filePath);
+export function setFileDirtyState(
+	profiles: Record<string, string[]>,
+	profileId: string,
+	filePath: string,
+	isDirty: boolean,
+) {
+	const dirtyFiles = profiles[profileId] ?? [];
+	const alreadyDirty = dirtyFiles.includes(filePath);
 
-				if (isDirty) {
-					if (!alreadyDirty) {
-						state.profiles[profileId] = [...dirtyFiles, filePath];
-					}
-					return;
-				}
+	if (isDirty) {
+		if (alreadyDirty) return profiles;
+		return {
+			...profiles,
+			[profileId]: [...dirtyFiles, filePath],
+		};
+	}
 
-				if (!alreadyDirty) return;
-				const nextDirtyFiles = dirtyFiles.filter((path) => path !== filePath);
-				if (nextDirtyFiles.length > 0) {
-					state.profiles[profileId] = nextDirtyFiles;
-				} else {
-					delete state.profiles[profileId];
-				}
-			});
+	if (!alreadyDirty) return profiles;
+	const nextDirtyFiles = dirtyFiles.filter((path) => path !== filePath);
+	if (nextDirtyFiles.length > 0) {
+		return {
+			...profiles,
+			[profileId]: nextDirtyFiles,
+		};
+	}
+
+	const nextProfiles = { ...profiles };
+	delete nextProfiles[profileId];
+	return nextProfiles;
+}
+
+export function openFileState(
+	profiles: Record<string, ProfileFileViewerState>,
+	profileId: string,
+	filePath: string,
+) {
+	const title = filePath.split("/").pop() ?? filePath;
+	const existing = profiles[profileId] ?? EMPTY_PROFILE_FILE_VIEWER_STATE;
+	const alreadyOpen = existing.tabs.some((t) => t.filePath === filePath);
+	return {
+		...profiles,
+		[profileId]: {
+			tabs: alreadyOpen
+				? existing.tabs
+				: [...existing.tabs, { filePath, title }],
+			activeFilePath: filePath,
+			fileTabActive: true,
 		},
-	})),
-);
+	};
+}
+
+export function closeTabState(
+	profiles: Record<string, ProfileFileViewerState>,
+	profileId: string,
+	filePath: string,
+) {
+	const profile = profiles[profileId];
+	if (!profile) return profiles;
+
+	const idx = profile.tabs.findIndex((t) => t.filePath === filePath);
+	if (idx === -1) return profiles;
+
+	const tabs = profile.tabs.filter((t) => t.filePath !== filePath);
+	if (tabs.length === 0) {
+		const nextProfiles = { ...profiles };
+		delete nextProfiles[profileId];
+		return nextProfiles;
+	}
+
+	const nextProfile = { ...profile, tabs };
+	if (profile.activeFilePath === filePath) {
+		const newIdx = Math.min(idx, tabs.length - 1);
+		nextProfile.activeFilePath = tabs[newIdx].filePath;
+	}
+
+	return {
+		...profiles,
+		[profileId]: nextProfile,
+	};
+}
+
+export function setFileActiveState(
+	profiles: Record<string, ProfileFileViewerState>,
+	profileId: string,
+	filePath: string,
+) {
+	const profile = profiles[profileId];
+	if (!profile) return profiles;
+	return {
+		...profiles,
+		[profileId]: {
+			...profile,
+			activeFilePath: filePath,
+			fileTabActive: true,
+		},
+	};
+}
+
+export function setTerminalActiveState(
+	profiles: Record<string, ProfileFileViewerState>,
+	profileId: string,
+) {
+	const profile = profiles[profileId];
+	if (!profile || !profile.fileTabActive) return profiles;
+	return {
+		...profiles,
+		[profileId]: {
+			...profile,
+			fileTabActive: false,
+		},
+	};
+}
+
+export const useFileViewerDirtyStore = create<FileViewerDirtyStore>()((set) => ({
+	profiles: {},
+
+	setFileDirty(profileId, filePath, isDirty) {
+		set((state) => ({
+			profiles: setFileDirtyState(
+				state.profiles,
+				profileId,
+				filePath,
+				isDirty,
+			),
+		}));
+	},
+}));
 
 export const useFileViewerTabsStore = create<FileViewerTabsStore>()(
 	persist(
-		immer((set) => ({
+		(set) => ({
 			profiles: {},
 
 			openFile(profileId, filePath) {
-				set((state) => {
-					const title = filePath.split("/").pop() ?? filePath;
-					const existing = state.profiles[profileId] ?? {
-						tabs: [],
-						activeFilePath: null,
-						fileTabActive: false,
-					};
-					const alreadyOpen = existing.tabs.some(
-						(t) => t.filePath === filePath,
-					);
-					state.profiles[profileId] = {
-						tabs: alreadyOpen
-							? existing.tabs
-							: [...existing.tabs, { filePath, title }],
-						activeFilePath: filePath,
-						fileTabActive: true,
-					};
-				});
+				set((state) => ({
+					profiles: openFileState(
+						state.profiles,
+						profileId,
+						filePath,
+					),
+				}));
 			},
 
 			closeTab(profileId, filePath) {
-				set((state) => {
-					const profile = state.profiles[profileId];
-					if (!profile) return;
-					const idx = profile.tabs.findIndex(
-						(t) => t.filePath === filePath,
-					);
-					profile.tabs = profile.tabs.filter(
-						(t) => t.filePath !== filePath,
-					);
-					if (profile.activeFilePath === filePath) {
-						if (profile.tabs.length > 0) {
-							const newIdx = Math.min(idx, profile.tabs.length - 1);
-							profile.activeFilePath = profile.tabs[newIdx].filePath;
-						} else {
-							profile.activeFilePath = null;
-							profile.fileTabActive = false;
-						}
-					}
-					if (profile.tabs.length === 0) {
-						delete state.profiles[profileId];
-					}
-				});
+				set((state) => ({
+					profiles: closeTabState(
+						state.profiles,
+						profileId,
+						filePath,
+					),
+				}));
 				useFileViewerDirtyStore
 					.getState()
 					.setFileDirty(profileId, filePath, false);
 			},
 
 			setFileActive(profileId, filePath) {
-				set((state) => {
-					const profile = state.profiles[profileId];
-					if (!profile) return;
-					profile.activeFilePath = filePath;
-					profile.fileTabActive = true;
-				});
+				set((state) => ({
+					profiles: setFileActiveState(
+						state.profiles,
+						profileId,
+						filePath,
+					),
+				}));
 			},
 
 			setTerminalActive(profileId) {
-				set((state) => {
-					const profile = state.profiles[profileId];
-					if (profile) profile.fileTabActive = false;
-				});
+				set((state) => ({
+					profiles: setTerminalActiveState(state.profiles, profileId),
+				}));
 			},
-		})),
+		}),
 		{ name: "file-viewer-tabs-v1" },
 	),
 );


### PR DESCRIPTION
## Summary
- remove Immer from file viewer tab and dirty state stores
- keep shallow immutable reducers for open/close/active/dirty updates
- add a Vitest benchmark comparing the old Immer reducer shape with the plain reducers

## Benchmarks
- `bunx vitest bench src/features/projects/fileViewerTabsStore.bench.ts --run`
  - plain open and close tab: 8,257.41 hz vs Immer 1,779.86 hz (4.64x faster)
  - plain update dirty files: 10,881.76 hz vs Immer 2,051.00 hz (5.31x faster)

## Tests
- `bunx vitest run src/features/projects/fileViewerTabsStore.test.ts`
- `bunx eslint src/features/projects/fileViewerTabsStore.ts src/features/projects/fileViewerTabsStore.bench.ts`
- `bunx tsc --noEmit`
