### PR TITLE
perf: use Mutative for terminal store drafts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -39,6 +39,7 @@
         "immer": "^11.1.4",
         "monaco-editor": "^0.55.1",
         "motion": "^12.38.0",
+        "mutative": "^1.3.0",
         "next-themes": "^0.4.6",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
@@ -1445,6 +1446,8 @@
     "motion-utils": ["motion-utils@12.36.0", "", {}, "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "mutative": ["mutative@1.3.0", "", {}, "sha512-8MJj6URmOZAV70dpFe1YnSppRTKC4DsMkXQiBDFayLcDI4ljGokHxmpqaBQuDWa4iAxWaJJ1PS8vAmbntjjKmQ=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "immer": "^11.1.4",
     "monaco-editor": "^0.55.1",
     "motion": "^12.38.0",
+    "mutative": "^1.3.0",
     "next-themes": "^0.4.6",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",

--- a/src/features/terminal/store.ts
+++ b/src/features/terminal/store.ts
@@ -1,10 +1,7 @@
 import { listen } from "@tauri-apps/api/event";
-import { enableMapSet } from "immer";
+import { create as createMutative, type Draft } from "mutative";
 import { create } from "zustand";
-import { immer } from "zustand/middleware/immer";
 import { useShallow } from "zustand/react/shallow";
-
-enableMapSet();
 
 interface TerminalTab {
 	id: string;
@@ -76,14 +73,18 @@ interface TerminalStore {
 	markProfileRead: (profileId: string) => void;
 }
 
-export const useTerminalStore = create<TerminalStore>()(
-	immer((set) => ({
+export const useTerminalStore = create<TerminalStore>()((set) => {
+	const mutate = (recipe: (state: Draft<TerminalStore>) => void) => {
+		set((state) => createMutative(state, recipe));
+	};
+
+	return {
 		profiles: {},
 		notifiedTabs: new Set<string>(),
 		sessionProfileIds: {},
 
 		addTab(profileId, sessionId, title) {
-			set((state) => {
+			mutate((state) => {
 				const existing = state.profiles[profileId] ?? {
 					tabs: [],
 					activeTabId: null,
@@ -104,7 +105,7 @@ export const useTerminalStore = create<TerminalStore>()(
 		},
 
 		closeTab(profileId, tabId) {
-			set((state) => {
+			mutate((state) => {
 				const profile = state.profiles[profileId];
 				if (!profile) return;
 				const wasActiveTab = tabId === profile.activeTabId;
@@ -131,7 +132,7 @@ export const useTerminalStore = create<TerminalStore>()(
 		},
 
 		setActiveTab(profileId, tabId) {
-			set((state) => {
+			mutate((state) => {
 				const profile = state.profiles[profileId];
 				if (!profile) return;
 				profile.activeTabId = tabId;
@@ -140,7 +141,7 @@ export const useTerminalStore = create<TerminalStore>()(
 		},
 
 		removeProfile(profileId) {
-			set((state) => {
+			mutate((state) => {
 				const profile = state.profiles[profileId];
 				profile?.tabs.forEach((tab) => state.notifiedTabs.delete(tab.id));
 				delete state.profiles[profileId];
@@ -151,7 +152,7 @@ export const useTerminalStore = create<TerminalStore>()(
 		},
 
 		updateTabTitle(profileId, tabId, title) {
-			set((state) => {
+			mutate((state) => {
 				const profile = state.profiles[profileId];
 				if (!profile) return;
 				const tab = profile.tabs.find((t) => t.id === tabId);
@@ -160,7 +161,7 @@ export const useTerminalStore = create<TerminalStore>()(
 		},
 
 		removeStaleProfiles(validIds) {
-			set((state) => {
+			mutate((state) => {
 				for (const id of Object.keys(state.profiles)) {
 					if (!validIds.has(id)) {
 						state.profiles[id].tabs.forEach((tab) =>
@@ -179,7 +180,7 @@ export const useTerminalStore = create<TerminalStore>()(
 		},
 
 		markNotified(sessionId) {
-			set((state) => {
+			mutate((state) => {
 				const profileId = state.sessionProfileIds[sessionId] ?? null;
 				if (
 					profileId &&
@@ -195,20 +196,20 @@ export const useTerminalStore = create<TerminalStore>()(
 		},
 
 		markRead(sessionId) {
-			set((state) => {
+			mutate((state) => {
 				state.notifiedTabs.delete(sessionId);
 			});
 		},
 
 		markProfileRead(profileId) {
-			set((state) => {
+			mutate((state) => {
 				const profile = state.profiles[profileId];
 				if (!profile) return;
 				profile.tabs.forEach((tab) => state.notifiedTabs.delete(tab.id));
 			});
 		},
-	})),
-);
+	};
+});
 
 /** IDs of profiles that currently have terminal tabs open. */
 export function useTerminalProfileIds() {


### PR DESCRIPTION
## Summary
- replace the terminal Zustand store's Immer middleware with Mutative
- keep the existing mutable draft update shape instead of rewriting reducers by hand
- remove the terminal store's local Immer MapSet setup, since Mutative handles Set drafts directly

## Validation
- bunx vitest run src/features/terminal/store.test.ts
- bunx tsc --noEmit
- bunx eslint src/features/terminal/store.ts