### PR TITLE
fix(file-viewer): render images instead of erroring on binary read

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -709,6 +709,7 @@ name = "code"
 version = "0.0.0"
 dependencies = [
  "axum",
+ "base64 0.22.1",
  "core-text",
  "diesel",
  "diesel_migrations",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -45,6 +45,7 @@ axum = "0.8"
 tokio = { version = "1", features = [ "net" ] }
 fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs" }
 tauri-plugin-process = "2"
+base64 = "0.22"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-text = "22"

--- a/src-tauri/src/handler/filesystem.rs
+++ b/src-tauri/src/handler/filesystem.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+use base64::Engine;
 use tauri::State;
 
 use infra::db::DbPool;
@@ -7,6 +8,24 @@ use model::error::AppError;
 use model::filesystem::{
 	FileSearchResult, FileTreeGitStatusEntry, ResolvedFilePath,
 };
+
+const MAX_IMAGE_BYTES: u64 = 10_000_000;
+
+fn image_mime_from_extension(path: &Path) -> Option<&'static str> {
+	let extension = path.extension()?.to_str()?.to_ascii_lowercase();
+	match extension.as_str() {
+		"apng" => Some("image/apng"),
+		"avif" => Some("image/avif"),
+		"bmp" => Some("image/bmp"),
+		"cur" | "ico" => Some("image/x-icon"),
+		"gif" => Some("image/gif"),
+		"jfif" | "jpe" | "jpeg" | "jpg" | "pjp" | "pjpeg" => Some("image/jpeg"),
+		"png" => Some("image/png"),
+		"svg" => Some("image/svg+xml"),
+		"webp" => Some("image/webp"),
+		_ => None,
+	}
+}
 
 fn profile_worktree_path(
 	db: &DbPool,
@@ -115,6 +134,42 @@ pub async fn read_file_content(path: String) -> Result<String, AppError> {
 		String::from_utf8(bytes).map_err(|_| {
 			AppError::IoError(std::io::Error::other("Invalid UTF-8"))
 		})
+	})
+	.await
+}
+
+#[tauri::command]
+pub async fn read_image_file_as_data_url(
+	path: String,
+) -> Result<String, AppError> {
+	super::run_blocking(move || {
+		let file_path = Path::new(&path);
+		if !file_path.exists() {
+			return Err(AppError::NotFound(format!("File: {path}")));
+		}
+		if file_path.is_dir() {
+			return Err(AppError::IoError(std::io::Error::other(
+				"Path is a directory",
+			)));
+		}
+
+		let mime = image_mime_from_extension(file_path).ok_or_else(|| {
+			AppError::IoError(std::io::Error::other(
+				"Not a previewable image",
+			))
+		})?;
+
+		let metadata = std::fs::metadata(&path)?;
+		if metadata.len() > MAX_IMAGE_BYTES {
+			return Err(AppError::IoError(std::io::Error::other(
+				"Image too large (> 10MB)",
+			)));
+		}
+
+		let bytes = std::fs::read(&path)?;
+		let encoded =
+			base64::engine::general_purpose::STANDARD.encode(&bytes);
+		Ok(format!("data:{mime};base64,{encoded}"))
 	})
 	.await
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -121,6 +121,7 @@ pub fn run() {
 			handler::filesystem::move_file_tree_paths,
 			handler::filesystem::delete_file_tree_paths,
 			handler::filesystem::read_file_content,
+			handler::filesystem::read_image_file_as_data_url,
 			handler::filesystem::write_file_content,
 			handler::filesystem::search_file,
 			handler::filesystem::get_file_tree_git_status,

--- a/src/features/projects/FileViewerDialog.tsx
+++ b/src/features/projects/FileViewerDialog.tsx
@@ -10,9 +10,10 @@ import {
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { useTerminalSettingsStore } from "@/features/settings/stores/terminalSettingsStore";
 import { useTerminalThemeId } from "@/features/terminal/hooks";
+import { getPreviewableImageMimeType } from "@/features/git/utils";
 import { detectLanguage } from "@/shared/lib/languageDetection";
 import { getPrismTheme } from "./prismThemes";
-import { useFileContent } from "./hooks";
+import { useFileContent, useImageFileDataUrl } from "./hooks";
 
 interface FileViewerDialogProps {
 	filePath: string | null;
@@ -28,17 +29,22 @@ export default function FileViewerDialog({
 	const fontSize = useTerminalSettingsStore((s) => s.fontSize);
 	const prismStyle = getPrismTheme(themeId);
 
+	const filename = filePath?.split("/").pop() ?? "";
+	const isImage = getPreviewableImageMimeType(filename) != null;
+
 	const {
 		data: content,
 		error,
 		isError,
 		isLoading,
-	} = useFileContent(
-		filePath ?? "",
-		!!filePath,
-	);
+	} = useFileContent(filePath ?? "", !!filePath && !isImage);
+	const {
+		data: imageDataUrl,
+		error: imageError,
+		isError: isImageError,
+		isLoading: isImageLoading,
+	} = useImageFileDataUrl(filePath ?? "", !!filePath && isImage);
 
-	const filename = filePath?.split("/").pop() ?? "";
 	const language = detectLanguage(filename);
 
 	return (
@@ -57,44 +63,83 @@ export default function FileViewerDialog({
 							</Dialog.Title>
 						</Dialog.Header>
 						<Dialog.Body p="0" overflow="auto" flex="1">
-							{isLoading && (
-								<Flex align="center" justify="center" h="32">
-									<Spinner size="sm" />
-								</Flex>
-							)}
-							{isError && (
-								<Flex align="center" justify="center" h="32" px="6">
-									<Text color="fg.muted" fontSize="sm" textAlign="center">
-										{error instanceof Error ? error.message : String(error)}
-									</Text>
-								</Flex>
-							)}
-							{content != null && (
-								<Box
-									css={{
-										"& pre": {
-											margin: "0 !important",
-											borderRadius: "0 !important",
-											fontSize: `${fontSize}px !important`,
-											fontFamily: `"${fontFamily}", monospace !important`,
-										},
-									}}
-								>
-									<SyntaxHighlighter
-										language={language}
-										style={prismStyle}
-										showLineNumbers
-										wrapLongLines={false}
-										customStyle={{
-											margin: 0,
-											borderRadius: 0,
-											fontSize: `${fontSize}px`,
-											fontFamily: `"${fontFamily}", monospace`,
-										}}
-									>
-										{content}
-									</SyntaxHighlighter>
-								</Box>
+							{isImage ? (
+								<>
+									{isImageLoading && (
+										<Flex align="center" justify="center" h="32">
+											<Spinner size="sm" />
+										</Flex>
+									)}
+									{isImageError && (
+										<Flex align="center" justify="center" h="32" px="6">
+											<Text color="fg.muted" fontSize="sm" textAlign="center">
+												{imageError instanceof Error
+													? imageError.message
+													: String(imageError)}
+											</Text>
+										</Flex>
+									)}
+									{imageDataUrl != null && (
+										<Flex
+											align="center"
+											justify="center"
+											h="full"
+											p="4"
+										>
+											<img
+												src={imageDataUrl}
+												alt={filename}
+												style={{
+													maxWidth: "100%",
+													maxHeight: "100%",
+													objectFit: "contain",
+												}}
+											/>
+										</Flex>
+									)}
+								</>
+							) : (
+								<>
+									{isLoading && (
+										<Flex align="center" justify="center" h="32">
+											<Spinner size="sm" />
+										</Flex>
+									)}
+									{isError && (
+										<Flex align="center" justify="center" h="32" px="6">
+											<Text color="fg.muted" fontSize="sm" textAlign="center">
+												{error instanceof Error ? error.message : String(error)}
+											</Text>
+										</Flex>
+									)}
+									{content != null && (
+										<Box
+											css={{
+												"& pre": {
+													margin: "0 !important",
+													borderRadius: "0 !important",
+													fontSize: `${fontSize}px !important`,
+													fontFamily: `"${fontFamily}", monospace !important`,
+												},
+											}}
+										>
+											<SyntaxHighlighter
+												language={language}
+												style={prismStyle}
+												showLineNumbers
+												wrapLongLines={false}
+												customStyle={{
+													margin: 0,
+													borderRadius: 0,
+													fontSize: `${fontSize}px`,
+													fontFamily: `"${fontFamily}", monospace`,
+												}}
+											>
+												{content}
+											</SyntaxHighlighter>
+										</Box>
+									)}
+								</>
 							)}
 						</Dialog.Body>
 						<Dialog.CloseTrigger asChild>

--- a/src/features/projects/FileViewerPane.test.tsx
+++ b/src/features/projects/FileViewerPane.test.tsx
@@ -12,7 +12,11 @@ import FileViewerPane from "./FileViewerPane";
 import {
 	useFileViewerDirtyStore,
 } from "./fileViewerTabsStore";
-import { useFileContent, useSaveFileContent } from "./hooks";
+import {
+	useFileContent,
+	useImageFileDataUrl,
+	useSaveFileContent,
+} from "./hooks";
 
 const { saveMutateMock } = vi.hoisted(() => ({
 	saveMutateMock: vi.fn(),
@@ -47,6 +51,7 @@ vi.mock("@monaco-editor/react", () => ({
 
 vi.mock("./hooks", () => ({
 	useFileContent: vi.fn(),
+	useImageFileDataUrl: vi.fn(),
 	useSaveFileContent: vi.fn(),
 }));
 
@@ -96,6 +101,12 @@ describe("fileViewerPane", () => {
 			.mockReturnValue(createVisibleRectList());
 		vi.mocked(useFileContent).mockReturnValue({
 			data: fileContent,
+			isLoading: false,
+			isError: false,
+			error: null,
+		} as FileContentResult);
+		vi.mocked(useImageFileDataUrl).mockReturnValue({
+			data: undefined,
 			isLoading: false,
 			isError: false,
 			error: null,

--- a/src/features/projects/FileViewerPane.tsx
+++ b/src/features/projects/FileViewerPane.tsx
@@ -16,8 +16,9 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useFileViewerDirtyStore } from "@/features/projects/fileViewerTabsStore";
 import { useTerminalSettingsStore } from "@/features/settings/stores/terminalSettingsStore";
 import { useTerminalThemeId } from "@/features/terminal/hooks";
+import { getPreviewableImageMimeType } from "@/features/git/utils";
 import { detectMonacoLanguage } from "@/shared/lib/languageDetection";
-import { useFileContent, useSaveFileContent } from "./hooks";
+import { useFileContent, useImageFileDataUrl, useSaveFileContent } from "./hooks";
 
 interface FileViewerPaneProps {
 	filePath: string;
@@ -43,18 +44,26 @@ export default function FileViewerPane({
 	const saveHandlerRef = useRef<() => void>(() => {});
 	const setFileDirty = useFileViewerDirtyStore((state) => state.setFileDirty);
 
+	const filename = filePath.split("/").pop() ?? "";
+	const isImage = getPreviewableImageMimeType(filename) != null;
+
 	const {
 		data: content,
 		error,
 		isError,
 		isLoading,
-	} = useFileContent(filePath, true);
+	} = useFileContent(filePath, !isImage);
+	const {
+		data: imageDataUrl,
+		error: imageError,
+		isError: isImageError,
+		isLoading: isImageLoading,
+	} = useImageFileDataUrl(filePath, isImage);
 	const {
 		isPending: isSaving,
 		mutate: saveFileContent,
 	} = useSaveFileContent(profileId);
 
-	const filename = filePath.split("/").pop() ?? "";
 	const language = detectMonacoLanguage(filename);
 	const monacoTheme = getMonacoTheme(themeId);
 	const draftValue = draftsByPath[filePath];
@@ -168,6 +177,52 @@ export default function FileViewerPane({
 			() => saveHandlerRef.current(),
 		);
 	}, []);
+
+	if (isImage) {
+		if (isImageLoading && !imageDataUrl) {
+			return (
+				<Flex align="center" justify="center" h="32">
+					<Spinner size="sm" />
+				</Flex>
+			);
+		}
+
+		if (isImageError && !imageDataUrl) {
+			return (
+				<Flex align="center" justify="center" h="32" px="6">
+					<Text color="fg.muted" fontSize="sm" textAlign="center">
+						{imageError instanceof Error
+							? imageError.message
+							: String(imageError)}
+					</Text>
+				</Flex>
+			);
+		}
+
+		if (!imageDataUrl) return null;
+
+		return (
+			<Flex
+				ref={paneRef}
+				align="center"
+				justify="center"
+				h="full"
+				minH="0"
+				p="4"
+				overflow="auto"
+			>
+				<img
+					src={imageDataUrl}
+					alt={filename}
+					style={{
+						maxWidth: "100%",
+						maxHeight: "100%",
+						objectFit: "contain",
+					}}
+				/>
+			</Flex>
+		);
+	}
 
 	if (isLoading && !hasLoadedFile) {
 		return (

--- a/src/features/projects/hooks.ts
+++ b/src/features/projects/hooks.ts
@@ -30,6 +30,7 @@ import {
 	listProjects,
 	moveFileTreePaths,
 	readFileContent,
+	readImageFileAsDataUrl,
 	renameFileTreePath,
 	saveProjectConfig,
 	searchFile,
@@ -416,6 +417,15 @@ export function useFileContent(path: string, enabled = true) {
 	return useQuery({
 		queryKey: queryKeys.fs.file(path),
 		queryFn: () => readFileContent({ path }),
+		enabled: !!path && enabled,
+		staleTime: 10000,
+	});
+}
+
+export function useImageFileDataUrl(path: string, enabled = true) {
+	return useQuery({
+		queryKey: queryKeys.fs.image(path),
+		queryFn: () => readImageFileAsDataUrl({ path }),
 		enabled: !!path && enabled,
 		staleTime: 10000,
 	});

--- a/src/generated/commands.ts
+++ b/src/generated/commands.ts
@@ -40,6 +40,11 @@ export async function readFileContent(params: types.ReadFileContentParams): Prom
 }
 
 
+export async function readImageFileAsDataUrl(params: types.ReadImageFileAsDataUrlParams): Promise<string> {
+  return invoke('read_image_file_as_data_url', params);
+}
+
+
 export async function writeFileContent(params: types.WriteFileContentParams): Promise<void> {
   return invoke('write_file_content', params);
 }

--- a/src/generated/types.ts
+++ b/src/generated/types.ts
@@ -228,6 +228,12 @@ export interface ReadFileContentParams {
 }
 
 
+export interface ReadImageFileAsDataUrlParams {
+  path: string;
+  [key: string]: unknown;
+}
+
+
 export interface WriteFileContentParams {
   path: string;
   content: string;

--- a/src/shared/lib/queryKeys.ts
+++ b/src/shared/lib/queryKeys.ts
@@ -16,6 +16,7 @@ export const queryNamespaces = {
 	"profile-notes": "profile-notes",
 	"topbar-apps": "topbar-apps",
 	"fs-file": "fs-file",
+	"fs-image": "fs-image",
 	"fs-search": "fs-search",
 	"fs-tree": "fs-tree",
 };
@@ -71,6 +72,7 @@ export const queryKeys = {
 	},
 	fs: {
 		file: (path: string) => ["fs-file", path] as const,
+		image: (path: string) => ["fs-image", path] as const,
 		search: (profileId: string, query: string) =>
 			["fs-search", profileId, query] as const,
 		tree: (path: string) => ["fs-tree", path] as const,


### PR DESCRIPTION
## Summary

- 之前打开图片文件（png/jpg/svg 等）时，`read_file_content` 检测到 null 字节就直接返回 `Binary file` 错误，整个 file viewer 报错
- 新增 `read_image_file_as_data_url` Tauri command，按扩展名识别图片并返回 `data:<mime>;base64,...`（10MB 上限）
- `FileViewerPane` 和 `FileViewerDialog` 按扩展名分流：图片走 `<img src={dataUrl}>`，其余继续走 Monaco / Prism

## Test plan

- [x] `cargo check` / `cargo test handler::filesystem` 通过
- [x] `tsc --noEmit` 通过
- [x] `vitest FileViewerPane`（3/3）通过
- [ ] 本地 `bun tauri dev` 打开 png/jpg/svg 文件，确认可见

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added image file preview support in the file viewer. Image files are now displayed as previews instead of text content, with proper loading and error states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AkaraChen/2code/pull/293?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->