### PR TITLE
Support file tree path drops into terminal tabs

### DIFF
--- a/src/features/projects/FileTreePanel.test.tsx
+++ b/src/features/projects/FileTreePanel.test.tsx
@@ -7,9 +7,15 @@ import {
 	screen,
 	waitFor,
 } from "@testing-library/react";
-import type { KeyboardEventHandler, MouseEventHandler, ReactNode } from "react";
+import type {
+	DragEventHandler,
+	KeyboardEventHandler,
+	MouseEventHandler,
+	ReactNode,
+} from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { appSystem } from "@/theme/system";
+import { FILE_TREE_TERMINAL_DROP_MIME } from "@/shared/lib/fileTreeTerminalDrop";
 import FileTreePanel from "./FileTreePanel";
 import {
 	useCreateFileTreePath,
@@ -85,11 +91,13 @@ vi.mock("@/shared/lib/clipboard", () => ({
 vi.mock("@pierre/trees/react", () => ({
 	FileTree: ({
 		onClick,
+		onDragStart,
 		onKeyUp,
 		onMouseDown,
 		renderContextMenu,
 	}: {
 		onClick?: MouseEventHandler<HTMLElement>;
+		onDragStart?: DragEventHandler<HTMLElement>;
 		onKeyUp?: KeyboardEventHandler<HTMLElement>;
 		onMouseDown?: MouseEventHandler<HTMLElement>;
 		renderContextMenu?: (
@@ -120,6 +128,9 @@ vi.mock("@pierre/trees/react", () => ({
 					}
 					onClick?.(event);
 				}}
+				onDragStart={
+					onDragStart as DragEventHandler<HTMLButtonElement>
+				}
 				onMouseDown={
 					onMouseDown as MouseEventHandler<HTMLButtonElement>
 				}
@@ -130,6 +141,9 @@ vi.mock("@pierre/trees/react", () => ({
 			<button
 				data-item-path="src/index.ts"
 				onClick={onClick as MouseEventHandler<HTMLButtonElement>}
+				onDragStart={
+					onDragStart as DragEventHandler<HTMLButtonElement>
+				}
 				onMouseDown={
 					onMouseDown as MouseEventHandler<HTMLButtonElement>
 				}
@@ -140,6 +154,9 @@ vi.mock("@pierre/trees/react", () => ({
 			<button
 				data-item-path="ignored.log"
 				onClick={onClick as MouseEventHandler<HTMLButtonElement>}
+				onDragStart={
+					onDragStart as DragEventHandler<HTMLButtonElement>
+				}
 				onMouseDown={
 					onMouseDown as MouseEventHandler<HTMLButtonElement>
 				}
@@ -256,6 +273,35 @@ function getLastMenuItem(name: string) {
 	const item = items[items.length - 1];
 	if (!item) throw new Error(`missing menu item: ${name}`);
 	return item;
+}
+
+function createTestDataTransfer(): DataTransfer {
+	const data = new Map<string, string>();
+	const types: string[] = [];
+	const transfer = {
+		dropEffect: "none",
+		effectAllowed: "uninitialized",
+		files: [] as unknown as FileList,
+		items: [] as unknown as DataTransferItemList,
+		types,
+		clearData: vi.fn((format?: string) => {
+			if (format) {
+				data.delete(format);
+				const index = types.indexOf(format);
+				if (index >= 0) types.splice(index, 1);
+			} else {
+				data.clear();
+				types.splice(0);
+			}
+		}),
+		getData: vi.fn((format: string) => data.get(format) ?? ""),
+		setData: vi.fn((format: string, value: string) => {
+			data.set(format, value);
+			if (!types.includes(format)) types.push(format);
+		}),
+		setDragImage: vi.fn(),
+	} as unknown as DataTransfer;
+	return transfer;
 }
 
 describe("fileTreePanel", () => {
@@ -517,6 +563,23 @@ describe("fileTreePanel", () => {
 		expect(onOpenFile).toHaveBeenCalledWith("/root/src/index.ts");
 	});
 
+	it("does not open files while mouse selection is waiting for click", () => {
+		const { onOpenFile } = renderPanel();
+
+		fireEvent.mouseDown(screen.getByText("index.ts"));
+		act(() => {
+			useFileTreeOptionsRef.current?.onSelectionChange?.([
+				"src/index.ts",
+			]);
+		});
+
+		expect(onOpenFile).not.toHaveBeenCalled();
+
+		fireEvent.click(screen.getByText("index.ts"));
+
+		expect(onOpenFile).toHaveBeenCalledWith("/root/src/index.ts");
+	});
+
 	it("does not open files while extending multi-selection", () => {
 		const { onOpenFile } = renderPanel();
 
@@ -529,6 +592,31 @@ describe("fileTreePanel", () => {
 		fireEvent.click(screen.getByText("index.ts"), { metaKey: true });
 
 		expect(onOpenFile).not.toHaveBeenCalled();
+	});
+
+	it("adds absolute file paths to file tree drag data without opening the file", () => {
+		const { onOpenFile } = renderPanel();
+		const dataTransfer = createTestDataTransfer();
+
+		fireEvent.mouseDown(screen.getByText("index.ts"));
+		act(() => {
+			useFileTreeOptionsRef.current?.onSelectionChange?.([
+				"src/index.ts",
+			]);
+		});
+		fireEvent.dragStart(screen.getByText("index.ts"), { dataTransfer });
+
+		expect(onOpenFile).not.toHaveBeenCalled();
+		expect(dataTransfer.effectAllowed).toBe("copyMove");
+		expect(dataTransfer.getData("text/plain")).toBe("/root/src/index.ts");
+		expect(
+			JSON.parse(dataTransfer.getData(FILE_TREE_TERMINAL_DROP_MIME)),
+		).toMatchObject({
+			profileId,
+			rootPath,
+			relativePaths: ["src/index.ts"],
+			absolutePaths: ["/root/src/index.ts"],
+		});
 	});
 
 	it("does not open directory rows", () => {

--- a/src/features/projects/FileTreePanel.tsx
+++ b/src/features/projects/FileTreePanel.tsx
@@ -13,6 +13,7 @@ import { FileTree, useFileTree } from "@pierre/trees/react";
 import { motion, useReducedMotion } from "motion/react";
 import {
 	type CSSProperties,
+	type DragEvent,
 	type KeyboardEvent,
 	type MouseEvent,
 	useCallback,
@@ -25,6 +26,14 @@ import * as m from "@/paraglide/messages.js";
 import { useHorizontalResize } from "@/shared/hooks/useHorizontalResize";
 import { copyTextToClipboard } from "@/shared/lib/clipboard";
 import { getErrorMessage } from "@/shared/lib/errors";
+import {
+	createFileTreeTerminalDropPayload,
+	FILE_TREE_TERMINAL_DROP_EVENT,
+	type FileTreeTerminalDropEventDetail,
+	type FileTreeTerminalDropPayload,
+	getFileTreeTerminalDropTargetAtPoint,
+	writeFileTreeTerminalDropPayload,
+} from "@/shared/lib/fileTreeTerminalDrop";
 import { toaster } from "@/shared/providers/appToaster";
 import FileViewerDialog from "./FileViewerDialog";
 import { toFileTreeGitStatus } from "./fileTreeGitStatus";
@@ -92,14 +101,18 @@ const EMPTY_LOADED_CHILD_PATHS_BY_DIRECTORY = new Map<
 	readonly string[]
 >();
 
-function getTreeItemPath(event: MouseEvent<HTMLElement>) {
-	for (const target of event.nativeEvent.composedPath()) {
+function getTreeItemPathFromComposedPath(composedPath: readonly EventTarget[]) {
+	for (const target of composedPath) {
 		if (target instanceof HTMLElement) {
 			const itemPath = target.dataset.itemPath;
 			if (itemPath) return itemPath;
 		}
 	}
 	return null;
+}
+
+function getTreeItemPath(event: MouseEvent<HTMLElement>) {
+	return getTreeItemPathFromComposedPath(event.nativeEvent.composedPath());
 }
 
 function toAbsolutePath(rootPath: string, relativePath: string) {
@@ -535,6 +548,9 @@ export default function FileTreePanel({
 		Map<string, Promise<readonly string[]>>
 	>(new Map());
 	const skipNextSelectionOpenRef = useRef(false);
+	const skipNextClickOpenRef = useRef(false);
+	const skipNextClickOpenUntilRef = useRef(0);
+	const dragPayloadRef = useRef<FileTreeTerminalDropPayload | null>(null);
 	const restoreModelRef = useRef(() => {});
 	const renameFileTreePathRef = useRef((_event: FileTreeRenameEvent) => {});
 	const moveFileTreePathsRef = useRef((_event: FileTreeDropResult) => {});
@@ -847,10 +863,18 @@ export default function FileTreePanel({
 	const handleTreeClick = useCallback(
 		(event: MouseEvent<HTMLElement>) => {
 			setRootContextMenu(null);
+			if (skipNextClickOpenRef.current) {
+				const shouldSkipClick = Date.now() <= skipNextClickOpenUntilRef.current;
+				skipNextClickOpenRef.current = false;
+				skipNextClickOpenUntilRef.current = 0;
+				skipNextSelectionOpenRef.current = false;
+				if (shouldSkipClick) return;
+			}
 			if (event.metaKey || event.ctrlKey || event.shiftKey) {
 				skipNextSelectionOpenRef.current = false;
 				return;
 			}
+			skipNextSelectionOpenRef.current = false;
 			const itemPath = getTreeItemPath(event);
 			if (itemPath && filePathSetRef.current.has(itemPath)) {
 				openRelativeFile(itemPath);
@@ -885,9 +909,8 @@ export default function FileTreePanel({
 	);
 
 	const handleTreeMouseDown = useCallback(
-		(event: MouseEvent<HTMLElement>) => {
-			skipNextSelectionOpenRef.current =
-				event.metaKey || event.ctrlKey || event.shiftKey;
+		() => {
+			skipNextSelectionOpenRef.current = true;
 		},
 		[],
 	);
@@ -940,6 +963,71 @@ export default function FileTreePanel({
 		},
 		[],
 	);
+	const handleTreeDragStart = useCallback(
+		(event: DragEvent<HTMLElement>) => {
+			skipNextSelectionOpenRef.current = true;
+			skipNextClickOpenRef.current = true;
+			skipNextClickOpenUntilRef.current = Date.now() + 500;
+
+			const itemPath = getTreeItemPathFromComposedPath(
+				event.nativeEvent.composedPath(),
+			);
+			if (!itemPath || !hasTreePath(treePathSetRef.current, itemPath)) {
+				return;
+			}
+
+			const candidatePaths =
+				selectedPaths.includes(itemPath) && selectedPaths.length > 0
+					? selectedPaths
+					: [itemPath];
+			const relativePaths = candidatePaths.filter((path) =>
+				hasTreePath(treePathSetRef.current, path),
+			);
+			if (relativePaths.length === 0) {
+				return;
+			}
+
+			const rootPath = rootPathRef.current;
+			const absolutePaths = relativePaths.map((path) =>
+				toAbsolutePath(rootPath, path),
+			);
+			const payload = createFileTreeTerminalDropPayload({
+				profileId,
+				rootPath,
+				relativePaths: [...relativePaths],
+				absolutePaths,
+			});
+			dragPayloadRef.current = payload;
+			writeFileTreeTerminalDropPayload(event.dataTransfer, payload);
+		},
+		[profileId, selectedPaths],
+	);
+	const handleTreeDragEnd = useCallback((event: DragEvent<HTMLElement>) => {
+		if (skipNextClickOpenRef.current) {
+			skipNextClickOpenUntilRef.current = Date.now() + 500;
+		}
+		const payload = dragPayloadRef.current;
+		dragPayloadRef.current = null;
+		if (payload) {
+			const target = getFileTreeTerminalDropTargetAtPoint(
+				event.clientX,
+				event.clientY,
+			);
+			target?.dispatchEvent(
+				new CustomEvent<FileTreeTerminalDropEventDetail>(
+					FILE_TREE_TERMINAL_DROP_EVENT,
+					{
+						bubbles: true,
+						detail: {
+							clientX: event.clientX,
+							clientY: event.clientY,
+							payload,
+						},
+					},
+				),
+			);
+		}
+	}, []);
 	const closeRootContextMenu = useCallback(() => {
 		setRootContextMenu(null);
 	}, []);
@@ -1066,6 +1154,8 @@ export default function FileTreePanel({
 										<FileTree
 											model={model}
 											onClick={handleTreeClick}
+											onDragEnd={handleTreeDragEnd}
+											onDragStart={handleTreeDragStart}
 											onKeyUp={handleTreeKeyUp}
 											onMouseDown={handleTreeMouseDown}
 											renderContextMenu={(

--- a/src/features/terminal/TabStrip.tsx
+++ b/src/features/terminal/TabStrip.tsx
@@ -1,6 +1,10 @@
 import { Box, CloseButton, HStack } from "@chakra-ui/react";
 import { AnimatePresence, motion } from "motion/react";
-import type { KeyboardEvent, ReactNode } from "react";
+import type {
+	KeyboardEvent,
+	ReactNode,
+	RefCallback,
+} from "react";
 
 const TAB_MIN_WIDTH = "140px";
 export const TAB_STRIP_HEIGHT = "32px";
@@ -12,6 +16,7 @@ export interface TabStripItem {
 	title: string;
 	maxTitleLength: number;
 	badge?: ReactNode;
+	elementRef?: RefCallback<HTMLDivElement>;
 	isSelected?: boolean;
 	onClose?: () => void;
 }
@@ -31,6 +36,7 @@ function TabButton({
 	title,
 	maxTitleLength,
 	badge,
+	elementRef,
 	isSelected,
 	onClose,
 	onSelect,
@@ -90,6 +96,7 @@ function TabButton({
 				outlineOffset: "-2px",
 			}}
 			draggable={false}
+			ref={elementRef}
 			onClick={selectTab}
 			onKeyDown={handleKeyDown}
 		>
@@ -144,6 +151,7 @@ function TabMotionItem({
 					title={item.title}
 					maxTitleLength={item.maxTitleLength}
 					badge={item.badge}
+					elementRef={item.elementRef}
 					isSelected={item.isSelected}
 					onClose={item.onClose}
 					onSelect={onSelect}

--- a/src/features/terminal/TerminalTabs.test.tsx
+++ b/src/features/terminal/TerminalTabs.test.tsx
@@ -115,7 +115,7 @@ function renderTerminalTabs() {
 	);
 }
 
-describe("TerminalTabs file tree drops", () => {
+describe("terminalTabs file tree drops", () => {
 	beforeEach(() => {
 		useTerminalStore.setState({
 			profiles: {},

--- a/src/features/terminal/TerminalTabs.test.tsx
+++ b/src/features/terminal/TerminalTabs.test.tsx
@@ -1,0 +1,168 @@
+import {
+	QueryClient,
+	QueryClientProvider,
+} from "@tanstack/react-query";
+import { ChakraProvider } from "@chakra-ui/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import type { Mock } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	useFileViewerDirtyStore,
+	useFileViewerTabsStore,
+} from "@/features/projects/fileViewerTabsStore";
+import {
+	createFileTreeTerminalDropPayload,
+	writeFileTreeTerminalDropPayload,
+} from "@/shared/lib/fileTreeTerminalDrop";
+import { writeToPty } from "@/generated";
+import { appSystem } from "@/theme/system";
+import TerminalTabs from "./TerminalTabs";
+import { useTerminalStore } from "./store";
+
+vi.mock("./Terminal", () => ({
+	Terminal: ({
+		sessionId,
+		isActive,
+	}: {
+		sessionId: string;
+		isActive: boolean;
+	}) => (
+		<div
+			data-active={isActive ? "true" : "false"}
+			data-testid={`terminal-${sessionId}`}
+		/>
+	),
+}));
+
+vi.mock("./TerminalTemplateMenu", () => ({
+	default: () => <div data-testid="terminal-template-menu" />,
+}));
+
+vi.mock("@/features/projects/UnsavedFileCloseDialog", () => ({
+	default: () => null,
+}));
+
+const writeToPtyMock = writeToPty as unknown as Mock;
+const profileId = "profile-1";
+
+function createWrapper() {
+	const queryClient = new QueryClient({
+		defaultOptions: {
+			queries: { retry: false },
+			mutations: { retry: false },
+		},
+	});
+
+	return ({ children }: { children: ReactNode }) => (
+		<QueryClientProvider client={queryClient}>
+			<ChakraProvider value={appSystem}>{children}</ChakraProvider>
+		</QueryClientProvider>
+	);
+}
+
+function createTestDataTransfer(): DataTransfer {
+	const data = new Map<string, string>();
+	const types: string[] = [];
+	const transfer = {
+		dropEffect: "none",
+		effectAllowed: "uninitialized",
+		files: [] as unknown as FileList,
+		items: [] as unknown as DataTransferItemList,
+		types,
+		clearData: vi.fn((format?: string) => {
+			if (format) {
+				data.delete(format);
+				const index = types.indexOf(format);
+				if (index >= 0) types.splice(index, 1);
+			} else {
+				data.clear();
+				types.splice(0);
+			}
+		}),
+		getData: vi.fn((format: string) => data.get(format) ?? ""),
+		setData: vi.fn((format: string, value: string) => {
+			data.set(format, value);
+			if (!types.includes(format)) types.push(format);
+		}),
+		setDragImage: vi.fn(),
+	} as unknown as DataTransfer;
+	return transfer;
+}
+
+function createFileTreeDrop(paths: string[]) {
+	const dataTransfer = createTestDataTransfer();
+	writeFileTreeTerminalDropPayload(
+		dataTransfer,
+		createFileTreeTerminalDropPayload({
+			profileId,
+			rootPath: "/root",
+			relativePaths: paths.map((path) => path.replace("/root/", "")),
+			absolutePaths: paths,
+		}),
+	);
+	return dataTransfer;
+}
+
+function renderTerminalTabs() {
+	render(
+		<TerminalTabs
+			projectId="project-1"
+			profileId={profileId}
+			cwd="/root"
+		/>,
+		{ wrapper: createWrapper() },
+	);
+}
+
+describe("TerminalTabs file tree drops", () => {
+	beforeEach(() => {
+		useTerminalStore.setState({
+			profiles: {},
+			notifiedTabs: new Set<string>(),
+			sessionProfileIds: {},
+		});
+		useFileViewerTabsStore.setState({ profiles: {} });
+		useFileViewerDirtyStore.setState({
+			profiles: {},
+			drafts: {},
+			savedValues: {},
+		});
+		writeToPtyMock.mockClear();
+		writeToPtyMock.mockResolvedValue(undefined);
+	});
+
+	it("activates the dropped terminal tab and writes dropped paths to its PTY", async () => {
+		useTerminalStore.getState().addTab(profileId, "session-1", "Terminal 1");
+		useTerminalStore.getState().addTab(profileId, "session-2", "Terminal 2");
+		useTerminalStore.getState().setActiveTab(profileId, "session-1");
+		useFileViewerTabsStore.getState().openFile(profileId, "/root/src/App.tsx");
+		renderTerminalTabs();
+
+		const dataTransfer = createFileTreeDrop([
+			"/root/src/index.ts",
+			"/root/src/components",
+		]);
+		const terminalTab = screen.getByRole("tab", { name: /Terminal 2/ });
+
+		fireEvent.dragOver(terminalTab, { dataTransfer });
+		fireEvent.drop(terminalTab, { dataTransfer });
+
+		await waitFor(() => {
+			expect(writeToPtyMock).toHaveBeenCalledWith({
+				sessionId: "session-2",
+				data: "/root/src/index.ts /root/src/components",
+			});
+		});
+		expect(useTerminalStore.getState().profiles[profileId].activeTabId).toBe(
+			"session-2",
+		);
+		expect(
+			useFileViewerTabsStore.getState().profiles[profileId]?.fileTabActive,
+		).toBe(false);
+		expect(screen.getByTestId("terminal-session-2")).toHaveAttribute(
+			"data-active",
+			"true",
+		);
+	});
+});

--- a/src/features/terminal/TerminalTabs.tsx
+++ b/src/features/terminal/TerminalTabs.tsx
@@ -35,6 +35,8 @@ import {
 	FILE_TREE_TERMINAL_DROP_TARGET_ATTR,
 	type FileTreeTerminalDropEventDetail,
 	formatTerminalPathInput,
+	hasFileTreeTerminalDropPayload,
+	readFileTreeTerminalDropPayload,
 } from "@/shared/lib/fileTreeTerminalDrop";
 import * as m from "@/paraglide/messages.js";
 import { useCloseTerminalTab } from "./hooks";
@@ -232,9 +234,34 @@ export default function TerminalTabs({
 				event.stopPropagation();
 				handleTerminalPathDrop(customEvent.detail, tab);
 			};
+			const handleDragOver = (event: DragEvent) => {
+				if (!hasFileTreeTerminalDropPayload(event.dataTransfer)) return;
+				event.preventDefault();
+				if (event.dataTransfer) {
+					event.dataTransfer.dropEffect = "copy";
+				}
+			};
+			const handleNativeDrop = (event: DragEvent) => {
+				const payload = readFileTreeTerminalDropPayload(event.dataTransfer);
+				if (!payload) return;
+				event.preventDefault();
+				event.stopPropagation();
+				handleTerminalPathDrop(
+					{
+						clientX: event.clientX,
+						clientY: event.clientY,
+						payload,
+					},
+					tab,
+				);
+			};
 			node.addEventListener(FILE_TREE_TERMINAL_DROP_EVENT, handleDrop);
+			node.addEventListener("dragover", handleDragOver);
+			node.addEventListener("drop", handleNativeDrop);
 			cleanup = () => {
 				node.removeEventListener(FILE_TREE_TERMINAL_DROP_EVENT, handleDrop);
+				node.removeEventListener("dragover", handleDragOver);
+				node.removeEventListener("drop", handleNativeDrop);
 				node.removeAttribute(FILE_TREE_TERMINAL_DROP_TARGET_ATTR);
 			};
 		};

--- a/src/features/terminal/TerminalTabs.tsx
+++ b/src/features/terminal/TerminalTabs.tsx
@@ -15,15 +15,27 @@ import openClawIconUrl from "@lobehub/icons-static-svg/icons/openclaw-color.svg"
 import opencodeIconUrl from "@lobehub/icons-static-svg/icons/opencode.svg";
 import qoderIconUrl from "@lobehub/icons-static-svg/icons/qoder-color.svg";
 import { useReducedMotion } from "motion/react";
-import { lazy, useMemo, useState, type ReactNode } from "react";
+import {
+	lazy,
+	useMemo,
+	useState,
+	type ReactNode,
+} from "react";
 import { FiFileText, FiTerminal } from "react-icons/fi";
 import { useShallow } from "zustand/react/shallow";
 import {
 	useFileViewerDirtyStore,
 	useFileViewerTabsStore,
 } from "@/features/projects/fileViewerTabsStore";
+import { writeToPty } from "@/generated";
 import { AsyncBoundary, InlineError } from "@/shared/components/Fallbacks";
 import FileTreeFileIcon from "@/shared/components/FileTreeFileIcon";
+import {
+	FILE_TREE_TERMINAL_DROP_EVENT,
+	FILE_TREE_TERMINAL_DROP_TARGET_ATTR,
+	type FileTreeTerminalDropEventDetail,
+	formatTerminalPathInput,
+} from "@/shared/lib/fileTreeTerminalDrop";
 import * as m from "@/paraglide/messages.js";
 import { useCloseTerminalTab } from "./hooks";
 import { useTerminalStore } from "./store";
@@ -190,6 +202,47 @@ export default function TerminalTabs({
 		setPendingCloseFile(null);
 	}
 
+	function handleTerminalPathDrop(
+		detail: FileTreeTerminalDropEventDetail,
+		tab: { id: string },
+	) {
+		const { payload } = detail;
+		if (payload.profileId !== profileId) return;
+
+		const data = formatTerminalPathInput(payload.absolutePaths);
+		if (!data) return;
+
+		setActiveTab(profileId, tab.id);
+		setTerminalActive(profileId);
+		writeToPty({ sessionId: tab.id, data });
+	}
+
+	function createTerminalDropRef(tab: { id: string }) {
+		let cleanup: (() => void) | null = null;
+
+		return (node: HTMLDivElement | null) => {
+			cleanup?.();
+			cleanup = null;
+			if (!node) return;
+
+			node.setAttribute(FILE_TREE_TERMINAL_DROP_TARGET_ATTR, "");
+			const handleDrop = (event: Event) => {
+				const customEvent = event as CustomEvent<FileTreeTerminalDropEventDetail>;
+				if (!customEvent.detail?.payload) return;
+				event.stopPropagation();
+				handleTerminalPathDrop(customEvent.detail, tab);
+			};
+			node.addEventListener(FILE_TREE_TERMINAL_DROP_EVENT, handleDrop);
+			cleanup = () => {
+				node.removeEventListener(FILE_TREE_TERMINAL_DROP_EVENT, handleDrop);
+				node.removeAttribute(FILE_TREE_TERMINAL_DROP_TARGET_ATTR);
+			};
+		};
+	}
+
+	const activeTerminalTab =
+		tabs.find((tab) => tab.id === activeTabId) ?? null;
+
 	const tabGroups: TabStripGroup[] = [
 		{
 			id: "terminal",
@@ -199,6 +252,7 @@ export default function TerminalTabs({
 				icon: getTerminalTabIcon(tab.title),
 				title: tab.title,
 				maxTitleLength: 10,
+				elementRef: createTerminalDropRef(tab),
 				isSelected: !fileTabActive && !notesActive && tab.id === activeValue,
 				badge:
 					notifiedTabSet.has(tab.id) && tab.id !== activeTabId ? (
@@ -360,6 +414,11 @@ export default function TerminalTabs({
 				minH="0"
 				position="relative"
 				display={fileTabActive || notesActive ? "none" : "block"}
+				ref={
+					activeTerminalTab
+						? createTerminalDropRef(activeTerminalTab)
+						: undefined
+				}
 			>
 				{tabs.map((tab) => (
 					<Box

--- a/src/shared/lib/fileTreeTerminalDrop.test.ts
+++ b/src/shared/lib/fileTreeTerminalDrop.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	FILE_TREE_TERMINAL_DROP_MIME,
+	createFileTreeTerminalDropPayload,
+	formatTerminalPathInput,
+	readFileTreeTerminalDropPayload,
+	writeFileTreeTerminalDropPayload,
+} from "./fileTreeTerminalDrop";
+
+function createTestDataTransfer(): DataTransfer {
+	const data = new Map<string, string>();
+	const types: string[] = [];
+	const transfer = {
+		dropEffect: "none",
+		effectAllowed: "uninitialized",
+		files: [] as unknown as FileList,
+		items: [] as unknown as DataTransferItemList,
+		types,
+		clearData: vi.fn(),
+		getData: vi.fn((format: string) => data.get(format) ?? ""),
+		setData: vi.fn((format: string, value: string) => {
+			data.set(format, value);
+			if (!types.includes(format)) types.push(format);
+		}),
+		setDragImage: vi.fn(),
+	} as unknown as DataTransfer;
+	return transfer;
+}
+
+describe("fileTreeTerminalDrop", () => {
+	it("round-trips file tree terminal drop payloads", () => {
+		const dataTransfer = createTestDataTransfer();
+		const payload = createFileTreeTerminalDropPayload({
+			profileId: "profile-1",
+			rootPath: "/root",
+			relativePaths: ["src/index.ts"],
+			absolutePaths: ["/root/src/index.ts"],
+		});
+
+		writeFileTreeTerminalDropPayload(dataTransfer, payload);
+
+		expect(dataTransfer.effectAllowed).toBe("copyMove");
+		expect(dataTransfer.types).toContain(FILE_TREE_TERMINAL_DROP_MIME);
+		expect(dataTransfer.getData("text/plain")).toBe("/root/src/index.ts");
+		expect(readFileTreeTerminalDropPayload(dataTransfer)).toEqual(payload);
+	});
+
+	it("formats terminal input as raw absolute paths", () => {
+		expect(
+			formatTerminalPathInput([
+				"/root/src/index.ts",
+				"/root/path with spaces/file.ts",
+			]),
+		).toBe("/root/src/index.ts /root/path with spaces/file.ts");
+	});
+});

--- a/src/shared/lib/fileTreeTerminalDrop.ts
+++ b/src/shared/lib/fileTreeTerminalDrop.ts
@@ -1,0 +1,106 @@
+export const FILE_TREE_TERMINAL_DROP_MIME =
+	"application/x-2code-file-tree-paths";
+export const FILE_TREE_TERMINAL_DROP_EVENT = "2code:file-tree-terminal-drop";
+export const FILE_TREE_TERMINAL_DROP_TARGET_ATTR =
+	"data-file-tree-terminal-drop-target";
+export const FILE_TREE_TERMINAL_DROP_TARGET_SELECTOR =
+	`[${FILE_TREE_TERMINAL_DROP_TARGET_ATTR}]`;
+
+const FILE_TREE_TERMINAL_DROP_SOURCE = "2code-file-tree";
+
+export interface FileTreeTerminalDropPayload {
+	source: typeof FILE_TREE_TERMINAL_DROP_SOURCE;
+	profileId: string;
+	rootPath: string;
+	relativePaths: string[];
+	absolutePaths: string[];
+}
+
+export interface FileTreeTerminalDropEventDetail {
+	clientX: number;
+	clientY: number;
+	payload: FileTreeTerminalDropPayload;
+}
+
+function isStringArray(value: unknown): value is string[] {
+	return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+export function getFileTreeTerminalDropTargetAtPoint(
+	clientX: number,
+	clientY: number,
+) {
+	return document.elementFromPoint?.(clientX, clientY)?.closest<HTMLElement>(
+		FILE_TREE_TERMINAL_DROP_TARGET_SELECTOR,
+	) ?? null;
+}
+
+export function createFileTreeTerminalDropPayload({
+	profileId,
+	rootPath,
+	relativePaths,
+	absolutePaths,
+}: Omit<FileTreeTerminalDropPayload, "source">): FileTreeTerminalDropPayload {
+	return {
+		source: FILE_TREE_TERMINAL_DROP_SOURCE,
+		profileId,
+		rootPath,
+		relativePaths,
+		absolutePaths,
+	};
+}
+
+export function hasFileTreeTerminalDropPayload(
+	dataTransfer: DataTransfer | null,
+) {
+	if (!dataTransfer) return false;
+	return Array.from(dataTransfer.types).includes(FILE_TREE_TERMINAL_DROP_MIME);
+}
+
+export function writeFileTreeTerminalDropPayload(
+	dataTransfer: DataTransfer,
+	payload: FileTreeTerminalDropPayload,
+) {
+	dataTransfer.effectAllowed = "copyMove";
+	dataTransfer.setData(
+		FILE_TREE_TERMINAL_DROP_MIME,
+		JSON.stringify(payload),
+	);
+	dataTransfer.setData("text/plain", payload.absolutePaths.join("\n"));
+}
+
+export function readFileTreeTerminalDropPayload(
+	dataTransfer: DataTransfer | null,
+): FileTreeTerminalDropPayload | null {
+	if (!dataTransfer || !hasFileTreeTerminalDropPayload(dataTransfer)) {
+		return null;
+	}
+
+	try {
+		const rawPayload = dataTransfer.getData(FILE_TREE_TERMINAL_DROP_MIME);
+		if (!rawPayload) return null;
+
+		const payload = JSON.parse(rawPayload) as Partial<FileTreeTerminalDropPayload>;
+		if (
+			payload.source !== FILE_TREE_TERMINAL_DROP_SOURCE ||
+			typeof payload.profileId !== "string" ||
+			typeof payload.rootPath !== "string" ||
+			!isStringArray(payload.relativePaths) ||
+			!isStringArray(payload.absolutePaths) ||
+			payload.absolutePaths.length === 0 ||
+			payload.relativePaths.length !== payload.absolutePaths.length
+		) {
+			return null;
+		}
+
+		return payload as FileTreeTerminalDropPayload;
+	} catch {
+		return null;
+	}
+}
+
+export function formatTerminalPathInput(paths: readonly string[]) {
+	return paths
+		.filter((path) => path.length > 0)
+		.join(" ");
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -100,6 +100,7 @@ vi.mock("@/generated", () => ({
 	startDebugLog: vi.fn(),
 	stopDebugLog: vi.fn(),
 	createPtySession: vi.fn(() => Promise.resolve("mock-session-id")),
+	writeToPty: vi.fn(() => Promise.resolve()),
 	closePtySession: vi.fn(() => Promise.resolve()),
 	deletePtySessionRecord: vi.fn(() => Promise.resolve()),
 	listProjects: vi.fn(() => Promise.resolve([])),


### PR DESCRIPTION
## Summary
- add file-tree drag payload helpers for terminal drops
- let terminal tab and active pane refs accept file-tree drop events and write raw paths into the PTY
- prevent drag gestures from immediately opening files while preserving normal click behavior
- add focused coverage for file-tree payloads and terminal path drop handling

## Validation
- Not run per request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Drag-and-drop file paths from the file tree directly into terminal tabs to insert absolute file paths
  * Terminal tabs now properly handle dropped files and activate the target tab

* **Tests**
  * Added comprehensive test coverage for file tree drag-and-drop operations
  * Added tests for terminal tab drop interactions, payload validation, and path formatting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->