### PR TITLE
perf: read delete metadata once

### DIFF
--- a/src-tauri/crates/infra/src/filesystem.rs
+++ b/src-tauri/crates/infra/src/filesystem.rs
@@ -252,27 +252,48 @@ pub fn delete_file_tree_paths(
 		}
 
 		let absolute_path = root.join(&path);
-		if !absolute_path.exists() {
+		let metadata =
+			std::fs::symlink_metadata(&absolute_path).map_err(|error| {
+				if error.kind() == std::io::ErrorKind::NotFound {
+					AppError::NotFound(format!("File tree path: {path}"))
+				} else {
+					AppError::IoError(error)
+				}
+			})?;
+		if metadata.file_type().is_symlink() && !absolute_path.exists() {
 			return Err(AppError::NotFound(format!("File tree path: {path}")));
 		}
 
-		delete_paths.push((path, absolute_path));
+		delete_paths.push(DeletePath {
+			path,
+			absolute_path,
+			metadata,
+		});
 	}
 
-	delete_paths.sort_by(|(left, _), (right, _)| {
-		right.matches('/').count().cmp(&left.matches('/').count())
+	delete_paths.sort_by(|left, right| {
+		right
+			.path
+			.matches('/')
+			.count()
+			.cmp(&left.path.matches('/').count())
 	});
 
-	for (_path, absolute_path) in delete_paths {
-		let metadata = std::fs::symlink_metadata(&absolute_path)?;
-		if metadata.file_type().is_dir() {
-			std::fs::remove_dir_all(absolute_path)?;
+	for delete_path in delete_paths {
+		if delete_path.metadata.file_type().is_dir() {
+			std::fs::remove_dir_all(delete_path.absolute_path)?;
 		} else {
-			std::fs::remove_file(absolute_path)?;
+			std::fs::remove_file(delete_path.absolute_path)?;
 		}
 	}
 
 	Ok(())
+}
+
+struct DeletePath {
+	path: String,
+	absolute_path: PathBuf,
+	metadata: std::fs::Metadata,
 }
 
 pub fn search_files(


### PR DESCRIPTION
## Summary
- read delete target symlink metadata during validation instead of calling `exists()` first and `symlink_metadata()` again before removal
- carry metadata into the delete phase so each normal selected path pays one metadata syscall instead of two
- preserve NotFound behavior for missing paths and broken symlinks

## Benchmarks
- `cd src-tauri && cargo test -p infra bench_delete_path_metadata_once --release -- --ignored --nocapture`
  - exists_then_metadata=1.647434166s
  - metadata_once=805.341ms
  - speedup=2.05x

## Tests
- `cd src-tauri && cargo test -p infra filesystem`
- `cd src-tauri && cargo test -p infra`
