### PR TITLE
perf: fill search line set directly

### DIFF
--- a/src/shared/hooks/useSearch.test.ts
+++ b/src/shared/hooks/useSearch.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { findSearchMatches, isSearchShortcut } from "./useSearch";
+import {
+	findSearchMatches,
+	getMatchedLineNumbers,
+	isSearchShortcut,
+} from "./useSearch";
 
 describe("findSearchMatches", () => {
 	it("finds case-insensitive matches across lines", () => {
@@ -11,6 +15,18 @@ describe("findSearchMatches", () => {
 
 	it("returns no matches for an empty query", () => {
 		expect(findSearchMatches("content", "")).toEqual([]);
+	});
+});
+
+describe("getMatchedLineNumbers", () => {
+	it("deduplicates matched line numbers", () => {
+		expect(
+			getMatchedLineNumbers([
+				{ columnIndex: 0, lineNumber: 1 },
+				{ columnIndex: 4, lineNumber: 1 },
+				{ columnIndex: 0, lineNumber: 2 },
+			]),
+		).toEqual(new Set([1, 2]));
 	});
 });
 

--- a/src/shared/hooks/useSearch.ts
+++ b/src/shared/hooks/useSearch.ts
@@ -57,6 +57,14 @@ export function findSearchMatches(content: string, query: string): SearchMatch[]
 	return matches;
 }
 
+export function getMatchedLineNumbers(matches: readonly SearchMatch[]) {
+	const lineNumbers = new Set<number>();
+	for (const match of matches) {
+		lineNumbers.add(match.lineNumber);
+	}
+	return lineNumbers;
+}
+
 export function useSearch(content: string) {
 	const [isSearchOpen, setIsSearchOpen] = useState(false);
 	const [searchQuery, setSearchQuery] = useState("");
@@ -69,7 +77,7 @@ export function useSearch(content: string) {
 		[content, deferredSearchQuery],
 	);
 	const matchedLineNumbers = useMemo(
-		() => new Set(matches.map((match) => match.lineNumber)),
+		() => getMatchedLineNumbers(matches),
 		[matches],
 	);
 	const effectiveCurrentMatchIndex =


### PR DESCRIPTION
Replaces #184 after its stacked base branch was deleted by merging #175.\n\n- Fills matched search line numbers directly instead of allocating an intermediate map array.\n- Keeps the focused matched-line deduplication test.\n- Benchmark file was removed from the production PR.