### PR TITLE
perf: build search line set directly

### DIFF
--- a/src/shared/hooks/useSearch.bench.ts
+++ b/src/shared/hooks/useSearch.bench.ts
@@ -1,0 +1,22 @@
+import { bench, describe } from "vitest";
+import type { SearchMatch } from "./useSearch";
+import { getMatchedLineNumbers } from "./useSearch";
+
+const matches: SearchMatch[] = Array.from({ length: 10_000 }, (_, index) => ({
+	columnIndex: index % 80,
+	lineNumber: Math.floor(index / 4) + 1,
+}));
+
+function getMatchedLineNumbersWithMap(values: readonly SearchMatch[]) {
+	return new Set(values.map((match) => match.lineNumber));
+}
+
+describe("matched line number set", () => {
+	bench("build set directly", () => {
+		getMatchedLineNumbers(matches);
+	});
+
+	bench("build set through map", () => {
+		getMatchedLineNumbersWithMap(matches);
+	});
+});

--- a/src/shared/hooks/useSearch.test.ts
+++ b/src/shared/hooks/useSearch.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { findSearchMatches, isSearchShortcut } from "./useSearch";
+import {
+	findSearchMatches,
+	getMatchedLineNumbers,
+	isSearchShortcut,
+} from "./useSearch";
 
 describe("useSearch utilities", () => {
 	it("finds case-insensitive matches with line and column positions", () => {
@@ -39,5 +43,15 @@ describe("useSearch utilities", () => {
 				shiftKey: true,
 			}),
 		).toBe(false);
+	});
+
+	it("builds matched line number sets without duplicate lines", () => {
+		expect([
+			...getMatchedLineNumbers([
+				{ columnIndex: 0, lineNumber: 1 },
+				{ columnIndex: 5, lineNumber: 1 },
+				{ columnIndex: 0, lineNumber: 3 },
+			]),
+		]).toEqual([1, 3]);
 	});
 });

--- a/src/shared/hooks/useSearch.ts
+++ b/src/shared/hooks/useSearch.ts
@@ -57,6 +57,14 @@ export function findSearchMatches(content: string, query: string): SearchMatch[]
 	return matches;
 }
 
+export function getMatchedLineNumbers(matches: readonly SearchMatch[]) {
+	const lineNumbers = new Set<number>();
+	for (const match of matches) {
+		lineNumbers.add(match.lineNumber);
+	}
+	return lineNumbers;
+}
+
 export function useSearch(content: string) {
 	const [isSearchOpen, setIsSearchOpen] = useState(false);
 	const [searchQuery, setSearchQuery] = useState("");
@@ -69,7 +77,7 @@ export function useSearch(content: string) {
 		[content, deferredSearchQuery],
 	);
 	const matchedLineNumbers = useMemo(
-		() => new Set(matches.map((match) => match.lineNumber)),
+		() => getMatchedLineNumbers(matches),
 		[matches],
 	);
 	const effectiveCurrentMatchIndex =


### PR DESCRIPTION
## Summary
- build matched search line number sets directly from matches
- avoid allocating an intermediate `matches.map(...)` array on every search result update
- add focused unit coverage and a Vitest benchmark

## Benchmarks
- `bunx vitest bench src/shared/hooks/useSearch.bench.ts --run`
  - build set directly: `6,582.50 hz`
  - build set through map: `4,341.80 hz`
  - direct path is `1.52x` faster

## Verification
- `bunx vitest run src/shared/hooks/useSearch.test.ts`
- `bunx eslint src/shared/hooks/useSearch.ts src/shared/hooks/useSearch.test.ts src/shared/hooks/useSearch.bench.ts`
- `bunx tsc --noEmit`