### PR TITLE
perf: collect included git files directly

### DIFF
--- a/src/features/git/components/GitDiffContent.tsx
+++ b/src/features/git/components/GitDiffContent.tsx
@@ -32,7 +32,7 @@ import {
 	useGitLog,
 	useGitPush,
 } from "../hooks";
-import { reconcileIncludedFiles } from "../utils";
+import { getOrderedIncludedFileNames, reconcileIncludedFiles } from "../utils";
 import { ChangesDiffPane, ChangesSidebar } from "./GitDiffChangesPanel";
 import { HistoryDiffPane, HistorySidebar } from "./GitDiffHistoryPanel";
 
@@ -106,10 +106,7 @@ export default function GitDiffContent({
 	const aheadCount = useGitAheadCount(profileId);
 	const gitPush = useGitPush(profileId);
 	const orderedIncludedFileNames = useMemo(
-		() =>
-			changesFiles.flatMap((file) =>
-				includedFileNames.has(file.name) ? [file.name] : [],
-			),
+		() => getOrderedIncludedFileNames(changesFiles, includedFileNames),
 		[changesFiles, includedFileNames],
 	);
 

--- a/src/features/git/utils.bench.ts
+++ b/src/features/git/utils.bench.ts
@@ -1,0 +1,31 @@
+import { bench, describe } from "vitest";
+import type { FileDiffMetadata } from "@pierre/diffs";
+import { getOrderedIncludedFileNames } from "./utils";
+
+const files = Array.from({ length: 5_000 }, (_, index) => ({
+	name: `src/file-${index}.ts`,
+	type: "change",
+	hunks: [],
+}) as unknown as FileDiffMetadata);
+const includedFileNames = new Set(
+	files.filter((_, index) => index % 2 === 0).map((file) => file.name),
+);
+
+function getOrderedIncludedFileNamesWithFlatMap(
+	values: readonly FileDiffMetadata[],
+	included: ReadonlySet<string>,
+) {
+	return values.flatMap((file) =>
+		included.has(file.name) ? [file.name] : [],
+	);
+}
+
+describe("ordered included git files", () => {
+	bench("collect included files directly", () => {
+		getOrderedIncludedFileNames(files, includedFileNames);
+	});
+
+	bench("collect included files with flatMap", () => {
+		getOrderedIncludedFileNamesWithFlatMap(files, includedFileNames);
+	});
+});

--- a/src/features/git/utils.test.ts
+++ b/src/features/git/utils.test.ts
@@ -7,6 +7,7 @@ import {
 	getGitBinaryPreviewPath,
 	getGitBinaryPreviewRevision,
 	getLineStats,
+	getOrderedIncludedFileNames,
 	getPreviewableImageMimeType,
 	isLargeGitDiffFile,
 	isBinaryImageDiffPreviewable,
@@ -323,6 +324,20 @@ describe("reconcileIncludedFiles", () => {
 				new Set(["a.ts", "b.ts"]),
 			),
 		).toEqual(new Set(["b.ts"]));
+	});
+});
+
+describe("getOrderedIncludedFileNames", () => {
+	it("returns included files in diff order", () => {
+		const files = [
+			{ name: "a.ts" },
+			{ name: "b.ts" },
+			{ name: "c.ts" },
+		] as FileDiffMetadata[];
+
+		expect(
+			getOrderedIncludedFileNames(files, new Set(["c.ts", "a.ts"])),
+		).toEqual(["a.ts", "c.ts"]);
 	});
 });
 

--- a/src/features/git/utils.ts
+++ b/src/features/git/utils.ts
@@ -140,3 +140,16 @@ export function reconcileIncludedFiles(
 
 	return nextIncluded;
 }
+
+export function getOrderedIncludedFileNames(
+	files: readonly FileDiffMetadata[],
+	includedFileNames: ReadonlySet<string>,
+) {
+	const orderedFileNames: string[] = [];
+	for (const file of files) {
+		if (includedFileNames.has(file.name)) {
+			orderedFileNames.push(file.name);
+		}
+	}
+	return orderedFileNames;
+}


### PR DESCRIPTION
## Summary
- collect ordered included git file names directly instead of using `flatMap` with per-file temporary arrays
- add a focused helper and unit coverage for preserving diff order
- add a Vitest benchmark for direct collection versus the previous flatMap path

## Benchmarks
- `bunx vitest bench src/features/git/utils.bench.ts --run`
  - collect included files directly: `5,043.53 hz`
  - collect included files with flatMap: `3,675.91 hz`
  - direct path is `1.37x` faster

## Verification
- `bunx vitest run src/features/git/utils.test.ts src/features/git/components/GitDiffPane.test.tsx`
- `bunx eslint src/features/git/utils.ts src/features/git/utils.test.ts src/features/git/utils.bench.ts src/features/git/components/GitDiffContent.tsx src/features/git/components/GitDiffPane.test.tsx`
- `bunx tsc --noEmit`