### PR TITLE
perf: split git file item path once

### DIFF
--- a/src/features/git/components/FileListItem.bench.ts
+++ b/src/features/git/components/FileListItem.bench.ts
@@ -1,0 +1,33 @@
+import { bench, describe } from "vitest";
+import { splitDiffFilePath } from "./filePath";
+
+const paths = [
+	"src/features/git/components/FileListItem.tsx",
+	"src/features/projects/FileViewerPane.tsx",
+	"src-tauri/crates/infra/src/git.rs",
+	"README.md",
+	"package.json",
+	"apps/web/src/routes/settings/profile/page.tsx",
+];
+
+function splitDiffFilePathWithSplit(name: string) {
+	const basename = name.split("/").pop() ?? name;
+	const parentPath = name.includes("/")
+		? name.split("/").slice(0, -1).join("/")
+		: null;
+	return { basename, parentPath };
+}
+
+describe("diff file path splitting", () => {
+	bench("split with lastIndexOf", () => {
+		for (const path of paths) {
+			splitDiffFilePath(path);
+		}
+	});
+
+	bench("split twice", () => {
+		for (const path of paths) {
+			splitDiffFilePathWithSplit(path);
+		}
+	});
+});

--- a/src/features/git/components/FileListItem.test.ts
+++ b/src/features/git/components/FileListItem.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { splitDiffFilePath } from "./filePath";
+
+describe("splitDiffFilePath", () => {
+	it("splits basename and parent path", () => {
+		expect(splitDiffFilePath("src/features/App.tsx")).toEqual({
+			basename: "App.tsx",
+			parentPath: "src/features",
+		});
+	});
+
+	it("handles root-level paths", () => {
+		expect(splitDiffFilePath("README.md")).toEqual({
+			basename: "README.md",
+			parentPath: null,
+		});
+	});
+});

--- a/src/features/git/components/FileListItem.tsx
+++ b/src/features/git/components/FileListItem.tsx
@@ -3,6 +3,7 @@ import type { FileDiffMetadata } from "@pierre/diffs";
 import type { MouseEventHandler } from "react";
 import OverflowTooltipText from "@/shared/components/OverflowTooltipText";
 import { changeBadge } from "../utils";
+import { splitDiffFilePath } from "./filePath";
 
 export interface FileListItemProps {
 	file: FileDiffMetadata;
@@ -24,11 +25,8 @@ export function FileListItem({
 	onToggleIncluded,
 }: FileListItemProps) {
 	const badge = changeBadge[file.type] ?? changeBadge.change;
-	const basename = file.name.split("/").pop() ?? file.name;
+	const { basename, parentPath } = splitDiffFilePath(file.name);
 	const effectiveIncluded = isIncluded ?? true;
-	const parentPath = file.name.includes("/")
-		? file.name.split("/").slice(0, -1).join("/")
-		: null;
 
 	return (
 		<HStack

--- a/src/features/git/components/filePath.ts
+++ b/src/features/git/components/filePath.ts
@@ -1,0 +1,10 @@
+export function splitDiffFilePath(name: string) {
+	const lastSlash = name.lastIndexOf("/");
+	if (lastSlash === -1) {
+		return { basename: name, parentPath: null };
+	}
+	return {
+		basename: name.slice(lastSlash + 1),
+		parentPath: name.slice(0, lastSlash),
+	};
+}


### PR DESCRIPTION
## Summary
- split git diff file paths once with `lastIndexOf`/`slice` instead of allocating with `split` twice per rendered file item
- keep FileListItem as a component-only export and move the path helper beside it
- add focused unit coverage and a Vitest benchmark

## Benchmarks
- `bunx vitest bench src/features/git/components/FileListItem.bench.ts --run`
  - split with lastIndexOf: `4,297,655.87 hz`
  - split twice: `1,006,447.19 hz`
  - lastIndexOf path is `4.27x` faster

## Verification
- `bunx vitest run src/features/git/components/FileListItem.test.ts src/features/git/components/ChangesFileList.test.tsx`
- `bunx eslint src/features/git/components/FileListItem.tsx src/features/git/components/filePath.ts src/features/git/components/FileListItem.test.ts src/features/git/components/FileListItem.bench.ts src/features/git/components/ChangesFileList.test.tsx`
- `bunx tsc --noEmit`