### PR TITLE
perf: avoid slugify cjk part joins

### DIFF
--- a/src-tauri/crates/infra/src/slug.rs
+++ b/src-tauri/crates/infra/src/slug.rs
@@ -4,23 +4,19 @@ use slug::slugify;
 /// Convert a string (possibly containing CJK characters) into a URL-safe slug.
 /// CJK characters are first converted to pinyin syllables, then the result is slugified.
 pub fn slugify_cjk(input: &str) -> String {
-	let mut parts: Vec<String> = Vec::new();
-	let mut buf = String::new();
+	let mut converted = String::with_capacity(input.len());
 	for c in input.chars() {
 		if let Some(py) = c.to_pinyin() {
-			if !buf.is_empty() {
-				parts.push(buf.clone());
-				buf.clear();
+			if !converted.is_empty() && !converted.ends_with(' ') {
+				converted.push(' ');
 			}
-			parts.push(py.plain().to_string());
+			converted.push_str(py.plain());
+			converted.push(' ');
 		} else {
-			buf.push(c);
+			converted.push(c);
 		}
 	}
-	if !buf.is_empty() {
-		parts.push(buf);
-	}
-	slugify(parts.join(" "))
+	slugify(converted)
 }
 
 #[cfg(test)]
@@ -49,5 +45,78 @@ mod tests {
 		assert!(result.contains("ni"));
 		assert!(result.contains("hao"));
 		assert!(result.contains("world"));
+	}
+
+	fn slugify_cjk_with_parts(input: &str) -> String {
+		let mut parts: Vec<String> = Vec::new();
+		let mut buf = String::new();
+		for c in input.chars() {
+			if let Some(py) = c.to_pinyin() {
+				if !buf.is_empty() {
+					parts.push(buf.clone());
+					buf.clear();
+				}
+				parts.push(py.plain().to_string());
+			} else {
+				buf.push(c);
+			}
+		}
+		if !buf.is_empty() {
+			parts.push(buf);
+		}
+		slugify(parts.join(" "))
+	}
+
+	#[test]
+	fn slugify_matches_part_join_for_boundaries() {
+		for input in [
+			"hello world",
+			"你好world",
+			"hello你好",
+			"hello你好world",
+			"🚀你好🔥world",
+			"测试/branch name",
+		] {
+			assert_eq!(slugify_cjk(input), slugify_cjk_with_parts(input));
+		}
+	}
+
+	#[test]
+	#[ignore]
+	fn bench_slugify_cjk_single_buffer() {
+		let inputs = [
+			"hello world project branch name",
+			"你好world项目分支",
+			"feature/修复终端通知性能问题",
+			"🚀发布 beta 版本 2026-05-15",
+		];
+		let iterations = 25_000;
+
+		let start = std::time::Instant::now();
+		let mut original_len = 0;
+		for _ in 0..iterations {
+			for input in inputs {
+				original_len += slugify_cjk_with_parts(input).len();
+			}
+		}
+		let original_elapsed = start.elapsed();
+
+		let start = std::time::Instant::now();
+		let mut single_buffer_len = 0;
+		for _ in 0..iterations {
+			for input in inputs {
+				single_buffer_len += slugify_cjk(input).len();
+			}
+		}
+		let single_buffer_elapsed = start.elapsed();
+
+		assert_eq!(original_len, single_buffer_len);
+		println!(
+			"parts_join={:?} single_buffer={:?} speedup={:.2}x",
+			original_elapsed,
+			single_buffer_elapsed,
+			original_elapsed.as_secs_f64()
+				/ single_buffer_elapsed.as_secs_f64()
+		);
 	}
 }


### PR DESCRIPTION
## Summary
- build CJK slug input in a single buffer instead of collecting parts, cloning the non-CJK buffer, and joining
- preserve existing slug output with boundary regression coverage
- add an ignored release benchmark for the old part-join path versus the new single-buffer path

## Benchmarks
- `cd src-tauri && cargo test -p infra bench_slugify_cjk_single_buffer --release -- --ignored --nocapture`
  - parts_join: `39.321875ms`
  - single_buffer: `17.536166ms`
  - speedup: `2.24x`

## Verification
- `cd src-tauri && cargo test -p infra slugify -- --nocapture`
- `cd src-tauri && cargo test -p infra`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal optimization to CJK text processing functionality with improved handling of character conversions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AkaraChen/2code/pull/256)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->