### PR TITLE
perf: drop immer from terminal store

### DIFF
--- a/src/features/terminal/store.bench.ts
+++ b/src/features/terminal/store.bench.ts
@@ -1,0 +1,115 @@
+import { enableMapSet, produce } from "immer";
+import { bench, describe } from "vitest";
+import {
+	closeTabState,
+	markNotifiedState,
+	type ProjectTerminalState,
+} from "./store";
+
+enableMapSet();
+
+interface TerminalDataState {
+	profiles: Record<string, ProjectTerminalState>;
+	notifiedTabs: Set<string>;
+}
+
+function createTerminalState(profileCount: number, tabsPerProfile: number) {
+	const profiles: Record<string, ProjectTerminalState> = {};
+	for (let profileIndex = 0; profileIndex < profileCount; profileIndex += 1) {
+		const profileId = `profile-${profileIndex}`;
+		const tabs = Array.from({ length: tabsPerProfile }, (_item, tabIndex) => ({
+			id: `session-${profileIndex}-${tabIndex}`,
+			title: `Terminal ${tabIndex + 1}`,
+		}));
+		profiles[profileId] = {
+			tabs,
+			activeTabId: tabs[tabs.length - 1]?.id ?? null,
+			counter: tabs.length,
+		};
+	}
+
+	return {
+		profiles,
+		notifiedTabs: new Set<string>(),
+	} satisfies TerminalDataState;
+}
+
+function findProfileIdBySessionId(
+	profiles: Record<string, ProjectTerminalState>,
+	sessionId: string,
+) {
+	for (const [profileId, profile] of Object.entries(profiles)) {
+		if (profile.tabs.some((tab) => tab.id === sessionId)) {
+			return profileId;
+		}
+	}
+
+	return null;
+}
+
+function markNotifiedWithImmer(
+	state: TerminalDataState,
+	sessionId: string,
+) {
+	return produce(state, (draft) => {
+		const profileId = findProfileIdBySessionId(draft.profiles, sessionId);
+		const focusedProfileId: string | null = null;
+		if (
+			profileId &&
+			profileId === focusedProfileId &&
+			draft.profiles[profileId]?.activeTabId === sessionId
+		) {
+			draft.notifiedTabs.delete(sessionId);
+			return;
+		}
+
+		draft.notifiedTabs.add(sessionId);
+	});
+}
+
+function closeTabWithImmer(
+	state: TerminalDataState,
+	profileId: string,
+	tabId: string,
+) {
+	return produce(state, (draft) => {
+		const profile = draft.profiles[profileId];
+		if (!profile) return;
+		const wasActiveTab = tabId === profile.activeTabId;
+
+		draft.notifiedTabs.delete(tabId);
+
+		const idx = profile.tabs.findIndex((t) => t.id === tabId);
+		profile.tabs = profile.tabs.filter((t) => t.id !== tabId);
+
+		if (profile.tabs.length === 0) {
+			delete draft.profiles[profileId];
+			return;
+		}
+
+		if (wasActiveTab) {
+			const newIdx = Math.min(idx, profile.tabs.length - 1);
+			profile.activeTabId = profile.tabs[newIdx].id;
+		}
+	});
+}
+
+describe("terminal store reducers", () => {
+	const state = createTerminalState(200, 6);
+
+	bench("immer mark notification", () => {
+		markNotifiedWithImmer(state, "session-100-3");
+	});
+
+	bench("plain mark notification", () => {
+		markNotifiedState(state, "session-100-3");
+	});
+
+	bench("immer close tab", () => {
+		closeTabWithImmer(state, "profile-100", "session-100-3");
+	});
+
+	bench("plain close tab", () => {
+		closeTabState(state, "profile-100", "session-100-3");
+	});
+});

--- a/src/features/terminal/store.ts
+++ b/src/features/terminal/store.ts
@@ -1,20 +1,21 @@
 import { listen } from "@tauri-apps/api/event";
-import { enableMapSet } from "immer";
 import { create } from "zustand";
-import { immer } from "zustand/middleware/immer";
 import { useShallow } from "zustand/react/shallow";
 
-enableMapSet();
-
-interface TerminalTab {
+export interface TerminalTab {
 	id: string;
 	title: string;
 }
 
-interface ProjectTerminalState {
+export interface ProjectTerminalState {
 	tabs: TerminalTab[];
 	activeTabId: string | null;
 	counter: number;
+}
+
+interface TerminalDataState {
+	profiles: Record<string, ProjectTerminalState>;
+	notifiedTabs: Set<string>;
 }
 
 const PROFILE_PATH_REGEX = /^\/projects\/[^/]+\/profiles\/([^/]+)$/;
@@ -37,21 +38,156 @@ function findProfileIdBySessionId(
 	return null;
 }
 
-function clearProfileActiveTabNotification(
-	state: Pick<TerminalStore, "profiles" | "notifiedTabs">,
-	profileId: string | null,
+export function addTabState(
+	state: TerminalDataState,
+	profileId: string,
+	sessionId: string,
+	title: string,
 ) {
-	if (!profileId) return;
+	const existing = state.profiles[profileId] ?? {
+		tabs: [],
+		activeTabId: null,
+		counter: 0,
+	};
+	const tab: TerminalTab = { id: sessionId, title };
+	const nextState: TerminalDataState = {
+		profiles: {
+			...state.profiles,
+			[profileId]: {
+				tabs: [...existing.tabs, tab],
+				activeTabId: tab.id,
+				counter: existing.counter + 1,
+			},
+		},
+		notifiedTabs: state.notifiedTabs,
+	};
 
-	const activeTabId = state.profiles[profileId]?.activeTabId;
-	if (activeTabId) {
-		state.notifiedTabs.delete(activeTabId);
+	if (getFocusedProfileId() !== profileId) {
+		return nextState;
 	}
+
+	const activeTabId = nextState.profiles[profileId]?.activeTabId;
+	if (!activeTabId || !nextState.notifiedTabs.has(activeTabId)) {
+		return nextState;
+	}
+
+	const notifiedTabs = new Set(nextState.notifiedTabs);
+	notifiedTabs.delete(activeTabId);
+	return { ...nextState, notifiedTabs };
 }
 
-interface TerminalStore {
-	profiles: Record<string, ProjectTerminalState>;
-	notifiedTabs: Set<string>;
+export function closeTabState(
+	state: TerminalDataState,
+	profileId: string,
+	tabId: string,
+) {
+	const profile = state.profiles[profileId];
+	if (!profile) return state;
+
+	const idx = profile.tabs.findIndex((t) => t.id === tabId);
+	if (idx === -1) return state;
+
+	const tabs = profile.tabs.filter((t) => t.id !== tabId);
+	const notifiedTabs = state.notifiedTabs.has(tabId)
+		? new Set(state.notifiedTabs)
+		: state.notifiedTabs;
+	if (notifiedTabs !== state.notifiedTabs) {
+		notifiedTabs.delete(tabId);
+	}
+
+	if (tabs.length === 0) {
+		const profiles = { ...state.profiles };
+		delete profiles[profileId];
+		return { profiles, notifiedTabs };
+	}
+
+	let activeTabId = profile.activeTabId;
+	if (tabId === profile.activeTabId) {
+		const newIdx = Math.min(idx, tabs.length - 1);
+		activeTabId = tabs[newIdx].id;
+	}
+
+	let nextNotifiedTabs = notifiedTabs;
+	if (
+		tabId === profile.activeTabId &&
+		getFocusedProfileId() === profileId &&
+		activeTabId &&
+		nextNotifiedTabs.has(activeTabId)
+	) {
+		nextNotifiedTabs = new Set(nextNotifiedTabs);
+		nextNotifiedTabs.delete(activeTabId);
+	}
+
+	return {
+		profiles: {
+			...state.profiles,
+			[profileId]: {
+				...profile,
+				tabs,
+				activeTabId,
+			},
+		},
+		notifiedTabs: nextNotifiedTabs,
+	};
+}
+
+export function setActiveTabState(
+	state: TerminalDataState,
+	profileId: string,
+	tabId: string,
+) {
+	const profile = state.profiles[profileId];
+	if (!profile) return state;
+
+	const notifiedTabs = state.notifiedTabs.has(tabId)
+		? new Set(state.notifiedTabs)
+		: state.notifiedTabs;
+	if (notifiedTabs !== state.notifiedTabs) {
+		notifiedTabs.delete(tabId);
+	}
+
+	return {
+		profiles: {
+			...state.profiles,
+			[profileId]: {
+				...profile,
+				activeTabId: tabId,
+			},
+		},
+		notifiedTabs,
+	};
+}
+
+export function markNotifiedState(
+	state: TerminalDataState,
+	sessionId: string,
+) {
+	const profileId = findProfileIdBySessionId(state.profiles, sessionId);
+	if (
+		profileId &&
+		profileId === getFocusedProfileId() &&
+		state.profiles[profileId]?.activeTabId === sessionId
+	) {
+		if (!state.notifiedTabs.has(sessionId)) return state;
+		const notifiedTabs = new Set(state.notifiedTabs);
+		notifiedTabs.delete(sessionId);
+		return { ...state, notifiedTabs };
+	}
+
+	if (state.notifiedTabs.has(sessionId)) return state;
+	const notifiedTabs = new Set(state.notifiedTabs);
+	notifiedTabs.add(sessionId);
+	return { ...state, notifiedTabs };
+}
+
+export function markReadState(state: TerminalDataState, sessionId: string) {
+	if (!state.notifiedTabs.has(sessionId)) return state;
+	const notifiedTabs = new Set(state.notifiedTabs);
+	notifiedTabs.delete(sessionId);
+	return { ...state, notifiedTabs };
+}
+
+interface TerminalStore extends TerminalDataState {
 	addTab: (profileId: string, sessionId: string, title: string) => void;
 	closeTab: (profileId: string, tabId: string) => void;
 	setActiveTab: (profileId: string, tabId: string) => void;
@@ -63,130 +199,98 @@ interface TerminalStore {
 	markProfileRead: (profileId: string) => void;
 }
 
-export const useTerminalStore = create<TerminalStore>()(
-	immer((set) => ({
-		profiles: {},
-		notifiedTabs: new Set<string>(),
+export const useTerminalStore = create<TerminalStore>()((set) => ({
+	profiles: {},
+	notifiedTabs: new Set<string>(),
 
-		addTab(profileId, sessionId, title) {
-			set((state) => {
-				const existing = state.profiles[profileId] ?? {
-					tabs: [],
-					activeTabId: null,
-					counter: 0,
-				};
-				const tab: TerminalTab = { id: sessionId, title };
-				state.profiles[profileId] = {
-					tabs: [...existing.tabs, tab],
-					activeTabId: tab.id,
-					counter: existing.counter + 1,
-				};
+	addTab(profileId, sessionId, title) {
+		set((state) => addTabState(state, profileId, sessionId, title));
+	},
 
-				if (getFocusedProfileId() === profileId) {
-					clearProfileActiveTabNotification(state, profileId);
-				}
-			});
-		},
+	closeTab(profileId, tabId) {
+		set((state) => closeTabState(state, profileId, tabId));
+	},
 
-		closeTab(profileId, tabId) {
-			set((state) => {
-				const profile = state.profiles[profileId];
-				if (!profile) return;
-				const wasActiveTab = tabId === profile.activeTabId;
+	setActiveTab(profileId, tabId) {
+		set((state) => setActiveTabState(state, profileId, tabId));
+	},
 
-				state.notifiedTabs.delete(tabId);
+	removeProfile(profileId) {
+		set((state) => {
+			const profile = state.profiles[profileId];
+			if (!profile) return state;
+			const profiles = { ...state.profiles };
+			delete profiles[profileId];
+			const notifiedTabs = new Set(state.notifiedTabs);
+			for (const tab of profile.tabs) {
+				notifiedTabs.delete(tab.id);
+			}
+			return { profiles, notifiedTabs };
+		});
+	},
 
-				const idx = profile.tabs.findIndex((t) => t.id === tabId);
-				profile.tabs = profile.tabs.filter((t) => t.id !== tabId);
+	updateTabTitle(profileId, tabId, title) {
+		set((state) => {
+			const profile = state.profiles[profileId];
+			if (!profile) return state;
+			const index = profile.tabs.findIndex((t) => t.id === tabId);
+			if (index === -1 || profile.tabs[index].title === title) {
+				return state;
+			}
+			const tabs = [...profile.tabs];
+			tabs[index] = { ...tabs[index], title };
+			return {
+				profiles: {
+					...state.profiles,
+					[profileId]: { ...profile, tabs },
+				},
+			};
+		});
+	},
 
-				if (profile.tabs.length === 0) {
-					delete state.profiles[profileId];
-					return;
-				}
-
-				if (wasActiveTab) {
-					const newIdx = Math.min(idx, profile.tabs.length - 1);
-					profile.activeTabId = profile.tabs[newIdx].id;
-					if (getFocusedProfileId() === profileId) {
-						clearProfileActiveTabNotification(state, profileId);
+	removeStaleProfiles(validIds) {
+		set((state) => {
+			let profiles: Record<string, ProjectTerminalState> | null = null;
+			let notifiedTabs: Set<string> | null = null;
+			for (const id of Object.keys(state.profiles)) {
+				if (!validIds.has(id)) {
+					profiles ??= { ...state.profiles };
+					notifiedTabs ??= new Set(state.notifiedTabs);
+					for (const tab of state.profiles[id].tabs) {
+						notifiedTabs.delete(tab.id);
 					}
+					delete profiles[id];
 				}
-			});
-		},
+			}
+			if (!profiles || !notifiedTabs) return state;
+			return { profiles, notifiedTabs };
+		});
+	},
 
-		setActiveTab(profileId, tabId) {
-			set((state) => {
-				const profile = state.profiles[profileId];
-				if (!profile) return;
-				profile.activeTabId = tabId;
-				state.notifiedTabs.delete(tabId);
-			});
-		},
+	markNotified(sessionId) {
+		set((state) => markNotifiedState(state, sessionId));
+	},
 
-		removeProfile(profileId) {
-			set((state) => {
-				const profile = state.profiles[profileId];
-				profile?.tabs.forEach((tab) => state.notifiedTabs.delete(tab.id));
-				delete state.profiles[profileId];
-			});
-		},
+	markRead(sessionId) {
+		set((state) => markReadState(state, sessionId));
+	},
 
-		updateTabTitle(profileId, tabId, title) {
-			set((state) => {
-				const profile = state.profiles[profileId];
-				if (!profile) return;
-				const tab = profile.tabs.find((t) => t.id === tabId);
-				if (tab && tab.title !== title) tab.title = title;
-			});
-		},
-
-		removeStaleProfiles(validIds) {
-			set((state) => {
-				for (const id of Object.keys(state.profiles)) {
-					if (!validIds.has(id)) {
-						state.profiles[id].tabs.forEach((tab) =>
-							state.notifiedTabs.delete(tab.id),
-						);
-						delete state.profiles[id];
-					}
+	markProfileRead(profileId) {
+		set((state) => {
+			const profile = state.profiles[profileId];
+			if (!profile) return state;
+			let notifiedTabs: Set<string> | null = null;
+			for (const tab of profile.tabs) {
+				if (state.notifiedTabs.has(tab.id)) {
+					notifiedTabs ??= new Set(state.notifiedTabs);
+					notifiedTabs.delete(tab.id);
 				}
-			});
-		},
-
-		markNotified(sessionId) {
-			set((state) => {
-				const profileId = findProfileIdBySessionId(
-					state.profiles,
-					sessionId,
-				);
-				if (
-					profileId &&
-					profileId === getFocusedProfileId() &&
-					state.profiles[profileId]?.activeTabId === sessionId
-				) {
-					state.notifiedTabs.delete(sessionId);
-					return;
-				}
-
-				state.notifiedTabs.add(sessionId);
-			});
-		},
-
-		markRead(sessionId) {
-			set((state) => {
-				state.notifiedTabs.delete(sessionId);
-			});
-		},
-
-		markProfileRead(profileId) {
-			set((state) => {
-				const profile = state.profiles[profileId];
-				if (!profile) return;
-				profile.tabs.forEach((tab) => state.notifiedTabs.delete(tab.id));
-			});
-		},
-	})),
-);
+			}
+			if (!notifiedTabs) return state;
+			return { notifiedTabs };
+		});
+	},
+}));
 
 /** IDs of profiles that currently have terminal tabs open. */
 export function useTerminalProfileIds() {


### PR DESCRIPTION
## Summary
- remove Immer from the terminal Zustand store
- use shallow immutable reducers for tab add/close, active tab, and notification updates
- avoid MapSet proxy work on high-frequency PTY notification events
- add a Vitest benchmark comparing the old Immer reducer shape with the plain reducers

## Benchmarks
- `bunx vitest bench src/features/terminal/store.bench.ts --run`
  - plain mark notification: 21,495.15 hz vs Immer 939.32 hz (22.88x faster)
  - plain close tab: 27,454.77 hz vs Immer 19,362.65 hz (1.42x faster)

## Tests
- `bunx vitest run src/features/terminal/store.test.ts`
- `bunx vitest run src/features/terminal/hooks.test.tsx src/features/terminal/store.test.ts`
- `bunx eslint src/features/terminal/store.ts src/features/terminal/store.bench.ts`
- `bunx tsc --noEmit`
