### PR TITLE
perf: cache terminal tab icons

### DIFF
--- a/src/features/terminal/TerminalTabs.tsx
+++ b/src/features/terminal/TerminalTabs.tsx
@@ -4,17 +4,8 @@ import {
 	Flex,
 	Spinner,
 } from "@chakra-ui/react";
-import claudeIconUrl from "@lobehub/icons-static-svg/icons/claude-color.svg";
-import clineIconUrl from "@lobehub/icons-static-svg/icons/cline.svg";
-import codexIconUrl from "@lobehub/icons-static-svg/icons/codex-color.svg";
-import geminiIconUrl from "@lobehub/icons-static-svg/icons/gemini-color.svg";
-import kimiIconUrl from "@lobehub/icons-static-svg/icons/kimi-color.svg";
-import openClawIconUrl from "@lobehub/icons-static-svg/icons/openclaw-color.svg";
-import opencodeIconUrl from "@lobehub/icons-static-svg/icons/opencode.svg";
-import qoderIconUrl from "@lobehub/icons-static-svg/icons/qoder-color.svg";
 import { useReducedMotion } from "motion/react";
 import { lazy, useMemo } from "react";
-import { FiTerminal } from "react-icons/fi";
 import { useShallow } from "zustand/react/shallow";
 import {
 	useFileViewerDirtyStore,
@@ -26,6 +17,7 @@ import { useCloseTerminalTab } from "./hooks";
 import { useTerminalStore } from "./store";
 import { TabStrip, type TabStripGroup } from "./TabStrip";
 import TerminalTemplateMenu from "./TerminalTemplateMenu";
+import { getTerminalTabIcon } from "./terminalTabIcon";
 import { Terminal } from "./Terminal";
 
 const FileViewerPane = lazy(() => import("@/features/projects/FileViewerPane"));
@@ -43,41 +35,12 @@ const TAB_EXIT_ANIMATION = {
 	duration: 0.14,
 	ease: [0.4, 0, 1, 1],
 } as const;
-const AGENT_TAB_ICONS: { keyword: string; iconUrl: string }[] = [
-	{ keyword: "claude", iconUrl: claudeIconUrl },
-	{ keyword: "codex", iconUrl: codexIconUrl },
-	{ keyword: "gemini", iconUrl: geminiIconUrl },
-	{ keyword: "kimi", iconUrl: kimiIconUrl },
-	{ keyword: "cline", iconUrl: clineIconUrl },
-	{ keyword: "openclaw", iconUrl: openClawIconUrl },
-	{ keyword: "opencode", iconUrl: opencodeIconUrl },
-	{ keyword: "qoder", iconUrl: qoderIconUrl },
-];
 const FULL_TAB_MOTION_PROPS = {
 	initial: { opacity: 0, scale: 0.92, y: 6 },
 	animate: { opacity: 1, scale: 1, y: 0 },
 	exit: { opacity: 0, scale: 0.88, y: -6, width: 0 },
 	transition: { default: TAB_ANIMATION, opacity: TAB_EXIT_ANIMATION },
 } as const;
-
-function getTerminalTabIcon(title: string) {
-	const lowerTitle = title.toLowerCase();
-	const match = AGENT_TAB_ICONS.find(({ keyword }) =>
-		lowerTitle.includes(keyword),
-	);
-
-	if (!match) return <FiTerminal size={14} />;
-
-	return (
-		<img
-			alt=""
-			aria-hidden="true"
-			draggable={false}
-			src={match.iconUrl}
-			style={{ width: 14, height: 14, flexShrink: 0 }}
-		/>
-	);
-}
 
 interface TerminalTabsProps {
 	projectId: string;

--- a/src/features/terminal/terminalTabIcon.bench.tsx
+++ b/src/features/terminal/terminalTabIcon.bench.tsx
@@ -1,0 +1,57 @@
+import { FiTerminal } from "react-icons/fi";
+import { bench, describe } from "vitest";
+import { getTerminalTabIcon } from "./terminalTabIcon";
+
+const AGENT_TAB_ICONS = [
+	{ keyword: "claude", iconUrl: "claude.svg" },
+	{ keyword: "codex", iconUrl: "codex.svg" },
+	{ keyword: "gemini", iconUrl: "gemini.svg" },
+	{ keyword: "kimi", iconUrl: "kimi.svg" },
+	{ keyword: "cline", iconUrl: "cline.svg" },
+	{ keyword: "openclaw", iconUrl: "openclaw.svg" },
+	{ keyword: "opencode", iconUrl: "opencode.svg" },
+	{ keyword: "qoder", iconUrl: "qoder.svg" },
+];
+const titles = [
+	"codex",
+	"claude",
+	"gemini worker",
+	"shell",
+	"npm run dev",
+	"opencode",
+	"qoder",
+	"plain zsh",
+];
+
+function getTerminalTabIconUncached(title: string) {
+	const lowerTitle = title.toLowerCase();
+	const match = AGENT_TAB_ICONS.find(({ keyword }) =>
+		lowerTitle.includes(keyword),
+	);
+
+	if (!match) return <FiTerminal size={14} />;
+
+	return (
+		<img
+			alt=""
+			aria-hidden="true"
+			draggable={false}
+			src={match.iconUrl}
+			style={{ width: 14, height: 14, flexShrink: 0 }}
+		/>
+	);
+}
+
+describe("terminal tab icon lookup", () => {
+	bench("cached icon lookup", () => {
+		for (const title of titles) {
+			getTerminalTabIcon(title);
+		}
+	});
+
+	bench("uncached icon lookup", () => {
+		for (const title of titles) {
+			getTerminalTabIconUncached(title);
+		}
+	});
+});

--- a/src/features/terminal/terminalTabIcon.test.tsx
+++ b/src/features/terminal/terminalTabIcon.test.tsx
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+import { getTerminalTabIcon } from "./terminalTabIcon";
+
+describe("getTerminalTabIcon", () => {
+	it("caches icons by title", () => {
+		expect(getTerminalTabIcon("codex")).toBe(getTerminalTabIcon("codex"));
+		expect(getTerminalTabIcon("shell")).toBe(getTerminalTabIcon("shell"));
+	});
+});

--- a/src/features/terminal/terminalTabIcon.tsx
+++ b/src/features/terminal/terminalTabIcon.tsx
@@ -1,0 +1,47 @@
+import claudeIconUrl from "@lobehub/icons-static-svg/icons/claude-color.svg";
+import clineIconUrl from "@lobehub/icons-static-svg/icons/cline.svg";
+import codexIconUrl from "@lobehub/icons-static-svg/icons/codex-color.svg";
+import geminiIconUrl from "@lobehub/icons-static-svg/icons/gemini-color.svg";
+import kimiIconUrl from "@lobehub/icons-static-svg/icons/kimi-color.svg";
+import openClawIconUrl from "@lobehub/icons-static-svg/icons/openclaw-color.svg";
+import opencodeIconUrl from "@lobehub/icons-static-svg/icons/opencode.svg";
+import qoderIconUrl from "@lobehub/icons-static-svg/icons/qoder-color.svg";
+import type { ReactNode } from "react";
+import { FiTerminal } from "react-icons/fi";
+
+const AGENT_TAB_ICONS: { keyword: string; iconUrl: string }[] = [
+	{ keyword: "claude", iconUrl: claudeIconUrl },
+	{ keyword: "codex", iconUrl: codexIconUrl },
+	{ keyword: "gemini", iconUrl: geminiIconUrl },
+	{ keyword: "kimi", iconUrl: kimiIconUrl },
+	{ keyword: "cline", iconUrl: clineIconUrl },
+	{ keyword: "openclaw", iconUrl: openClawIconUrl },
+	{ keyword: "opencode", iconUrl: opencodeIconUrl },
+	{ keyword: "qoder", iconUrl: qoderIconUrl },
+];
+
+const terminalTabIconCache = new Map<string, ReactNode>();
+
+export function getTerminalTabIcon(title: string) {
+	const cachedIcon = terminalTabIconCache.get(title);
+	if (cachedIcon) return cachedIcon;
+
+	const lowerTitle = title.toLowerCase();
+	const match = AGENT_TAB_ICONS.find(({ keyword }) =>
+		lowerTitle.includes(keyword),
+	);
+
+	const icon = match ? (
+		<img
+			alt=""
+			aria-hidden="true"
+			draggable={false}
+			src={match.iconUrl}
+			style={{ width: 14, height: 14, flexShrink: 0 }}
+		/>
+	) : (
+		<FiTerminal size={14} />
+	);
+	terminalTabIconCache.set(title, icon);
+	return icon;
+}


### PR DESCRIPTION
## Summary
- cache terminal tab icon resolution by stable tab title
- move agent icon keyword matching out of TerminalTabs into a small utility
- add unit coverage and a Vitest benchmark for cached versus uncached icon lookup

## Benchmarks
- `bunx vitest bench src/features/terminal/terminalTabIcon.bench.tsx --run`
  - cached icon lookup: `4,656,481.07 hz`
  - uncached icon lookup: `83,776.14 hz`
  - cached path is `55.58x` faster

## Verification
- `bunx vitest run src/features/terminal/terminalTabIcon.test.tsx src/features/terminal/hooks.test.tsx`
- `bunx eslint src/features/terminal/TerminalTabs.tsx src/features/terminal/terminalTabIcon.tsx src/features/terminal/terminalTabIcon.test.tsx src/features/terminal/terminalTabIcon.bench.tsx src/features/terminal/hooks.test.tsx`
- `bunx tsc --noEmit`