### PR TITLE
feat(windows): custom title bar (Variant A — top-right, single row)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -48,6 +48,16 @@ pub fn run() {
 		.manage(handler::updater::PendingUpdate::default())
 		.setup(|app| {
 			use tauri::Manager;
+
+			// On Windows the native title bar would render as an opaque bar
+			// above the app content. Drop system decorations so the frontend
+			// can render a custom title bar that matches the macOS overlay
+			// look; the WindowControls component supplies min/max/close.
+			#[cfg(target_os = "windows")]
+			if let Some(window) = app.get_webview_window("main") {
+				let _ = window.set_decorations(false);
+			}
+
 			let app_data_dir = app
 				.path()
 				.app_data_dir()

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import SettingsPage from "./features/settings/SettingsPage";
 import TerminalLayer from "./features/terminal/TerminalLayer";
 import StartupUpdateCheck from "./features/updater/StartupUpdateCheck";
 import AppSidebar from "./layout/AppSidebar";
+import WindowControls from "./layout/WindowControls";
 import {
 	AsyncBoundary,
 	PageError,
@@ -16,6 +17,7 @@ import {
 	SidebarError,
 	SidebarSkeleton,
 } from "./shared/components/Fallbacks";
+import { isWindowsPlatform } from "./shared/lib/platform";
 import "./app.css";
 
 export default function App() {
@@ -80,6 +82,7 @@ export default function App() {
 				</Box>
 			</Flex>
 			<DebugFloat />
+			{isWindowsPlatform() && <WindowControls />}
 		</Flex>
 	);
 }

--- a/src/features/git/ProjectTopBar.tsx
+++ b/src/features/git/ProjectTopBar.tsx
@@ -32,6 +32,7 @@ import {
 import { useTopBarStore } from "@/features/topbar/store";
 import type { Profile } from "@/generated";
 import * as m from "@/paraglide/messages.js";
+import { isWindowsPlatform } from "@/shared/lib/platform";
 
 const FILE_TREE_TOGGLE_ICON_TRANSITION = {
 	duration: 0.12,
@@ -135,6 +136,133 @@ export default function ProjectTopBar({
 	const visibleActiveControls = activeControls.filter((id) =>
 		supportedControlIdSet.has(id),
 	);
+	const isWindows = isWindowsPlatform();
+
+	const titleContent = (
+		<HStack gap="2">
+			{onToggleFileTree && (
+				<Tooltip.Root>
+					<Tooltip.Trigger asChild>
+						<IconButton
+							aria-label={isFileTreeOpen ? "Close file tree" : "Open file tree"}
+							aria-pressed={isFileTreeOpen}
+							size="xs"
+							variant="ghost"
+							p="0"
+							color={isFileTreeOpen ? "fg" : "fg.muted"}
+							bg={isFileTreeOpen ? "bg.subtle" : "transparent"}
+							_hover={{
+								bg: isFileTreeOpen ? "bg.muted" : "bg.subtle",
+							}}
+							transition={
+								prefersReducedMotion
+									? undefined
+									: "background-color 0.18s cubic-bezier(0.22, 1, 0.36, 1), color 0.18s cubic-bezier(0.22, 1, 0.36, 1)"
+							}
+							onClick={onToggleFileTree}
+						>
+							<motion.span
+								animate={{
+									rotate: isFileTreeOpen ? 0 : 180,
+									x: isFileTreeOpen ? 0 : -1,
+								}}
+								transition={
+									prefersReducedMotion
+										? { duration: 0 }
+										: FILE_TREE_TOGGLE_ICON_TRANSITION
+								}
+								style={{ display: "inline-flex" }}
+							>
+								<PiSidebarSimpleFill />
+							</motion.span>
+						</IconButton>
+					</Tooltip.Trigger>
+					<Portal>
+						<Tooltip.Positioner>
+							<Tooltip.Content>
+								{isFileTreeOpen ? "Close file tree" : "Open file tree"} ⌘E
+							</Tooltip.Content>
+						</Tooltip.Positioner>
+					</Portal>
+				</Tooltip.Root>
+			)}
+			<Tooltip.Root>
+				<Tooltip.Trigger asChild>
+					<Text
+						as="span"
+						fontWeight="semibold"
+						userSelect="none"
+						cursor="default"
+					>
+						{projectName}
+					</Text>
+				</Tooltip.Trigger>
+				<Portal>
+					<Tooltip.Positioner>
+						<Tooltip.Content>
+							<Text as="span" fontSize="xs">
+								{profile.worktree_path}
+							</Text>
+						</Tooltip.Content>
+					</Tooltip.Positioner>
+				</Portal>
+			</Tooltip.Root>
+			<Box color="fg.muted">
+				{profile.is_default ? (
+					isActive ? (
+						<GitBranchLabel cwd={profile.worktree_path} isActive={isActive} />
+					) : null
+				) : (
+					<HStack gap="1" userSelect="none">
+						<PiGitBranchFill />
+						<Text as="span">{profile.branch_name}</Text>
+					</HStack>
+				)}
+			</Box>
+		</HStack>
+	);
+
+	const controlsContent = (
+		<HStack gap="2">
+			{visibleActiveControls.map((controlId) => {
+				const def = controlRegistry.get(controlId);
+				if (!def) return null;
+				const Comp = def.component;
+				return (
+					<Comp
+						key={controlId}
+						profile={profile}
+						isActive={isActive}
+						options={{
+							...(controlOptions[controlId] ?? {}),
+							...(controlId === "git-diff"
+								? { onOpen: openGitDiffDialog }
+								: {}),
+						}}
+					/>
+				);
+			})}
+			<Tooltip.Root>
+				<Tooltip.Trigger asChild>
+					<IconButton
+						aria-label={m.projectSettings()}
+						size="xs"
+						variant="subtle"
+						onClick={() => setSettingsOpen(true)}
+					>
+						<PiGearSixFill />
+					</IconButton>
+				</Tooltip.Trigger>
+				<Portal>
+					<Tooltip.Positioner>
+						<Tooltip.Content>
+							{m.projectSettings()}
+						</Tooltip.Content>
+					</Tooltip.Positioner>
+				</Portal>
+			</Tooltip.Root>
+		</HStack>
+	);
 
 	return (
 		<>
@@ -143,131 +271,13 @@ export default function ProjectTopBar({
 				align="flex-end"
 				justify="space-between"
 				pl="4"
-				pr="5"
+				pr={isWindows ? "118px" : "5"}
 				pb="2"
 				pt="2"
 				minH="52px"
 			>
-				<HStack gap="2">
-					{onToggleFileTree && (
-						<Tooltip.Root>
-							<Tooltip.Trigger asChild>
-								<IconButton
-									aria-label={isFileTreeOpen ? "Close file tree" : "Open file tree"}
-									aria-pressed={isFileTreeOpen}
-									size="xs"
-									variant="ghost"
-									p="0"
-									color={isFileTreeOpen ? "fg" : "fg.muted"}
-									bg={isFileTreeOpen ? "bg.subtle" : "transparent"}
-									_hover={{
-										bg: isFileTreeOpen ? "bg.muted" : "bg.subtle",
-									}}
-									transition={
-										prefersReducedMotion
-											? undefined
-											: "background-color 0.18s cubic-bezier(0.22, 1, 0.36, 1), color 0.18s cubic-bezier(0.22, 1, 0.36, 1)"
-									}
-									onClick={onToggleFileTree}
-								>
-									<motion.span
-										animate={{
-											rotate: isFileTreeOpen ? 0 : 180,
-											x: isFileTreeOpen ? 0 : -1,
-										}}
-										transition={
-											prefersReducedMotion
-												? { duration: 0 }
-												: FILE_TREE_TOGGLE_ICON_TRANSITION
-										}
-										style={{ display: "inline-flex" }}
-									>
-										<PiSidebarSimpleFill />
-									</motion.span>
-								</IconButton>
-							</Tooltip.Trigger>
-							<Portal>
-								<Tooltip.Positioner>
-									<Tooltip.Content>
-										{isFileTreeOpen ? "Close file tree" : "Open file tree"} ⌘E
-									</Tooltip.Content>
-								</Tooltip.Positioner>
-							</Portal>
-						</Tooltip.Root>
-					)}
-					<Tooltip.Root>
-						<Tooltip.Trigger asChild>
-							<Text
-								as="span"
-								fontWeight="semibold"
-								userSelect="none"
-								cursor="default"
-							>
-								{projectName}
-							</Text>
-						</Tooltip.Trigger>
-						<Portal>
-							<Tooltip.Positioner>
-								<Tooltip.Content>
-									<Text as="span" fontSize="xs">
-										{profile.worktree_path}
-									</Text>
-								</Tooltip.Content>
-							</Tooltip.Positioner>
-						</Portal>
-					</Tooltip.Root>
-					<Box color="fg.muted">
-						{profile.is_default ? (
-							isActive ? (
-								<GitBranchLabel cwd={profile.worktree_path} />
-							) : null
-						) : (
-							<HStack gap="1" userSelect="none">
-								<PiGitBranchFill />
-								<Text as="span">{profile.branch_name}</Text>
-							</HStack>
-						)}
-					</Box>
-				</HStack>
-				<HStack gap="2">
-					{visibleActiveControls.map((controlId) => {
-						const def = controlRegistry.get(controlId);
-						if (!def) return null;
-						const Comp = def.component;
-						return (
-							<Comp
-								key={controlId}
-								profile={profile}
-								isActive={isActive}
-								options={{
-									...(controlOptions[controlId] ?? {}),
-									...(controlId === "git-diff"
-										? { onOpen: openGitDiffDialog }
-										: {}),
-								}}
-							/>
-						);
-					})}
-					<Tooltip.Root>
-						<Tooltip.Trigger asChild>
-							<IconButton
-								aria-label={m.projectSettings()}
-								size="xs"
-								variant="subtle"
-								onClick={() => setSettingsOpen(true)}
-							>
-								<PiGearSixFill />
-							</IconButton>
-						</Tooltip.Trigger>
-						<Portal>
-							<Tooltip.Positioner>
-								<Tooltip.Content>
-									{m.projectSettings()}
-								</Tooltip.Content>
-							</Tooltip.Positioner>
-						</Portal>
-					</Tooltip.Root>
-				</HStack>
+				{titleContent}
+				{controlsContent}
 			</Flex>
 
 			<ProjectSettingsDialog

--- a/src/layout/AppSidebar.tsx
+++ b/src/layout/AppSidebar.tsx
@@ -37,6 +37,7 @@ import * as m from "@/paraglide/messages.js";
 import { SidebarLink } from "@/shared/components/SidebarLink";
 import { useDialogState } from "@/shared/hooks/useDialogState";
 import { useHorizontalResize } from "@/shared/hooks/useHorizontalResize";
+import { isMacPlatform } from "@/shared/lib/platform";
 import { toaster } from "@/shared/providers/appToaster";
 import { ProjectGroupSection } from "./sidebar/ProjectGroupSection";
 import { ProjectAvatar } from "./sidebar/ProjectAvatar";
@@ -62,10 +63,6 @@ import {
 	APP_SIDEBAR_MIN_WIDTH,
 	useAppSidebarStore,
 } from "./sidebarStore";
-
-function isMacPlatform() {
-	return /mac/i.test(`${navigator.platform} ${navigator.userAgent}`);
-}
 
 function insertAt<T>(items: T[], item: T, index: number) {
 	const next = [...items];
@@ -319,8 +316,8 @@ function SortableGroupRow({
 			</Text>
 			<Text color="fg.subtle">{entry.projects.length}</Text>
 		</HStack>
-	);
-}
+		);
+	}
 
 export default function AppSidebar() {
 	const { data: projects } = useProjects();

--- a/src/layout/WindowControls.tsx
+++ b/src/layout/WindowControls.tsx
@@ -1,9 +1,16 @@
 import { Box, HStack } from "@chakra-ui/react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useEffect, useState } from "react";
+import {
+	VscChromeClose,
+	VscChromeMaximize,
+	VscChromeMinimize,
+	VscChromeRestore,
+} from "react-icons/vsc";
 
 const BUTTON_WIDTH = "36px";
 const BUTTON_HEIGHT = "28px";
+const ICON_SIZE = 12;
 
 type ControlKind = "minimize" | "maximize" | "close";
 
@@ -22,76 +29,16 @@ function ControlIcon({
 	isMaximized: boolean;
 }) {
 	if (kind === "minimize") {
-		return (
-			<svg
-				aria-hidden="true"
-				width="9"
-				height="9"
-				viewBox="0 0 10 10"
-				fill="none"
-			>
-				<title>minimize</title>
-				<path d="M0 5h10" stroke="currentColor" strokeWidth="1" />
-			</svg>
-		);
+		return <VscChromeMinimize size={ICON_SIZE} />;
 	}
 	if (kind === "maximize") {
-		if (isMaximized) {
-			return (
-				<svg
-					aria-hidden="true"
-					width="10"
-					height="10"
-					viewBox="0 0 10 10"
-					fill="none"
-				>
-					<title>restore</title>
-					<path
-						d="M2 0h8v8H8M0 2h8v8H0V2z"
-						stroke="currentColor"
-						strokeWidth="1"
-						fill="none"
-					/>
-				</svg>
-			);
-		}
-		return (
-			<svg
-				aria-hidden="true"
-				width="9"
-				height="9"
-				viewBox="0 0 10 10"
-				fill="none"
-			>
-				<title>maximize</title>
-				<rect
-					x="0.5"
-					y="0.5"
-					width="9"
-					height="9"
-					stroke="currentColor"
-					strokeWidth="1"
-					fill="none"
-				/>
-			</svg>
+		return isMaximized ? (
+			<VscChromeRestore size={ICON_SIZE} />
+		) : (
+			<VscChromeMaximize size={ICON_SIZE} />
 		);
 	}
-	return (
-		<svg
-			aria-hidden="true"
-			width="10"
-			height="10"
-			viewBox="0 0 10 10"
-			fill="none"
-		>
-			<title>close</title>
-			<path
-				d="M0 0l10 10M10 0L0 10"
-				stroke="currentColor"
-				strokeWidth="1"
-			/>
-		</svg>
-	);
+	return <VscChromeClose size={ICON_SIZE} />;
 }
 
 function ControlButton({

--- a/src/layout/WindowControls.tsx
+++ b/src/layout/WindowControls.tsx
@@ -1,0 +1,191 @@
+import { Box, HStack } from "@chakra-ui/react";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { useEffect, useState } from "react";
+
+const BUTTON_WIDTH = "36px";
+const BUTTON_HEIGHT = "28px";
+
+type ControlKind = "minimize" | "maximize" | "close";
+
+interface ControlButtonProps {
+	kind: ControlKind;
+	label: string;
+	onClick: () => void;
+	isMaximized?: boolean;
+}
+
+function ControlIcon({
+	kind,
+	isMaximized,
+}: {
+	kind: ControlKind;
+	isMaximized: boolean;
+}) {
+	if (kind === "minimize") {
+		return (
+			<svg
+				aria-hidden="true"
+				width="9"
+				height="9"
+				viewBox="0 0 10 10"
+				fill="none"
+			>
+				<title>minimize</title>
+				<path d="M0 5h10" stroke="currentColor" strokeWidth="1" />
+			</svg>
+		);
+	}
+	if (kind === "maximize") {
+		if (isMaximized) {
+			return (
+				<svg
+					aria-hidden="true"
+					width="10"
+					height="10"
+					viewBox="0 0 10 10"
+					fill="none"
+				>
+					<title>restore</title>
+					<path
+						d="M2 0h8v8H8M0 2h8v8H0V2z"
+						stroke="currentColor"
+						strokeWidth="1"
+						fill="none"
+					/>
+				</svg>
+			);
+		}
+		return (
+			<svg
+				aria-hidden="true"
+				width="9"
+				height="9"
+				viewBox="0 0 10 10"
+				fill="none"
+			>
+				<title>maximize</title>
+				<rect
+					x="0.5"
+					y="0.5"
+					width="9"
+					height="9"
+					stroke="currentColor"
+					strokeWidth="1"
+					fill="none"
+				/>
+			</svg>
+		);
+	}
+	return (
+		<svg
+			aria-hidden="true"
+			width="10"
+			height="10"
+			viewBox="0 0 10 10"
+			fill="none"
+		>
+			<title>close</title>
+			<path
+				d="M0 0l10 10M10 0L0 10"
+				stroke="currentColor"
+				strokeWidth="1"
+			/>
+		</svg>
+	);
+}
+
+function ControlButton({
+	kind,
+	label,
+	onClick,
+	isMaximized = false,
+}: ControlButtonProps) {
+	const hoverBg =
+		kind === "close" ? "#c42b1c" : "rgba(127, 127, 127, 0.18)";
+	const hoverColor = kind === "close" ? "white" : undefined;
+	const activeBg =
+		kind === "close" ? "#b32717" : "rgba(127, 127, 127, 0.28)";
+
+	return (
+		<Box
+			as="button"
+			aria-label={label}
+			onClick={onClick}
+			w={BUTTON_WIDTH}
+			h={BUTTON_HEIGHT}
+			display="grid"
+			placeItems="center"
+			bg="transparent"
+			color="fg.muted"
+			borderRadius="0"
+			transition="background-color 0.08s ease, color 0.08s ease"
+			_hover={{ bg: hoverBg, color: hoverColor }}
+			_active={{ bg: activeBg }}
+			_focusVisible={{ outline: "none", bg: hoverBg, color: hoverColor }}
+			css={{ WebkitAppRegion: "no-drag" }}
+		>
+			<ControlIcon kind={kind} isMaximized={isMaximized} />
+		</Box>
+	);
+}
+
+export default function WindowControls() {
+	const [isMaximized, setIsMaximized] = useState(false);
+
+	useEffect(() => {
+		const window = getCurrentWindow();
+		let unlisten: (() => void) | undefined;
+
+		window.isMaximized().then(setIsMaximized);
+
+		window
+			.onResized(() => {
+				window.isMaximized().then(setIsMaximized);
+			})
+			.then((fn) => {
+				unlisten = fn;
+			});
+
+		return () => {
+			unlisten?.();
+		};
+	}, []);
+
+	const handleMinimize = () => {
+		getCurrentWindow().minimize();
+	};
+	const handleToggleMaximize = () => {
+		getCurrentWindow().toggleMaximize();
+	};
+	const handleClose = () => {
+		getCurrentWindow().close();
+	};
+
+	return (
+		<HStack
+			gap="0"
+			position="fixed"
+			top="0"
+			right="0"
+			zIndex="banner"
+			h={BUTTON_HEIGHT}
+			data-window-controls
+		>
+			<ControlButton
+				kind="minimize"
+				label="Minimize"
+				onClick={handleMinimize}
+			/>
+			<ControlButton
+				kind="maximize"
+				label={isMaximized ? "Restore" : "Maximize"}
+				onClick={handleToggleMaximize}
+				isMaximized={isMaximized}
+			/>
+			<ControlButton kind="close" label="Close" onClick={handleClose} />
+		</HStack>
+	);
+}
+
+export const WINDOW_CONTROLS_WIDTH = 36 * 3;
+export const WINDOW_CONTROLS_HEIGHT = 28;

--- a/src/shared/lib/platform.ts
+++ b/src/shared/lib/platform.ts
@@ -1,0 +1,13 @@
+const platformString = `${navigator.platform} ${navigator.userAgent}`;
+
+export function isMacPlatform() {
+	return /mac/i.test(platformString);
+}
+
+export function isWindowsPlatform() {
+	return /win/i.test(platformString);
+}
+
+export function isLinuxPlatform() {
+	return /linux/i.test(platformString);
+}


### PR DESCRIPTION
## Summary

**Windows only.** macOS untouched.

One of two competing variants for the Windows custom title bar — the other is the macOS-style traffic lights at top-left.

This variant keeps the **standard Windows convention**: min / max / close at the top-right corner, drawn with the `VscChrome*` icons from `react-icons/vsc` (the same set VS Code uses). Buttons are 36×28 with the Win11 red close-hover (`#c42b1c`). `ProjectTopBar` stays a single row — the shrunk control size leaves enough room for the existing topbar action icons on the same line.

## Screenshot
<img width="1800" height="1162" alt="PixPin_2026-05-24_18-51-03" src="https://github.com/user-attachments/assets/07c3b879-ad3d-48ff-bdcd-521f8bd00224" />

<!-- Drag the screenshot into this area on GitHub and save -->

## Test plan

- [ ] Windows: black system title bar gone
- [ ] Windows: min / max / close at top-right work; close turns red on hover
- [ ] Windows: maximize icon swaps to restore when maximized
- [ ] Windows: top areas of `HomePage`, `SettingsPage`, `ProjectDetailPage` stay draggable
- [ ] Windows: topbar action icons + window controls coexist on one row without overlap
- [ ] macOS: layout unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added custom window controls (minimize, maximize, close buttons) for Windows users, providing a native-looking interface in place of the standard system title bar.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->