### PR TITLE
fix(terminal): resolve Store-installed pwsh on Windows

### DIFF
--- a/src-tauri/src/handler/shell.rs
+++ b/src-tauri/src/handler/shell.rs
@@ -55,6 +55,55 @@ fn push_existing_shell(
 	}
 }
 
+/// An App Execution Alias (`%LOCALAPPDATA%\Microsoft\WindowsApps\*.exe`) is a
+/// zero-byte reparse point whose `IO_REPARSE_TAG_APPEXECLINK` is only honored
+/// by the Windows shell/loader. portable_pty's ConPTY spawn path does not
+/// resolve it, so spawning the alias path produces no child and the terminal
+/// stays blank. We must skip these stubs in favor of the real binary.
+#[cfg(windows)]
+fn is_app_exec_alias_stub(path: &str) -> bool {
+	let lower = path.to_lowercase().replace('/', "\\");
+	if !lower.contains("\\microsoft\\windowsapps\\") {
+		return false;
+	}
+	std::fs::metadata(path)
+		.map(|m| m.len() == 0)
+		.unwrap_or(false)
+}
+
+/// Probe `C:\Program Files\WindowsApps` for a Microsoft Store install of pwsh.
+/// Reading this directory often fails for standard users due to ACLs, so this
+/// is best-effort — callers must handle `None`.
+#[cfg(windows)]
+fn find_store_pwsh() -> Option<String> {
+	let store_root = Path::new(r"C:\Program Files\WindowsApps");
+	let entries = std::fs::read_dir(store_root).ok()?;
+	let mut best: Option<(String, String)> = None;
+	for entry in entries.flatten() {
+		let name = entry.file_name().to_string_lossy().into_owned();
+		if !name.starts_with("Microsoft.PowerShell_") || !name.contains("_x64_")
+		{
+			continue;
+		}
+		let pwsh = entry.path().join("pwsh.exe");
+		if !pwsh.is_file() {
+			continue;
+		}
+		let version = name
+			.strip_prefix("Microsoft.PowerShell_")
+			.and_then(|s| s.split("_x64_").next())
+			.unwrap_or("")
+			.to_string();
+		let pwsh_str = pwsh.to_string_lossy().into_owned();
+		match &best {
+			None => best = Some((version, pwsh_str)),
+			Some((v, _)) if version > *v => best = Some((version, pwsh_str)),
+			_ => {}
+		}
+	}
+	best.map(|(_, p)| p)
+}
+
 #[cfg(windows)]
 fn find_pwsh_path() -> Option<String> {
 	let candidates = [
@@ -67,20 +116,22 @@ fn find_pwsh_path() -> Option<String> {
 			return Some(path.to_string());
 		}
 	}
-	// Fallback: check PATH via `where`
+	if let Some(p) = find_store_pwsh() {
+		return Some(p);
+	}
+	// Fallback: check PATH via `where`, skipping App Execution Alias stubs.
 	let output = command_without_windows_console("where")
 		.arg("pwsh")
 		.output()
 		.ok()?;
 	if output.status.success() {
-		let first = String::from_utf8_lossy(&output.stdout)
-			.lines()
-			.next()
-			.unwrap_or("")
-			.trim()
-			.to_string();
-		if !first.is_empty() {
-			return Some(first);
+		let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+		for line in stdout.lines() {
+			let path = line.trim();
+			if path.is_empty() || is_app_exec_alias_stub(path) {
+				continue;
+			}
+			return Some(path.to_string());
 		}
 	}
 	None

--- a/src-tauri/src/handler/shell.rs
+++ b/src-tauri/src/handler/shell.rs
@@ -71,6 +71,16 @@ fn is_app_exec_alias_stub(path: &str) -> bool {
 		.unwrap_or(false)
 }
 
+/// Parse a dotted version string (e.g. `"7.4.10"`) into a numeric vector for
+/// correct ordering. Lexicographic string comparison misorders multi-digit
+/// segments — `"7.4.10" < "7.4.9"` as strings, but `[7,4,10] > [7,4,9]`.
+/// Non-numeric segments become 0, which is fine for the Store package naming
+/// scheme we encounter here.
+#[cfg(windows)]
+fn parse_version(s: &str) -> Vec<u32> {
+	s.split('.').map(|p| p.parse().unwrap_or(0)).collect()
+}
+
 /// Probe `C:\Program Files\WindowsApps` for a Microsoft Store install of pwsh.
 /// Reading this directory often fails for standard users due to ACLs, so this
 /// is best-effort — callers must handle `None`.
@@ -78,7 +88,7 @@ fn is_app_exec_alias_stub(path: &str) -> bool {
 fn find_store_pwsh() -> Option<String> {
 	let store_root = Path::new(r"C:\Program Files\WindowsApps");
 	let entries = std::fs::read_dir(store_root).ok()?;
-	let mut best: Option<(String, String)> = None;
+	let mut best: Option<(Vec<u32>, String)> = None;
 	for entry in entries.flatten() {
 		let name = entry.file_name().to_string_lossy().into_owned();
 		if !name.starts_with("Microsoft.PowerShell_") || !name.contains("_x64_")
@@ -89,11 +99,11 @@ fn find_store_pwsh() -> Option<String> {
 		if !pwsh.is_file() {
 			continue;
 		}
-		let version = name
-			.strip_prefix("Microsoft.PowerShell_")
-			.and_then(|s| s.split("_x64_").next())
-			.unwrap_or("")
-			.to_string();
+		let version = parse_version(
+			name.strip_prefix("Microsoft.PowerShell_")
+				.and_then(|s| s.split("_x64_").next())
+				.unwrap_or(""),
+		);
 		let pwsh_str = pwsh.to_string_lossy().into_owned();
 		match &best {
 			None => best = Some((version, pwsh_str)),


### PR DESCRIPTION
## 症状

Windows 上从 NSIS 装的 2code,点"新建终端"后终端面板纯黑——光标不闪、键入无回显、`Ctrl+C` 没反应、关 tab 不报错、前端 toast 一片安静、xterm 也没有报错。从用户视角看就是"新终端炸了,但什么都没说"。

## 为什么这么难定位

调了很多次都看不出来,因为每一层都在"正常工作":

1. 后端日志显示 `pty: session created`、`spawn_command` 没抛错——整条链路看着是绿的
2. 前端 `listen('pty-output-{id}')` 注册成功——监听器在,只是永远等不到事件
3. **没有 `pty-exit` 事件**——所以"进程崩了"这个假设也排除
4. 直接跑 `target\release\code.exe`(dev 模式)又是好的——因为 dev 的 PATH 不一样,`where pwsh` 命中了别处
5. `%TEMP%\2code.log` 里能看到一堆 `read: bytes from PTY n=16 / n=88`,看着像 PowerShell 在跑——但那其实是**上一个会话**留下来的 restored scrollback,新会话压根没字节出来

## 真正发生的事

`find_pwsh_path()` 硬编码的候选(`C:\Program Files\PowerShell\7\pwsh.exe` 等)全 miss,因为用户的 pwsh 是 Microsoft Store 装的,真路径在:

```
C:\Program Files\WindowsApps\Microsoft.PowerShell_*_x64_*\pwsh.exe
```

Fallback 跑 `where pwsh`,Windows 优先返回 App Execution Alias:

```
C:\Users\<user>\AppData\Local\Microsoft\WindowsApps\pwsh.exe
```

**这个文件是 0 字节的重解析点**(`IO_REPARSE_TAG_APPEXECLINK`)。只有 Win32 `CreateProcess` 才会解析它——内核拦截、读 reparse buffer、把 spawn 重定向到真正的 Store 包。

但 `portable_pty` 的 ConPTY spawn 路径**不走这套解析逻辑**。结果是:

- ConPTY 创建了伪终端 ✅
- `spawn_command` 返回 `Ok` ✅(因为文件存在,可执行属性也对)
- 实际上**没有任何子进程被启动**
- PTY master 那头永远不会有字节出来
- 前端 listener 永远不会触发
- 没人报错、没人退出,只是悄悄什么都不发生

## 修复

1. `find_store_pwsh()` 主动扫 `C:\Program Files\WindowsApps\Microsoft.PowerShell_*_x64_*\pwsh.exe`,在 fallback 之前就找到真二进制
2. `is_app_exec_alias_stub` 检测 0 字节 + 路径包含 `\Microsoft\WindowsApps\`,把这种 stub 从 `where pwsh` 的输出里过滤掉

## Test plan

- [x] 本地构建 NSIS 安装,覆盖安装后新终端能正常打开 PowerShell
- [ ] 没装 Store pwsh、只有 MSI 版的环境下行为不变(命中硬编码候选路径)
- [ ] 完全没装 pwsh 的环境下回退到 `null`(由调用方处理)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Windows PowerShell discovery to skip problematic stub entries that failed to execute correctly.
  * Improved shell detection to better identify valid Microsoft Store PowerShell installations.
  * Refined fallback path resolution for more reliable shell selection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AkaraChen/2code/pull/297?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->