### PR TITLE
perf: check root children directory once

### DIFF
--- a/src-tauri/crates/infra/src/filesystem.rs
+++ b/src-tauri/crates/infra/src/filesystem.rs
@@ -85,7 +85,7 @@ pub fn list_file_tree_child_paths(
 	let parent_dir = parent_path
 		.as_ref()
 		.map_or_else(|| root.to_path_buf(), |path| root.join(path));
-	if !parent_dir.is_dir() {
+	if parent_path.is_some() && !parent_dir.is_dir() {
 		return Err(AppError::NotFound(format!(
 			"Directory: {}",
 			parent_dir.display()
@@ -555,6 +555,7 @@ fn subsequence_score(query: &str, candidate: &str) -> Option<u32> {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use std::time::Instant;
 
 	#[test]
 	fn scores_exact_name_first() {
@@ -654,6 +655,35 @@ mod tests {
 			vec!["node_modules/".to_string(), "src/".to_string()]
 		);
 		assert_eq!(node_module_paths, vec!["node_modules/pkg/".to_string()]);
+	}
+
+	#[test]
+	#[ignore]
+	fn bench_list_root_children_checks_root_once() {
+		let temp_dir = tempfile::tempdir().expect("temp dir");
+		let root = temp_dir.path();
+		std::fs::create_dir_all(root.join("src")).expect("create src");
+		std::fs::write(root.join("README.md"), "readme").expect("write file");
+
+		let iterations = 100_000;
+		let double_check_start = Instant::now();
+		for _ in 0..iterations {
+			assert!(root.is_dir());
+			assert!(root.is_dir());
+		}
+		let double_check_duration = double_check_start.elapsed();
+
+		let single_check_start = Instant::now();
+		for _ in 0..iterations {
+			assert!(root.is_dir());
+		}
+		let single_check_duration = single_check_start.elapsed();
+
+		println!(
+			"double_root_is_dir={double_check_duration:?} single_root_is_dir={single_check_duration:?} speedup={:.2}x",
+			double_check_duration.as_secs_f64()
+				/ single_check_duration.as_secs_f64()
+		);
 	}
 
 	#[test]


### PR DESCRIPTION
## Summary
- avoid checking the root directory twice when listing root-level file tree children
- keep the parent directory existence check for non-root child listings
- add an ignored Rust benchmark for the duplicate `is_dir` metadata cost

## Benchmarks
- `cd src-tauri && cargo test -p infra bench_list_root_children_checks_root_once --release -- --ignored --nocapture`
  - double_root_is_dir=258.84025ms
  - single_root_is_dir=127.580166ms
  - speedup=2.03x

## Tests
- `cd src-tauri && cargo test -p infra filesystem::tests::lists_file_tree_child_paths_without_recursing_into_ignored_dirs`
- `cd src-tauri && cargo test -p infra`
