### PR TITLE
perf: resolve helper host triple once

### DIFF
--- a/scripts/build-helper-utils.mjs
+++ b/scripts/build-helper-utils.mjs
@@ -1,0 +1,17 @@
+import { execFileSync } from "node:child_process";
+
+const NEWLINE_PATTERN = /\r?\n/;
+
+export function parseHostTriple(versionOutput) {
+	const host = versionOutput
+		.split(NEWLINE_PATTERN)
+		.find((line) => line.startsWith("host: "))
+		?.slice("host: ".length)
+		.trim();
+	if (!host) throw new Error("Could not resolve Rust host target triple");
+	return host;
+}
+
+export function hostTriple() {
+	return parseHostTriple(execFileSync("rustc", ["-vV"], { encoding: "utf8" }));
+}

--- a/scripts/build-helper.bench.mjs
+++ b/scripts/build-helper.bench.mjs
@@ -1,0 +1,26 @@
+import { execFileSync } from "node:child_process";
+import process from "node:process";
+import { bench, describe } from "vitest";
+import { parseHostTriple } from "./build-helper-utils.mjs";
+
+function resolveHostTriple() {
+	return parseHostTriple(execFileSync("rustc", ["-vV"], { encoding: "utf8" }));
+}
+
+describe("build-helper host triple lookup", () => {
+	bench("resolve host triple once", () => {
+		const host = resolveHostTriple();
+		const target = process.env.TWOCODE_HELPER_TARGET || host;
+		if (!target) {
+			throw new Error("missing target triple");
+		}
+	}, { time: 500 });
+
+	bench("resolve host triple twice", () => {
+		const target = process.env.TWOCODE_HELPER_TARGET || resolveHostTriple();
+		const host = resolveHostTriple();
+		if (!target || !host) {
+			throw new Error("missing target triple");
+		}
+	}, { time: 500 });
+});

--- a/scripts/build-helper.mjs
+++ b/scripts/build-helper.mjs
@@ -1,25 +1,16 @@
 import { copyFileSync, chmodSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { execFileSync } from "node:child_process";
+import process from "node:process";
 import { fileURLToPath } from "node:url";
+import { hostTriple } from "./build-helper-utils.mjs";
 
 const mode = process.argv[2] === "release" ? "release" : "debug";
 const root = fileURLToPath(new URL("..", import.meta.url));
 const srcTauri = join(root, "src-tauri");
 
-function hostTriple() {
-	const version = execFileSync("rustc", ["-vV"], { encoding: "utf8" });
-	const host = version
-		.split(/\r?\n/)
-		.find((line) => line.startsWith("host: "))
-		?.slice("host: ".length)
-		.trim();
-	if (!host) throw new Error("Could not resolve Rust host target triple");
-	return host;
-}
-
-const targetTriple = process.env.TWOCODE_HELPER_TARGET || hostTriple();
 const host = hostTriple();
+const targetTriple = process.env.TWOCODE_HELPER_TARGET || host;
 const isWindows = targetTriple.includes("windows");
 const binSuffix = isWindows ? ".exe" : "";
 const cargoArgs = ["build", "-p", "twocode-helper"];


### PR DESCRIPTION
## Summary
- resolve the Rust host triple once in build-helper instead of spawning `rustc -vV` twice
- move host triple parsing into a small utility so the benchmark can import it without running the build script
- add a Vitest benchmark for the one-rustc vs two-rustc lookup path

## Benchmarks
- `bunx vitest bench scripts/build-helper.bench.mjs --run`
  - resolve host triple once: `3.5088 hz`
  - resolve host triple twice: `1.8374 hz`
  - once path is `1.91x` faster

## Verification
- `bun ./scripts/build-helper.mjs debug`
- `bunx eslint scripts/build-helper.mjs scripts/build-helper-utils.mjs scripts/build-helper.bench.mjs`