### PR TITLE
feat(git): add diff review queue

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@emotion/react": "^11.14.0",
+        "@floating-ui/dom": "^1.7.6",
         "@fontsource-variable/bricolage-grotesque": "^5.2.10",
         "@icons-pack/react-simple-icons": "^13.13.0",
         "@lobehub/icons-static-svg": "^1.88.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@emotion/react": "^11.14.0",
+    "@floating-ui/dom": "^1.7.6",
     "@fontsource-variable/bricolage-grotesque": "^5.2.10",
     "@icons-pack/react-simple-icons": "^13.13.0",
     "@lobehub/icons-static-svg": "^1.88.0",

--- a/src/features/git/components/GitDiffChangesPanel.tsx
+++ b/src/features/git/components/GitDiffChangesPanel.tsx
@@ -11,6 +11,7 @@ import ChangesFileList from "./ChangesFileList";
 import CommitComposer from "./CommitComposer";
 import GitDiffPane from "./GitDiffPane";
 import { GitDiffContext } from "../gitDiffReducer";
+import type { DiffReviewComment } from "../reviewQueue";
 
 // CSS display toggle — never unmounts children (preserves diff pane scroll)
 function VisibleBox({
@@ -102,7 +103,13 @@ export function ChangesSidebar({
 	);
 }
 
-export function ChangesDiffPane({ visible }: { visible: boolean }) {
+export function ChangesDiffPane({
+	visible,
+	onAddReviewComment,
+}: {
+	visible: boolean;
+	onAddReviewComment?: (comment: DiffReviewComment) => void;
+}) {
 	const { changesFiles, state, options, profileId } = use(GitDiffContext)!;
 	const activeFile =
 		changesFiles.length > 0 && state.selectedFileIndex < changesFiles.length
@@ -122,6 +129,7 @@ export function ChangesDiffPane({ visible }: { visible: boolean }) {
 					options={options}
 					contextKey="working-tree"
 					previewContext={{ kind: "working-tree", profileId }}
+					onAddReviewComment={onAddReviewComment}
 					emptyMessage={
 						changesFiles.length === 0
 							? m.noChangesDetected()

--- a/src/features/git/components/GitDiffContent.tsx
+++ b/src/features/git/components/GitDiffContent.tsx
@@ -558,11 +558,6 @@ export default function GitDiffContent({
 						zIndex={3}
 						size="sm"
 						variant="solid"
-						alignItems="center"
-						gap="2"
-						h="9"
-						px="3"
-						borderRadius="full"
 						boxShadow="xl"
 						onClick={() => setReviewQueueOpen(true)}
 					>

--- a/src/features/git/components/GitDiffContent.tsx
+++ b/src/features/git/components/GitDiffContent.tsx
@@ -547,39 +547,44 @@ export default function GitDiffContent({
 				</Activity>
 			</Flex>
 				{reviewComments.length > 0 && (
-					<Flex
+					<Button
 						position="absolute"
 						right="4"
 						bottom="4"
 						zIndex={3}
-						align="center"
-						justify="space-between"
-						gap="3"
+						size="sm"
+						variant="solid"
+						alignItems="center"
+						gap="2"
+						h="9"
 						px="3"
-						py="2"
-						borderWidth="1px"
-						borderColor="border.emphasized"
-						borderRadius="md"
-						bg="bg.panel"
-						boxShadow="lg"
+						borderRadius="full"
+						boxShadow="xl"
+						onClick={() => setReviewQueueOpen(true)}
 					>
-						<Text fontSize="sm" color="fg.muted">
-							{reviewComments.length} queued review comment
-							{reviewComments.length === 1 ? "" : "s"}
+						<FiMessageSquare />
+						<Text fontSize="sm" fontWeight="medium">
+							Review Queue
 						</Text>
-						<Button
-							size="sm"
-							variant="outline"
-							onClick={() => setReviewQueueOpen(true)}
+						<Box
+							as="span"
+							minW="5"
+							px="1.5"
+							borderRadius="full"
+							bg="whiteAlpha.300"
+							fontSize="xs"
+							fontWeight="semibold"
+							lineHeight="5"
+							textAlign="center"
 						>
-							<FiMessageSquare />
-							Review Queue ({reviewComments.length})
-						</Button>
-					</Flex>
+							{reviewComments.length}
+						</Box>
+					</Button>
 				)}
 				<GitReviewQueueDialog
 					isOpen={reviewQueueOpen}
 					comments={reviewComments}
+					options={options}
 					onClose={() => setReviewQueueOpen(false)}
 					onClear={handleClearReviewComments}
 					onDelete={handleDeleteReviewComment}

--- a/src/features/git/components/GitDiffContent.tsx
+++ b/src/features/git/components/GitDiffContent.tsx
@@ -150,9 +150,13 @@ export default function GitDiffContent({
 	}, []);
 
 	const handleDeleteReviewComment = useCallback((id: string) => {
-		setReviewComments((comments) =>
-			comments.filter((comment) => comment.id !== id),
-		);
+		setReviewComments((comments) => {
+			const nextComments = comments.filter((comment) => comment.id !== id);
+			if (nextComments.length === 0) {
+				setReviewQueueOpen(false);
+			}
+			return nextComments;
+		});
 	}, []);
 
 	const handleClearReviewComments = useCallback(() => {

--- a/src/features/git/components/GitDiffContent.tsx
+++ b/src/features/git/components/GitDiffContent.tsx
@@ -139,11 +139,6 @@ export default function GitDiffContent({
 
 	const handleAddReviewComment = useCallback((comment: DiffReviewComment) => {
 		setReviewComments((comments) => [...comments, comment]);
-		toaster.create({
-			title: "Review comment queued",
-			type: "success",
-			closable: true,
-		});
 	}, []);
 
 	const handleUpdateReviewComment = useCallback((id: string, body: string) => {
@@ -158,6 +153,10 @@ export default function GitDiffContent({
 		setReviewComments((comments) =>
 			comments.filter((comment) => comment.id !== id),
 		);
+	}, []);
+
+	const handleClearReviewComments = useCallback(() => {
+		setReviewComments([]);
 	}, []);
 
 	const handleTabChange = (value: string) => {
@@ -582,6 +581,7 @@ export default function GitDiffContent({
 					isOpen={reviewQueueOpen}
 					comments={reviewComments}
 					onClose={() => setReviewQueueOpen(false)}
+					onClear={handleClearReviewComments}
 					onDelete={handleDeleteReviewComment}
 					onUpdate={handleUpdateReviewComment}
 				/>

--- a/src/features/git/components/GitDiffContent.tsx
+++ b/src/features/git/components/GitDiffContent.tsx
@@ -382,7 +382,7 @@ export default function GitDiffContent({
 
 	return (
 		<GitDiffContext value={ctxValue}>
-			<Flex direction="column" flex="1" minH="0" overflow="hidden">
+			<Box position="relative" flex="1" minH="0" overflow="hidden">
 				<Flex flex="1" minH="0" overflow="hidden">
 				{/* Sidebar column */}
 				<Flex
@@ -549,15 +549,20 @@ export default function GitDiffContent({
 			</Flex>
 				{reviewComments.length > 0 && (
 					<Flex
-						flexShrink={0}
+						position="absolute"
+						right="4"
+						bottom="4"
+						zIndex={3}
 						align="center"
 						justify="space-between"
 						gap="3"
-						px="4"
+						px="3"
 						py="2"
-						borderTopWidth="1px"
-						borderColor="border.subtle"
+						borderWidth="1px"
+						borderColor="border.emphasized"
+						borderRadius="md"
 						bg="bg.panel"
+						boxShadow="lg"
 					>
 						<Text fontSize="sm" color="fg.muted">
 							{reviewComments.length} queued review comment
@@ -580,7 +585,7 @@ export default function GitDiffContent({
 					onDelete={handleDeleteReviewComment}
 					onUpdate={handleUpdateReviewComment}
 				/>
-			</Flex>
+			</Box>
 		</GitDiffContext>
 	);
 }

--- a/src/features/git/components/GitDiffContent.tsx
+++ b/src/features/git/components/GitDiffContent.tsx
@@ -382,7 +382,7 @@ export default function GitDiffContent({
 
 	return (
 		<GitDiffContext value={ctxValue}>
-			<Box position="relative" flex="1" minH="0" overflow="hidden">
+			<Flex position="relative" flex="1" minH="0" overflow="hidden">
 				<Flex flex="1" minH="0" overflow="hidden">
 				{/* Sidebar column */}
 				<Flex
@@ -585,7 +585,7 @@ export default function GitDiffContent({
 					onDelete={handleDeleteReviewComment}
 					onUpdate={handleUpdateReviewComment}
 				/>
-			</Box>
+			</Flex>
 		</GitDiffContext>
 	);
 }

--- a/src/features/git/components/GitDiffContent.tsx
+++ b/src/features/git/components/GitDiffContent.tsx
@@ -1,5 +1,6 @@
-import { Box, Flex, Tabs } from "@chakra-ui/react";
+import { Box, Button, Flex, Tabs, Text } from "@chakra-ui/react";
 import type { FileDiffMetadata, FileDiffOptions } from "@pierre/diffs";
+import { FiMessageSquare } from "react-icons/fi";
 import {
 	Activity,
 	startTransition,
@@ -35,7 +36,9 @@ import {
 import { reconcileIncludedFiles, toggleIncludedFileName } from "../utils";
 import { ChangesDiffPane, ChangesSidebar } from "./GitDiffChangesPanel";
 import { HistoryDiffPane, HistorySidebar } from "./GitDiffHistoryPanel";
+import GitReviewQueueDialog from "./GitReviewQueueDialog";
 import { collectOrderedIncludedFileNames } from "./includedFileNames";
+import type { DiffReviewComment } from "../reviewQueue";
 
 const SIDEBAR_TAB_CONTENT_PROPS = {
 	position: "absolute",
@@ -95,6 +98,10 @@ export default function GitDiffContent({
 	);
 	const [commitMessage, setCommitMessage] = useState("");
 	const [commitBody, setCommitBody] = useState("");
+	const [reviewQueueOpen, setReviewQueueOpen] = useState(false);
+	const [reviewComments, setReviewComments] = useState<DiffReviewComment[]>(
+		() => [],
+	);
 	const sidebarRef = useRef<HTMLDivElement>(null);
 	const previousChangeFileNamesRef = useRef<Set<string>>(new Set());
 
@@ -129,6 +136,29 @@ export default function GitDiffContent({
 			});
 		}
 	}, [gitPush]);
+
+	const handleAddReviewComment = useCallback((comment: DiffReviewComment) => {
+		setReviewComments((comments) => [...comments, comment]);
+		toaster.create({
+			title: "Review comment queued",
+			type: "success",
+			closable: true,
+		});
+	}, []);
+
+	const handleUpdateReviewComment = useCallback((id: string, body: string) => {
+		setReviewComments((comments) =>
+			comments.map((comment) =>
+				comment.id === id ? { ...comment, body } : comment,
+			),
+		);
+	}, []);
+
+	const handleDeleteReviewComment = useCallback((id: string) => {
+		setReviewComments((comments) =>
+			comments.filter((comment) => comment.id !== id),
+		);
+	}, []);
 
 	const handleTabChange = (value: string) => {
 		startTransition(() => {
@@ -352,7 +382,8 @@ export default function GitDiffContent({
 
 	return (
 		<GitDiffContext value={ctxValue}>
-			<Flex flex="1" overflow="hidden">
+			<Flex direction="column" flex="1" minH="0" overflow="hidden">
+				<Flex flex="1" minH="0" overflow="hidden">
 				{/* Sidebar column */}
 				<Flex
 					ref={sidebarRef}
@@ -506,12 +537,49 @@ export default function GitDiffContent({
 
 				{/* Pane column — Activity preserves mounted diff state while hidden */}
 				<Activity mode={isChanges ? "visible" : "hidden"}>
-					<ChangesDiffPane visible={isChanges} />
+					<ChangesDiffPane
+						visible={isChanges}
+						onAddReviewComment={handleAddReviewComment}
+					/>
 				</Activity>
 
 				<Activity mode={!isChanges ? "visible" : "hidden"}>
 					<HistoryDiffPane visible={!isChanges} />
 				</Activity>
+			</Flex>
+				{reviewComments.length > 0 && (
+					<Flex
+						flexShrink={0}
+						align="center"
+						justify="space-between"
+						gap="3"
+						px="4"
+						py="2"
+						borderTopWidth="1px"
+						borderColor="border.subtle"
+						bg="bg.panel"
+					>
+						<Text fontSize="sm" color="fg.muted">
+							{reviewComments.length} queued review comment
+							{reviewComments.length === 1 ? "" : "s"}
+						</Text>
+						<Button
+							size="sm"
+							variant="outline"
+							onClick={() => setReviewQueueOpen(true)}
+						>
+							<FiMessageSquare />
+							Review Queue ({reviewComments.length})
+						</Button>
+					</Flex>
+				)}
+				<GitReviewQueueDialog
+					isOpen={reviewQueueOpen}
+					comments={reviewComments}
+					onClose={() => setReviewQueueOpen(false)}
+					onDelete={handleDeleteReviewComment}
+					onUpdate={handleUpdateReviewComment}
+				/>
 			</Flex>
 		</GitDiffContext>
 	);

--- a/src/features/git/components/GitDiffPane.test.tsx
+++ b/src/features/git/components/GitDiffPane.test.tsx
@@ -193,6 +193,6 @@ describe("gitDiffPane review composer", () => {
 		expect(
 			screen.getByPlaceholderText("Write a review comment..."),
 		).toBeInTheDocument();
-		expect(screen.getByText("Comment on 1-3 (additions)")).toBeInTheDocument();
+		expect(screen.getByText("Comment on 1-3")).toBeInTheDocument();
 	});
 });

--- a/src/features/git/components/GitDiffPane.test.tsx
+++ b/src/features/git/components/GitDiffPane.test.tsx
@@ -1,10 +1,18 @@
 import { ChakraProvider } from "@chakra-ui/react";
-import type { FileDiffMetadata } from "@pierre/diffs";
-import { fireEvent, render, screen } from "@testing-library/react";
+import type {
+	FileDiffMetadata,
+	FileDiffOptions,
+	SelectedLineRange,
+} from "@pierre/diffs";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { appSystem } from "@/theme/system";
 import { GIT_DIFF_LARGE_FILE_LINE_THRESHOLD } from "../utils";
 import GitDiffPane from "./GitDiffPane";
+
+const fileDiffMockState = vi.hoisted(() => ({
+	latestOptions: undefined as FileDiffOptions<unknown> | undefined,
+}));
 
 vi.mock("@/paraglide/messages.js", async () => {
 	const actual = await vi.importActual<typeof import("@/paraglide/messages.js")>(
@@ -29,9 +37,16 @@ vi.mock("@/paraglide/messages.js", async () => {
 });
 
 vi.mock("@pierre/diffs/react", () => ({
-	FileDiff: ({ fileDiff }: { fileDiff: { name: string } }) => (
-		<div data-testid="mock-file-diff">{fileDiff.name}</div>
-	),
+	FileDiff: ({
+		fileDiff,
+		options,
+	}: {
+		fileDiff: { name: string };
+		options: FileDiffOptions<unknown>;
+	}) => {
+		fileDiffMockState.latestOptions = options;
+		return <div data-testid="mock-file-diff">{fileDiff.name}</div>;
+	},
 }));
 
 function makeDiffFile(
@@ -61,6 +76,25 @@ function renderPane(activeFile: FileDiffMetadata) {
 			<GitDiffPane activeFile={activeFile} options={{}} emptyMessage="empty" />
 		</ChakraProvider>,
 	);
+}
+
+function renderReviewPane(activeFile: FileDiffMetadata) {
+	return render(
+		<ChakraProvider value={appSystem}>
+			<GitDiffPane
+				activeFile={activeFile}
+				options={{}}
+				emptyMessage="empty"
+				onAddReviewComment={vi.fn()}
+			/>
+		</ChakraProvider>,
+	);
+}
+
+function emitSelectionChange(range: SelectedLineRange | null) {
+	act(() => {
+		fileDiffMockState.latestOptions?.onLineSelectionChange?.(range);
+	});
 }
 
 function makeRenameOnlyFile(): FileDiffMetadata {
@@ -130,5 +164,22 @@ describe("gitDiffPane rename display", () => {
 		expect(screen.getByText("Current path")).toBeInTheDocument();
 		expect(screen.getByText("src/new-name.ts")).toBeInTheDocument();
 		expect(screen.queryByTestId("mock-file-diff")).not.toBeInTheDocument();
+	});
+});
+
+describe("gitDiffPane review composer", () => {
+	it("opens while a line selection is changing", () => {
+		renderReviewPane(makeDiffFile("src/review.ts", 3));
+
+		emitSelectionChange({
+			start: 1,
+			end: 3,
+			side: "additions",
+		});
+
+		expect(
+			screen.getByPlaceholderText("Write a review comment..."),
+		).toBeInTheDocument();
+		expect(screen.getByText("Comment on 1-3 (additions)")).toBeInTheDocument();
 	});
 });

--- a/src/features/git/components/GitDiffPane.test.tsx
+++ b/src/features/git/components/GitDiffPane.test.tsx
@@ -97,6 +97,12 @@ function emitSelectionChange(range: SelectedLineRange | null) {
 	});
 }
 
+function emitSelectionEnd(range: SelectedLineRange | null) {
+	act(() => {
+		fileDiffMockState.latestOptions?.onLineSelectionEnd?.(range);
+	});
+}
+
 function makeRenameOnlyFile(): FileDiffMetadata {
 	return {
 		name: "src/new-name.ts",
@@ -168,14 +174,21 @@ describe("gitDiffPane rename display", () => {
 });
 
 describe("gitDiffPane review composer", () => {
-	it("opens while a line selection is changing", () => {
+	it("waits until a line selection is committed before opening", () => {
 		renderReviewPane(makeDiffFile("src/review.ts", 3));
-
-		emitSelectionChange({
+		const selection = {
 			start: 1,
 			end: 3,
 			side: "additions",
-		});
+		} satisfies SelectedLineRange;
+
+		emitSelectionChange(selection);
+
+		expect(
+			screen.queryByPlaceholderText("Write a review comment..."),
+		).not.toBeInTheDocument();
+
+		emitSelectionEnd(selection);
 
 		expect(
 			screen.getByPlaceholderText("Write a review comment..."),

--- a/src/features/git/components/GitDiffPane.tsx
+++ b/src/features/git/components/GitDiffPane.tsx
@@ -263,18 +263,21 @@ function ActiveGitDiffFilePane({
 							bottom="3"
 							right="3"
 							zIndex={2}
-							w="min(24rem, calc(100% - 1.5rem))"
-							borderWidth="1px"
-							borderColor="border.emphasized"
-							borderRadius="md"
-							bg="bg.panel"
-							boxShadow="lg"
-							p="2"
 							mr="3"
 							mb="3"
 						>
 							{isCommentInputOpen ? (
-								<Flex gap="2" align="start">
+								<Flex
+									w="min(24rem, calc(100% - 1.5rem))"
+									gap="2"
+									align="start"
+									borderWidth="1px"
+									borderColor="border.emphasized"
+									borderRadius="lg"
+									bg="bg.panel"
+									boxShadow="xl"
+									p="2"
+								>
 									<Textarea
 										value={commentBody}
 										placeholder={`Comment on ${formatReviewRange(selectedLines)}`}
@@ -308,13 +311,16 @@ function ActiveGitDiffFilePane({
 									</IconButton>
 								</Flex>
 							) : (
-								<Button
+								<IconButton
 									size="sm"
+									aria-label={`Comment on ${formatReviewRange(selectedLines)}`}
+									borderRadius="full"
+									boxShadow="lg"
+									colorPalette="blue"
 									onClick={() => setIsCommentInputOpen(true)}
 								>
 									<FiMessageSquare />
-									Comment on {formatReviewRange(selectedLines)}
-								</Button>
+								</IconButton>
 							)}
 						</Box>
 					)}

--- a/src/features/git/components/GitDiffPane.tsx
+++ b/src/features/git/components/GitDiffPane.tsx
@@ -4,14 +4,18 @@ import {
 	Button,
 	Flex,
 	HStack,
+	IconButton,
+	Textarea,
 	Text,
 } from "@chakra-ui/react";
 import type {
 	FileDiffMetadata,
 	FileDiffOptions,
+	SelectedLineRange,
 } from "@pierre/diffs";
 import { FileDiff } from "@pierre/diffs/react";
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
+import { FiMessageSquare, FiPlus, FiX } from "react-icons/fi";
 import * as m from "@/paraglide/messages.js";
 import { useTerminalSettingsStore } from "@/features/settings/stores/terminalSettingsStore";
 import {
@@ -20,6 +24,11 @@ import {
 	getLineStats,
 	isBinaryImageDiffPreviewable,
 } from "../utils";
+import {
+	createReviewComment,
+	type DiffReviewComment,
+	formatReviewRange,
+} from "../reviewQueue";
 import { BinaryImageDiffPreview, type GitPreviewContext } from "./GitBinaryPreview";
 
 export type { GitPreviewContext };
@@ -164,13 +173,19 @@ function ActiveGitDiffFilePane({
 	previewContext,
 	isLargeDiffExpanded,
 	onRevealLargeDiff,
+	onAddReviewComment,
 }: {
 	activeFile: FileDiffMetadata;
 	options: FileDiffOptions<unknown>;
 	previewContext?: GitPreviewContext;
 	isLargeDiffExpanded: boolean;
 	onRevealLargeDiff: () => void;
+	onAddReviewComment?: (comment: DiffReviewComment) => void;
 }) {
+	const [selectedLines, setSelectedLines] =
+		useState<SelectedLineRange | null>(null);
+	const [commentBody, setCommentBody] = useState("");
+	const [isCommentInputOpen, setIsCommentInputOpen] = useState(false);
 	const { additions, deletions } = useMemo(
 		() => getLineStats(activeFile),
 		[activeFile],
@@ -183,6 +198,33 @@ function ActiveGitDiffFilePane({
 		changedLineCount >= GIT_DIFF_LARGE_FILE_LINE_THRESHOLD &&
 		!isLargeDiffExpanded;
 	const showRenameOnlyDiff = activeFile.type === "rename-pure";
+	const canReviewDiff =
+		onAddReviewComment != null &&
+		!showBinaryPreview &&
+		!showLargeDiffGuardrail &&
+		!showRenameOnlyDiff;
+	const interactiveOptions = useMemo<FileDiffOptions<unknown>>(
+		() => ({
+			...options,
+			enableLineSelection: canReviewDiff,
+			onLineSelectionEnd: (range) => {
+				setSelectedLines(range);
+				setIsCommentInputOpen(range != null);
+				options.onLineSelectionEnd?.(range);
+			},
+		}),
+		[canReviewDiff, options],
+	);
+	const handleAddReviewComment = useCallback(() => {
+		if (!selectedLines || !commentBody.trim() || !onAddReviewComment) return;
+
+		onAddReviewComment(
+			createReviewComment(activeFile, selectedLines, commentBody.trim()),
+		);
+		setCommentBody("");
+		setIsCommentInputOpen(false);
+		setSelectedLines(null);
+	}, [activeFile, commentBody, onAddReviewComment, selectedLines]);
 
 	return (
 		<>
@@ -201,10 +243,75 @@ function ActiveGitDiffFilePane({
 					onReveal={onRevealLargeDiff}
 				/>
 			) : (
-				<FileDiff
-					fileDiff={activeFile}
-					options={options}
-				/>
+				<Box position="relative">
+					<FileDiff
+						fileDiff={activeFile}
+						options={interactiveOptions}
+						selectedLines={selectedLines}
+					/>
+					{canReviewDiff && selectedLines && (
+						<Box
+							position="sticky"
+							float="right"
+							bottom="3"
+							right="3"
+							zIndex={2}
+							w="min(24rem, calc(100% - 1.5rem))"
+							borderWidth="1px"
+							borderColor="border.emphasized"
+							borderRadius="md"
+							bg="bg.panel"
+							boxShadow="lg"
+							p="2"
+							mr="3"
+							mb="3"
+						>
+							{isCommentInputOpen ? (
+								<Flex gap="2" align="start">
+									<Textarea
+										value={commentBody}
+										placeholder={`Comment on ${formatReviewRange(selectedLines)}`}
+										autoresize
+										minH="2.25rem"
+										maxH="8rem"
+										fontSize="sm"
+										onChange={(event) =>
+											setCommentBody(event.target.value)
+										}
+									/>
+									<IconButton
+										aria-label="Add review comment"
+										size="sm"
+										disabled={!commentBody.trim()}
+										onClick={handleAddReviewComment}
+									>
+										<FiPlus />
+									</IconButton>
+									<IconButton
+										aria-label="Cancel review comment"
+										size="sm"
+										variant="ghost"
+										onClick={() => {
+											setCommentBody("");
+											setIsCommentInputOpen(false);
+											setSelectedLines(null);
+										}}
+									>
+										<FiX />
+									</IconButton>
+								</Flex>
+							) : (
+								<Button
+									size="sm"
+									onClick={() => setIsCommentInputOpen(true)}
+								>
+									<FiMessageSquare />
+									Comment on {formatReviewRange(selectedLines)}
+								</Button>
+							)}
+						</Box>
+					)}
+				</Box>
 			)}
 		</>
 	);
@@ -228,6 +335,7 @@ interface GitDiffPaneProps {
 	emptyMessage: string;
 	contextKey?: string;
 	previewContext?: GitPreviewContext;
+	onAddReviewComment?: (comment: DiffReviewComment) => void;
 }
 
 export default function GitDiffPane({
@@ -236,6 +344,7 @@ export default function GitDiffPane({
 	emptyMessage,
 	contextKey = "default",
 	previewContext,
+	onAddReviewComment,
 }: GitDiffPaneProps) {
 	const fontFamily = useTerminalSettingsStore((s) => s.fontFamily);
 	const fontSize = useTerminalSettingsStore((s) => s.fontSize);
@@ -263,6 +372,7 @@ export default function GitDiffPane({
 					options={options}
 					previewContext={previewContext}
 					isLargeDiffExpanded={expandedLargeDiffFileKeys.has(activeFileKey)}
+					onAddReviewComment={onAddReviewComment}
 					onRevealLargeDiff={() =>
 						setExpandedLargeDiffFileKeys((prev) => {
 							const next = new Set(prev);

--- a/src/features/git/components/GitDiffPane.tsx
+++ b/src/features/git/components/GitDiffPane.tsx
@@ -249,6 +249,7 @@ function ActiveGitDiffFilePane({
 	);
 	const diffContentRef = useRef<HTMLDivElement>(null);
 	const commentComposerRef = useRef<HTMLDivElement>(null);
+	const pendingSelectionRef = useRef<SelectedLineRange | null>(null);
 	const { additions, deletions } = useMemo(
 		() => getLineStats(activeFile),
 		[activeFile],
@@ -356,21 +357,26 @@ function ActiveGitDiffFilePane({
 	);
 	const openCommentComposerFromSelection = useCallback(
 		(range: SelectedLineRange | null) => {
+			pendingSelectionRef.current = null;
 			setSelectedLines(range);
 			syncCommentAnchorFromSelection(range);
 			setIsCommentInputOpen(range != null);
 		},
 		[syncCommentAnchorFromSelection],
 	);
-	const syncOpenCommentComposerFromSelection = useCallback(
+	const syncPendingSelection = useCallback(
 		(range: SelectedLineRange | null) => {
+			pendingSelectionRef.current = range;
 			setSelectedLines(range);
 			syncCommentAnchorFromSelection(range);
-			if (range) {
-				setIsCommentInputOpen(true);
-			}
 		},
 		[syncCommentAnchorFromSelection],
+	);
+	const openCommentComposerOnSelectionCommit = useCallback(
+		(range: SelectedLineRange | null) => {
+			openCommentComposerFromSelection(range ?? pendingSelectionRef.current);
+		},
+		[openCommentComposerFromSelection],
 	);
 	useEffect(() => {
 		const anchorElement = commentAnchor;
@@ -398,28 +404,28 @@ function ActiveGitDiffFilePane({
 				options.onLineNumberClick?.(lineEvent);
 			},
 			onLineSelectionStart: (range) => {
-				syncOpenCommentComposerFromSelection(range);
+				syncPendingSelection(range);
 				options.onLineSelectionStart?.(range);
 			},
 			onLineSelectionChange: (range) => {
-				syncOpenCommentComposerFromSelection(range);
+				syncPendingSelection(range);
 				options.onLineSelectionChange?.(range);
 			},
 			onLineSelectionEnd: (range) => {
-				openCommentComposerFromSelection(range);
+				openCommentComposerOnSelectionCommit(range);
 				options.onLineSelectionEnd?.(range);
 			},
 			onLineSelected: (range) => {
-				openCommentComposerFromSelection(range);
+				openCommentComposerOnSelectionCommit(range);
 				options.onLineSelected?.(range);
 			},
 		}),
 		[
 			canReviewDiff,
 			openCommentComposer,
-			openCommentComposerFromSelection,
+			openCommentComposerOnSelectionCommit,
 			options,
-			syncOpenCommentComposerFromSelection,
+			syncPendingSelection,
 		],
 	);
 	const handleAddReviewComment = useCallback(() => {

--- a/src/features/git/components/GitDiffPane.tsx
+++ b/src/features/git/components/GitDiffPane.tsx
@@ -215,6 +215,16 @@ function getElementsVirtualReference(
 	};
 }
 
+function queryDiffElements(root: ParentNode, selector: string): HTMLElement[] {
+	const elements = Array.from(root.querySelectorAll<HTMLElement>(selector));
+	for (const host of root.querySelectorAll<HTMLElement>("*")) {
+		if (host.shadowRoot) {
+			elements.push(...queryDiffElements(host.shadowRoot, selector));
+		}
+	}
+	return elements;
+}
+
 function ActiveGitDiffFilePane({
 	activeFile,
 	options,
@@ -262,8 +272,9 @@ function ActiveGitDiffFilePane({
 			if (lineElement) return lineElement;
 			if (!diffContent) return null;
 
-			const selectedElements = Array.from(
-				diffContent.querySelectorAll<HTMLElement>("[data-selected-line]"),
+			const selectedElements = queryDiffElements(
+				diffContent,
+				"[data-selected-line]",
 			);
 			const selectedReference =
 				getElementsVirtualReference(selectedElements);
@@ -271,22 +282,23 @@ function ActiveGitDiffFilePane({
 
 			const start = Math.min(range.start, range.end);
 			const end = Math.max(range.start, range.end);
-			const fallbackElements = Array.from(
-				diffContent.querySelectorAll<HTMLElement>(
-					[
-						`[data-column-number="${start}"]`,
-						`[data-column-number="${end}"]`,
-						`[data-line="${start}"]`,
-						`[data-line="${end}"]`,
-					].join(", "),
-				),
+			const fallbackElements = queryDiffElements(
+				diffContent,
+				[
+					`[data-column-number="${start}"]`,
+					`[data-column-number="${end}"]`,
+					`[data-line="${start}"]`,
+					`[data-line="${end}"]`,
+				].join(", "),
 			);
 
 			return (
 				getElementsVirtualReference(fallbackElements) ??
-				diffContent.querySelector<HTMLElement>(
+				queryDiffElements(
+					diffContent,
 					`[data-line-index="${start}"], [data-line-index="${end}"]`,
-				)
+				)[0] ??
+				null
 			);
 		},
 		[],
@@ -350,6 +362,16 @@ function ActiveGitDiffFilePane({
 		},
 		[syncCommentAnchorFromSelection],
 	);
+	const syncOpenCommentComposerFromSelection = useCallback(
+		(range: SelectedLineRange | null) => {
+			setSelectedLines(range);
+			syncCommentAnchorFromSelection(range);
+			if (range) {
+				setIsCommentInputOpen(true);
+			}
+		},
+		[syncCommentAnchorFromSelection],
+	);
 	useEffect(() => {
 		const anchorElement = commentAnchor;
 		const composerElement = commentComposerRef.current;
@@ -375,9 +397,12 @@ function ActiveGitDiffFilePane({
 				}
 				options.onLineNumberClick?.(lineEvent);
 			},
+			onLineSelectionStart: (range) => {
+				syncOpenCommentComposerFromSelection(range);
+				options.onLineSelectionStart?.(range);
+			},
 			onLineSelectionChange: (range) => {
-				setSelectedLines(range);
-				syncCommentAnchorFromSelection(range);
+				syncOpenCommentComposerFromSelection(range);
 				options.onLineSelectionChange?.(range);
 			},
 			onLineSelectionEnd: (range) => {
@@ -394,7 +419,7 @@ function ActiveGitDiffFilePane({
 			openCommentComposer,
 			openCommentComposerFromSelection,
 			options,
-			syncCommentAnchorFromSelection,
+			syncOpenCommentComposerFromSelection,
 		],
 	);
 	const handleAddReviewComment = useCallback(() => {

--- a/src/features/git/components/GitDiffPane.tsx
+++ b/src/features/git/components/GitDiffPane.tsx
@@ -17,6 +17,7 @@ import {
 	Textarea,
 	Text,
 } from "@chakra-ui/react";
+import type { ButtonProps } from "@chakra-ui/react";
 import type {
 	FileDiffMetadata,
 	FileDiffOptions,
@@ -41,6 +42,9 @@ import {
 import { BinaryImageDiffPreview, type GitPreviewContext } from "./GitBinaryPreview";
 
 export type { GitPreviewContext };
+
+const SECONDARY_BUTTON_VARIANT =
+	"secondary" as unknown as NonNullable<ButtonProps["variant"]>;
 
 function FileDiffHeader({
 	file,
@@ -537,7 +541,7 @@ function ActiveGitDiffFilePane({
 								>
 									<Button
 										size="xs"
-										colorPalette="blue"
+										variant={SECONDARY_BUTTON_VARIANT}
 										disabled={!commentBody.trim()}
 										onClick={handleAddReviewComment}
 									>

--- a/src/features/git/components/GitDiffPane.tsx
+++ b/src/features/git/components/GitDiffPane.tsx
@@ -15,7 +15,7 @@ import type {
 } from "@pierre/diffs";
 import { FileDiff } from "@pierre/diffs/react";
 import { useCallback, useMemo, useState } from "react";
-import { FiMessageSquare, FiPlus, FiX } from "react-icons/fi";
+import { FiPlus, FiX } from "react-icons/fi";
 import * as m from "@/paraglide/messages.js";
 import { useTerminalSettingsStore } from "@/features/settings/stores/terminalSettingsStore";
 import {
@@ -210,13 +210,13 @@ function ActiveGitDiffFilePane({
 			enableGutterUtility: canReviewDiff,
 			lineHoverHighlight: canReviewDiff ? "both" : options.lineHoverHighlight,
 			onGutterUtilityClick: (range) => {
-				setSelectedLines(range);
+				setSelectedLines((currentRange) => currentRange ?? range);
 				setIsCommentInputOpen(true);
 				options.onGutterUtilityClick?.(range);
 			},
 			onLineSelectionEnd: (range) => {
 				setSelectedLines(range);
-				setIsCommentInputOpen(range != null);
+				setIsCommentInputOpen(false);
 				options.onLineSelectionEnd?.(range);
 			},
 		}),
@@ -256,7 +256,7 @@ function ActiveGitDiffFilePane({
 						options={interactiveOptions}
 						selectedLines={selectedLines}
 					/>
-					{canReviewDiff && selectedLines && (
+					{canReviewDiff && selectedLines && isCommentInputOpen && (
 						<Box
 							position="sticky"
 							float="right"
@@ -266,62 +266,49 @@ function ActiveGitDiffFilePane({
 							mr="3"
 							mb="3"
 						>
-							{isCommentInputOpen ? (
-								<Flex
-									w="min(24rem, calc(100% - 1.5rem))"
-									gap="2"
-									align="start"
-									borderWidth="1px"
-									borderColor="border.emphasized"
-									borderRadius="lg"
-									bg="bg.panel"
-									boxShadow="xl"
-									p="2"
-								>
-									<Textarea
-										value={commentBody}
-										placeholder={`Comment on ${formatReviewRange(selectedLines)}`}
-										autoresize
-										minH="2.25rem"
-										maxH="8rem"
-										fontSize="sm"
-										onChange={(event) =>
-											setCommentBody(event.target.value)
-										}
-									/>
-									<IconButton
-										aria-label="Add review comment"
-										size="sm"
-										disabled={!commentBody.trim()}
-										onClick={handleAddReviewComment}
-									>
-										<FiPlus />
-									</IconButton>
-									<IconButton
-										aria-label="Cancel review comment"
-										size="sm"
-										variant="ghost"
-										onClick={() => {
-											setCommentBody("");
-											setIsCommentInputOpen(false);
-											setSelectedLines(null);
-										}}
-									>
-										<FiX />
-									</IconButton>
-								</Flex>
-							) : (
+							<Flex
+								w="min(24rem, calc(100% - 1.5rem))"
+								gap="2"
+								align="start"
+								borderWidth="1px"
+								borderColor="border.emphasized"
+								borderRadius="lg"
+								bg="bg.panel"
+								boxShadow="xl"
+								p="2"
+							>
+								<Textarea
+									value={commentBody}
+									placeholder={`Comment on ${formatReviewRange(selectedLines)}`}
+									autoresize
+									minH="2.25rem"
+									maxH="8rem"
+									fontSize="sm"
+									onChange={(event) =>
+										setCommentBody(event.target.value)
+									}
+								/>
 								<IconButton
+									aria-label="Add review comment"
 									size="sm"
-									aria-label={`Comment on ${formatReviewRange(selectedLines)}`}
-									borderRadius="full"
-									boxShadow="lg"
-									colorPalette="blue"
-									onClick={() => setIsCommentInputOpen(true)}
+									disabled={!commentBody.trim()}
+									onClick={handleAddReviewComment}
 								>
-									<FiMessageSquare />
+									<FiPlus />
 								</IconButton>
-							)}
+								<IconButton
+									aria-label="Cancel review comment"
+									size="sm"
+									variant="ghost"
+									onClick={() => {
+										setCommentBody("");
+										setIsCommentInputOpen(false);
+										setSelectedLines(null);
+									}}
+								>
+									<FiX />
+								</IconButton>
+							</Flex>
 						</Box>
 					)}
 				</Box>

--- a/src/features/git/components/GitDiffPane.tsx
+++ b/src/features/git/components/GitDiffPane.tsx
@@ -207,6 +207,13 @@ function ActiveGitDiffFilePane({
 		() => ({
 			...options,
 			enableLineSelection: canReviewDiff,
+			enableGutterUtility: canReviewDiff,
+			lineHoverHighlight: canReviewDiff ? "both" : options.lineHoverHighlight,
+			onGutterUtilityClick: (range) => {
+				setSelectedLines(range);
+				setIsCommentInputOpen(true);
+				options.onGutterUtilityClick?.(range);
+			},
 			onLineSelectionEnd: (range) => {
 				setSelectedLines(range);
 				setIsCommentInputOpen(range != null);

--- a/src/features/git/components/GitDiffPane.tsx
+++ b/src/features/git/components/GitDiffPane.tsx
@@ -17,7 +17,6 @@ import {
 	Textarea,
 	Text,
 } from "@chakra-ui/react";
-import type { ButtonProps } from "@chakra-ui/react";
 import type {
 	FileDiffMetadata,
 	FileDiffOptions,
@@ -28,6 +27,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { FiPlus, FiX } from "react-icons/fi";
 import * as m from "@/paraglide/messages.js";
 import { useTerminalSettingsStore } from "@/features/settings/stores/terminalSettingsStore";
+import { SECONDARY_BUTTON_VARIANT } from "@/theme/buttonVariants";
 import {
 	changeBadge,
 	GIT_DIFF_LARGE_FILE_LINE_THRESHOLD,
@@ -42,9 +42,6 @@ import {
 import { BinaryImageDiffPreview, type GitPreviewContext } from "./GitBinaryPreview";
 
 export type { GitPreviewContext };
-
-const SECONDARY_BUTTON_VARIANT =
-	"secondary" as unknown as NonNullable<ButtonProps["variant"]>;
 
 function FileDiffHeader({
 	file,

--- a/src/features/git/components/GitDiffPane.tsx
+++ b/src/features/git/components/GitDiffPane.tsx
@@ -207,7 +207,7 @@ function ActiveGitDiffFilePane({
 		() => ({
 			...options,
 			enableLineSelection: canReviewDiff,
-			enableGutterUtility: canReviewDiff,
+			enableGutterUtility: false,
 			lineHoverHighlight: canReviewDiff ? "both" : options.lineHoverHighlight,
 			onLineNumberClick: (lineEvent) => {
 				if (canReviewDiff) {
@@ -216,19 +216,23 @@ function ActiveGitDiffFilePane({
 						end: lineEvent.lineNumber,
 						side: lineEvent.annotationSide,
 					});
+					setIsCommentInputOpen(true);
 				}
 				options.onLineNumberClick?.(lineEvent);
 			},
 			onLineSelectionChange: (range) => {
 				setSelectedLines(range);
+				setIsCommentInputOpen(range != null);
 				options.onLineSelectionChange?.(range);
 			},
 			onLineSelectionEnd: (range) => {
 				setSelectedLines(range);
+				setIsCommentInputOpen(range != null);
 				options.onLineSelectionEnd?.(range);
 			},
 			onLineSelected: (range) => {
 				setSelectedLines(range);
+				setIsCommentInputOpen(range != null);
 				options.onLineSelected?.(range);
 			},
 		}),
@@ -267,37 +271,6 @@ function ActiveGitDiffFilePane({
 						fileDiff={activeFile}
 						options={interactiveOptions}
 						selectedLines={selectedLines}
-						renderGutterUtility={(getHoveredLine) => {
-							const hoveredLine = getHoveredLine();
-							const range =
-								selectedLines ??
-								(hoveredLine
-									? {
-											start: hoveredLine.lineNumber,
-											end: hoveredLine.lineNumber,
-											side: hoveredLine.side,
-										}
-									: null);
-
-							if (!range) return null;
-
-							return (
-								<IconButton
-									aria-label={`Comment on ${formatReviewRange(range)}`}
-									size="2xs"
-									variant="solid"
-									colorPalette="blue"
-									onClick={(event) => {
-										event.preventDefault();
-										event.stopPropagation();
-										setSelectedLines(range);
-										setIsCommentInputOpen(true);
-									}}
-								>
-									<FiPlus />
-								</IconButton>
-							);
-						}}
 					/>
 					{canReviewDiff && selectedLines && isCommentInputOpen && (
 						<Box

--- a/src/features/git/components/GitDiffPane.tsx
+++ b/src/features/git/components/GitDiffPane.tsx
@@ -14,7 +14,7 @@ import type {
 	SelectedLineRange,
 } from "@pierre/diffs";
 import { FileDiff } from "@pierre/diffs/react";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { FiPlus, FiX } from "react-icons/fi";
 import * as m from "@/paraglide/messages.js";
 import { useTerminalSettingsStore } from "@/features/settings/stores/terminalSettingsStore";
@@ -186,6 +186,8 @@ function ActiveGitDiffFilePane({
 		useState<SelectedLineRange | null>(null);
 	const [commentBody, setCommentBody] = useState("");
 	const [isCommentInputOpen, setIsCommentInputOpen] = useState(false);
+	const [commentComposerTop, setCommentComposerTop] = useState(0);
+	const diffContentRef = useRef<HTMLDivElement>(null);
 	const { additions, deletions } = useMemo(
 		() => getLineStats(activeFile),
 		[activeFile],
@@ -203,6 +205,34 @@ function ActiveGitDiffFilePane({
 		!showBinaryPreview &&
 		!showLargeDiffGuardrail &&
 		!showRenameOnlyDiff;
+	const updateCommentComposerAnchor = useCallback(
+		(range: SelectedLineRange, lineElement?: HTMLElement) => {
+			const diffContent = diffContentRef.current;
+			if (!diffContent) return;
+
+			const line =
+				lineElement ??
+				diffContent.querySelector<HTMLElement>(
+					`[data-line="${Math.min(range.start, range.end)}"]`,
+				);
+			if (!line) return;
+
+			const containerRect = diffContent.getBoundingClientRect();
+			const lineRect = line.getBoundingClientRect();
+			setCommentComposerTop(
+				Math.max(12, lineRect.top - containerRect.top + diffContent.scrollTop),
+			);
+		},
+		[],
+	);
+	const openCommentComposer = useCallback(
+		(range: SelectedLineRange, lineElement?: HTMLElement) => {
+			setSelectedLines(range);
+			updateCommentComposerAnchor(range, lineElement);
+			setIsCommentInputOpen(true);
+		},
+		[updateCommentComposerAnchor],
+	);
 	const interactiveOptions = useMemo<FileDiffOptions<unknown>>(
 		() => ({
 			...options,
@@ -211,32 +241,34 @@ function ActiveGitDiffFilePane({
 			lineHoverHighlight: canReviewDiff ? "both" : options.lineHoverHighlight,
 			onLineNumberClick: (lineEvent) => {
 				if (canReviewDiff) {
-					setSelectedLines({
+					openCommentComposer({
 						start: lineEvent.lineNumber,
 						end: lineEvent.lineNumber,
 						side: lineEvent.annotationSide,
-					});
-					setIsCommentInputOpen(true);
+					}, lineEvent.lineElement);
 				}
 				options.onLineNumberClick?.(lineEvent);
 			},
 			onLineSelectionChange: (range) => {
 				setSelectedLines(range);
+				if (range) updateCommentComposerAnchor(range);
 				setIsCommentInputOpen(range != null);
 				options.onLineSelectionChange?.(range);
 			},
 			onLineSelectionEnd: (range) => {
 				setSelectedLines(range);
+				if (range) updateCommentComposerAnchor(range);
 				setIsCommentInputOpen(range != null);
 				options.onLineSelectionEnd?.(range);
 			},
 			onLineSelected: (range) => {
 				setSelectedLines(range);
+				if (range) updateCommentComposerAnchor(range);
 				setIsCommentInputOpen(range != null);
 				options.onLineSelected?.(range);
 			},
 		}),
-		[canReviewDiff, options],
+		[canReviewDiff, openCommentComposer, options, updateCommentComposerAnchor],
 	);
 	const handleAddReviewComment = useCallback(() => {
 		if (!selectedLines || !commentBody.trim() || !onAddReviewComment) return;
@@ -266,7 +298,7 @@ function ActiveGitDiffFilePane({
 					onReveal={onRevealLargeDiff}
 				/>
 			) : (
-				<Box position="relative">
+				<Box ref={diffContentRef} position="relative">
 					<FileDiff
 						fileDiff={activeFile}
 						options={interactiveOptions}
@@ -274,19 +306,14 @@ function ActiveGitDiffFilePane({
 					/>
 					{canReviewDiff && selectedLines && isCommentInputOpen && (
 						<Box
-							position="sticky"
-							bottom="3"
-							right="3"
+							position="absolute"
+							top={`${commentComposerTop}px`}
+							right="4"
 							zIndex={2}
-							display="flex"
-							justifyContent="flex-end"
-							px="3"
-							pb="3"
-							mt="-1"
 							pointerEvents="none"
 						>
 							<Box
-								w="min(28rem, 100%)"
+								w="min(28rem, calc(100% - 2rem))"
 								borderWidth="1px"
 								borderColor="border.emphasized"
 								borderRadius="lg"

--- a/src/features/git/components/GitDiffPane.tsx
+++ b/src/features/git/components/GitDiffPane.tsx
@@ -275,56 +275,93 @@ function ActiveGitDiffFilePane({
 					{canReviewDiff && selectedLines && isCommentInputOpen && (
 						<Box
 							position="sticky"
-							float="right"
 							bottom="3"
 							right="3"
 							zIndex={2}
-							mr="3"
-							mb="3"
+							display="flex"
+							justifyContent="flex-end"
+							px="3"
+							pb="3"
+							mt="-1"
+							pointerEvents="none"
 						>
-							<Flex
-								w="min(24rem, calc(100% - 1.5rem))"
-								gap="2"
-								align="start"
+							<Box
+								w="min(28rem, 100%)"
 								borderWidth="1px"
 								borderColor="border.emphasized"
 								borderRadius="lg"
 								bg="bg.panel"
 								boxShadow="xl"
-								p="2"
+								overflow="hidden"
+								pointerEvents="auto"
 							>
+								<HStack
+									px="3"
+									py="2"
+									borderBottomWidth="1px"
+									borderColor="border.subtle"
+									justify="space-between"
+									gap="3"
+								>
+									<Text
+										fontSize="xs"
+										fontWeight="semibold"
+										color="fg.muted"
+										truncate
+									>
+										Comment on{" "}
+										{formatReviewRange(selectedLines)}
+									</Text>
+									<IconButton
+										aria-label="Cancel review comment"
+										size="2xs"
+										variant="ghost"
+										onClick={() => {
+											setCommentBody("");
+											setIsCommentInputOpen(false);
+											setSelectedLines(null);
+										}}
+									>
+										<FiX />
+									</IconButton>
+								</HStack>
 								<Textarea
 									value={commentBody}
-									placeholder={`Comment on ${formatReviewRange(selectedLines)}`}
+									placeholder="Write a review comment..."
 									autoresize
-									minH="2.25rem"
-									maxH="8rem"
+									minH="5.5rem"
+									maxH="10rem"
 									fontSize="sm"
+									borderWidth="0"
+									borderRadius="0"
+									resize="none"
+									_focusVisible={{
+										outline: "none",
+										boxShadow: "none",
+									}}
 									onChange={(event) =>
 										setCommentBody(event.target.value)
 									}
 								/>
-								<IconButton
-									aria-label="Add review comment"
-									size="sm"
-									disabled={!commentBody.trim()}
-									onClick={handleAddReviewComment}
+								<Flex
+									px="3"
+									py="2"
+									borderTopWidth="1px"
+									borderColor="border.subtle"
+									bg="bg.subtle"
+									justify="flex-end"
 								>
-									<FiPlus />
-								</IconButton>
-								<IconButton
-									aria-label="Cancel review comment"
-									size="sm"
-									variant="ghost"
-									onClick={() => {
-										setCommentBody("");
-										setIsCommentInputOpen(false);
-										setSelectedLines(null);
-									}}
-								>
-									<FiX />
-								</IconButton>
-							</Flex>
+									<Button
+										size="xs"
+										colorPalette="blue"
+										disabled={!commentBody.trim()}
+										onClick={handleAddReviewComment}
+									>
+										<FiPlus />
+										Add to queue
+									</Button>
+								</Flex>
+							</Box>
 						</Box>
 					)}
 				</Box>

--- a/src/features/git/components/GitDiffPane.tsx
+++ b/src/features/git/components/GitDiffPane.tsx
@@ -1,4 +1,13 @@
 import {
+	autoUpdate,
+	computePosition,
+	flip,
+	offset,
+	shift,
+	size,
+} from "@floating-ui/dom";
+import type { Strategy } from "@floating-ui/dom";
+import {
 	Badge,
 	Box,
 	Button,
@@ -14,7 +23,7 @@ import type {
 	SelectedLineRange,
 } from "@pierre/diffs";
 import { FileDiff } from "@pierre/diffs/react";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { FiPlus, FiX } from "react-icons/fi";
 import * as m from "@/paraglide/messages.js";
 import { useTerminalSettingsStore } from "@/features/settings/stores/terminalSettingsStore";
@@ -186,8 +195,10 @@ function ActiveGitDiffFilePane({
 		useState<SelectedLineRange | null>(null);
 	const [commentBody, setCommentBody] = useState("");
 	const [isCommentInputOpen, setIsCommentInputOpen] = useState(false);
-	const [commentComposerTop, setCommentComposerTop] = useState(0);
+	const [commentAnchorElement, setCommentAnchorElement] =
+		useState<HTMLElement | null>(null);
 	const diffContentRef = useRef<HTMLDivElement>(null);
+	const commentComposerRef = useRef<HTMLDivElement>(null);
 	const { additions, deletions } = useMemo(
 		() => getLineStats(activeFile),
 		[activeFile],
@@ -205,34 +216,63 @@ function ActiveGitDiffFilePane({
 		!showBinaryPreview &&
 		!showLargeDiffGuardrail &&
 		!showRenameOnlyDiff;
-	const updateCommentComposerAnchor = useCallback(
+	const getCommentAnchorElement = useCallback(
 		(range: SelectedLineRange, lineElement?: HTMLElement) => {
-			const diffContent = diffContentRef.current;
-			if (!diffContent) return;
-
-			const line =
+			return (
 				lineElement ??
-				diffContent.querySelector<HTMLElement>(
+				diffContentRef.current?.querySelector<HTMLElement>(
 					`[data-line="${Math.min(range.start, range.end)}"]`,
-				);
-			if (!line) return;
-
-			const containerRect = diffContent.getBoundingClientRect();
-			const lineRect = line.getBoundingClientRect();
-			setCommentComposerTop(
-				Math.max(12, lineRect.top - containerRect.top + diffContent.scrollTop),
+				) ??
+				null
 			);
 		},
 		[],
 	);
+	const updateFloatingComposer = useCallback(() => {
+		const anchorElement = commentAnchorElement;
+		const composerElement = commentComposerRef.current;
+		if (!anchorElement || !composerElement) return;
+
+		void computePosition(anchorElement, composerElement, {
+			placement: "right-start",
+			strategy: "fixed" satisfies Strategy,
+			middleware: [
+				offset(12),
+				flip({
+					fallbackPlacements: ["left-start", "bottom-start", "top-start"],
+				}),
+				shift({ padding: 12 }),
+				size({
+					padding: 12,
+					apply({ availableWidth, elements }) {
+						Object.assign(elements.floating.style, {
+							maxWidth: `${Math.min(448, availableWidth)}px`,
+						});
+					},
+				}),
+			],
+		}).then(({ x, y }) => {
+			Object.assign(composerElement.style, {
+				left: `${x}px`,
+				top: `${y}px`,
+			});
+		});
+	}, [commentAnchorElement]);
 	const openCommentComposer = useCallback(
 		(range: SelectedLineRange, lineElement?: HTMLElement) => {
 			setSelectedLines(range);
-			updateCommentComposerAnchor(range, lineElement);
+			setCommentAnchorElement(getCommentAnchorElement(range, lineElement));
 			setIsCommentInputOpen(true);
 		},
-		[updateCommentComposerAnchor],
+		[getCommentAnchorElement],
 	);
+	useEffect(() => {
+		const anchorElement = commentAnchorElement;
+		const composerElement = commentComposerRef.current;
+		if (!isCommentInputOpen || !anchorElement || !composerElement) return;
+
+		return autoUpdate(anchorElement, composerElement, updateFloatingComposer);
+	}, [commentAnchorElement, isCommentInputOpen, updateFloatingComposer]);
 	const interactiveOptions = useMemo<FileDiffOptions<unknown>>(
 		() => ({
 			...options,
@@ -251,24 +291,24 @@ function ActiveGitDiffFilePane({
 			},
 			onLineSelectionChange: (range) => {
 				setSelectedLines(range);
-				if (range) updateCommentComposerAnchor(range);
+				setCommentAnchorElement(range ? getCommentAnchorElement(range) : null);
 				setIsCommentInputOpen(range != null);
 				options.onLineSelectionChange?.(range);
 			},
 			onLineSelectionEnd: (range) => {
 				setSelectedLines(range);
-				if (range) updateCommentComposerAnchor(range);
+				setCommentAnchorElement(range ? getCommentAnchorElement(range) : null);
 				setIsCommentInputOpen(range != null);
 				options.onLineSelectionEnd?.(range);
 			},
 			onLineSelected: (range) => {
 				setSelectedLines(range);
-				if (range) updateCommentComposerAnchor(range);
+				setCommentAnchorElement(range ? getCommentAnchorElement(range) : null);
 				setIsCommentInputOpen(range != null);
 				options.onLineSelected?.(range);
 			},
 		}),
-		[canReviewDiff, openCommentComposer, options, updateCommentComposerAnchor],
+		[canReviewDiff, getCommentAnchorElement, openCommentComposer, options],
 	);
 	const handleAddReviewComment = useCallback(() => {
 		if (!selectedLines || !commentBody.trim() || !onAddReviewComment) return;
@@ -306,14 +346,13 @@ function ActiveGitDiffFilePane({
 					/>
 					{canReviewDiff && selectedLines && isCommentInputOpen && (
 						<Box
-							position="absolute"
-							top={`${commentComposerTop}px`}
-							right="4"
+							ref={commentComposerRef}
+							position="fixed"
 							zIndex={2}
 							pointerEvents="none"
 						>
 							<Box
-								w="min(28rem, calc(100% - 2rem))"
+								w="min(28rem, calc(100vw - 2rem))"
 								borderWidth="1px"
 								borderColor="border.emphasized"
 								borderRadius="lg"

--- a/src/features/git/components/GitDiffPane.tsx
+++ b/src/features/git/components/GitDiffPane.tsx
@@ -203,10 +203,6 @@ function ActiveGitDiffFilePane({
 		!showBinaryPreview &&
 		!showLargeDiffGuardrail &&
 		!showRenameOnlyDiff;
-	const handleOpenReviewComposer = useCallback((range: SelectedLineRange) => {
-		setSelectedLines(range);
-		setIsCommentInputOpen(true);
-	}, []);
 	const interactiveOptions = useMemo<FileDiffOptions<unknown>>(
 		() => ({
 			...options,
@@ -215,7 +211,7 @@ function ActiveGitDiffFilePane({
 			lineHoverHighlight: canReviewDiff ? "both" : options.lineHoverHighlight,
 			onLineNumberClick: (lineEvent) => {
 				if (canReviewDiff) {
-					handleOpenReviewComposer({
+					setSelectedLines({
 						start: lineEvent.lineNumber,
 						end: lineEvent.lineNumber,
 						side: lineEvent.annotationSide,
@@ -225,21 +221,18 @@ function ActiveGitDiffFilePane({
 			},
 			onLineSelectionChange: (range) => {
 				setSelectedLines(range);
-				setIsCommentInputOpen(range != null);
 				options.onLineSelectionChange?.(range);
 			},
 			onLineSelectionEnd: (range) => {
 				setSelectedLines(range);
-				setIsCommentInputOpen(range != null);
 				options.onLineSelectionEnd?.(range);
 			},
 			onLineSelected: (range) => {
 				setSelectedLines(range);
-				setIsCommentInputOpen(range != null);
 				options.onLineSelected?.(range);
 			},
 		}),
-		[canReviewDiff, handleOpenReviewComposer, options],
+		[canReviewDiff, options],
 	);
 	const handleAddReviewComment = useCallback(() => {
 		if (!selectedLines || !commentBody.trim() || !onAddReviewComment) return;
@@ -297,7 +290,8 @@ function ActiveGitDiffFilePane({
 									onClick={(event) => {
 										event.preventDefault();
 										event.stopPropagation();
-										handleOpenReviewComposer(range);
+										setSelectedLines(range);
+										setIsCommentInputOpen(true);
 									}}
 								>
 									<FiPlus />

--- a/src/features/git/components/GitDiffPane.tsx
+++ b/src/features/git/components/GitDiffPane.tsx
@@ -27,7 +27,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { FiPlus, FiX } from "react-icons/fi";
 import * as m from "@/paraglide/messages.js";
 import { useTerminalSettingsStore } from "@/features/settings/stores/terminalSettingsStore";
-import { SECONDARY_BUTTON_VARIANT } from "@/theme/buttonVariants";
 import {
 	changeBadge,
 	GIT_DIFF_LARGE_FILE_LINE_THRESHOLD,
@@ -538,7 +537,7 @@ function ActiveGitDiffFilePane({
 								>
 									<Button
 										size="xs"
-										variant={SECONDARY_BUTTON_VARIANT}
+										variant="solid"
 										disabled={!commentBody.trim()}
 										onClick={handleAddReviewComment}
 									>

--- a/src/features/git/components/GitDiffPane.tsx
+++ b/src/features/git/components/GitDiffPane.tsx
@@ -342,6 +342,14 @@ function ActiveGitDiffFilePane({
 		},
 		[getCommentAnchor],
 	);
+	const openCommentComposerFromSelection = useCallback(
+		(range: SelectedLineRange | null) => {
+			setSelectedLines(range);
+			syncCommentAnchorFromSelection(range);
+			setIsCommentInputOpen(range != null);
+		},
+		[syncCommentAnchorFromSelection],
+	);
 	useEffect(() => {
 		const anchorElement = commentAnchor;
 		const composerElement = commentComposerRef.current;
@@ -370,23 +378,24 @@ function ActiveGitDiffFilePane({
 			onLineSelectionChange: (range) => {
 				setSelectedLines(range);
 				syncCommentAnchorFromSelection(range);
-				setIsCommentInputOpen(range != null);
 				options.onLineSelectionChange?.(range);
 			},
 			onLineSelectionEnd: (range) => {
-				setSelectedLines(range);
-				syncCommentAnchorFromSelection(range);
-				setIsCommentInputOpen(range != null);
+				openCommentComposerFromSelection(range);
 				options.onLineSelectionEnd?.(range);
 			},
 			onLineSelected: (range) => {
-				setSelectedLines(range);
-				syncCommentAnchorFromSelection(range);
-				setIsCommentInputOpen(range != null);
+				openCommentComposerFromSelection(range);
 				options.onLineSelected?.(range);
 			},
 		}),
-		[canReviewDiff, openCommentComposer, options, syncCommentAnchorFromSelection],
+		[
+			canReviewDiff,
+			openCommentComposer,
+			openCommentComposerFromSelection,
+			options,
+			syncCommentAnchorFromSelection,
+		],
 	);
 	const handleAddReviewComment = useCallback(() => {
 		if (!selectedLines || !commentBody.trim() || !onAddReviewComment) return;

--- a/src/features/git/components/GitDiffPane.tsx
+++ b/src/features/git/components/GitDiffPane.tsx
@@ -218,9 +218,16 @@ function ActiveGitDiffFilePane({
 		!showRenameOnlyDiff;
 	const getCommentAnchorElement = useCallback(
 		(range: SelectedLineRange, lineElement?: HTMLElement) => {
+			const diffContent = diffContentRef.current;
 			return (
 				lineElement ??
-				diffContentRef.current?.querySelector<HTMLElement>(
+				diffContent?.querySelector<HTMLElement>(
+					'[data-selected-line="first"], [data-selected-line="single"], [data-selected-line]',
+				) ??
+				diffContent?.querySelector<HTMLElement>(
+					`[data-column-number="${Math.min(range.start, range.end)}"]`,
+				) ??
+				diffContent?.querySelector<HTMLElement>(
 					`[data-line="${Math.min(range.start, range.end)}"]`,
 				) ??
 				null
@@ -266,6 +273,17 @@ function ActiveGitDiffFilePane({
 		},
 		[getCommentAnchorElement],
 	);
+	const syncCommentAnchorFromSelection = useCallback(
+		(range: SelectedLineRange | null) => {
+			setCommentAnchorElement(range ? getCommentAnchorElement(range) : null);
+			if (!range) return;
+
+			requestAnimationFrame(() => {
+				setCommentAnchorElement(getCommentAnchorElement(range));
+			});
+		},
+		[getCommentAnchorElement],
+	);
 	useEffect(() => {
 		const anchorElement = commentAnchorElement;
 		const composerElement = commentComposerRef.current;
@@ -291,24 +309,24 @@ function ActiveGitDiffFilePane({
 			},
 			onLineSelectionChange: (range) => {
 				setSelectedLines(range);
-				setCommentAnchorElement(range ? getCommentAnchorElement(range) : null);
+				syncCommentAnchorFromSelection(range);
 				setIsCommentInputOpen(range != null);
 				options.onLineSelectionChange?.(range);
 			},
 			onLineSelectionEnd: (range) => {
 				setSelectedLines(range);
-				setCommentAnchorElement(range ? getCommentAnchorElement(range) : null);
+				syncCommentAnchorFromSelection(range);
 				setIsCommentInputOpen(range != null);
 				options.onLineSelectionEnd?.(range);
 			},
 			onLineSelected: (range) => {
 				setSelectedLines(range);
-				setCommentAnchorElement(range ? getCommentAnchorElement(range) : null);
+				syncCommentAnchorFromSelection(range);
 				setIsCommentInputOpen(range != null);
 				options.onLineSelected?.(range);
 			},
 		}),
-		[canReviewDiff, getCommentAnchorElement, openCommentComposer, options],
+		[canReviewDiff, openCommentComposer, options, syncCommentAnchorFromSelection],
 	);
 	const handleAddReviewComment = useCallback(() => {
 		if (!selectedLines || !commentBody.trim() || !onAddReviewComment) return;

--- a/src/features/git/components/GitDiffPane.tsx
+++ b/src/features/git/components/GitDiffPane.tsx
@@ -203,24 +203,43 @@ function ActiveGitDiffFilePane({
 		!showBinaryPreview &&
 		!showLargeDiffGuardrail &&
 		!showRenameOnlyDiff;
+	const handleOpenReviewComposer = useCallback((range: SelectedLineRange) => {
+		setSelectedLines(range);
+		setIsCommentInputOpen(true);
+	}, []);
 	const interactiveOptions = useMemo<FileDiffOptions<unknown>>(
 		() => ({
 			...options,
 			enableLineSelection: canReviewDiff,
 			enableGutterUtility: canReviewDiff,
 			lineHoverHighlight: canReviewDiff ? "both" : options.lineHoverHighlight,
-			onGutterUtilityClick: (range) => {
-				setSelectedLines((currentRange) => currentRange ?? range);
-				setIsCommentInputOpen(true);
-				options.onGutterUtilityClick?.(range);
+			onLineNumberClick: (lineEvent) => {
+				if (canReviewDiff) {
+					handleOpenReviewComposer({
+						start: lineEvent.lineNumber,
+						end: lineEvent.lineNumber,
+						side: lineEvent.annotationSide,
+					});
+				}
+				options.onLineNumberClick?.(lineEvent);
+			},
+			onLineSelectionChange: (range) => {
+				setSelectedLines(range);
+				setIsCommentInputOpen(range != null);
+				options.onLineSelectionChange?.(range);
 			},
 			onLineSelectionEnd: (range) => {
 				setSelectedLines(range);
-				setIsCommentInputOpen(false);
+				setIsCommentInputOpen(range != null);
 				options.onLineSelectionEnd?.(range);
 			},
+			onLineSelected: (range) => {
+				setSelectedLines(range);
+				setIsCommentInputOpen(range != null);
+				options.onLineSelected?.(range);
+			},
 		}),
-		[canReviewDiff, options],
+		[canReviewDiff, handleOpenReviewComposer, options],
 	);
 	const handleAddReviewComment = useCallback(() => {
 		if (!selectedLines || !commentBody.trim() || !onAddReviewComment) return;
@@ -255,6 +274,36 @@ function ActiveGitDiffFilePane({
 						fileDiff={activeFile}
 						options={interactiveOptions}
 						selectedLines={selectedLines}
+						renderGutterUtility={(getHoveredLine) => {
+							const hoveredLine = getHoveredLine();
+							const range =
+								selectedLines ??
+								(hoveredLine
+									? {
+											start: hoveredLine.lineNumber,
+											end: hoveredLine.lineNumber,
+											side: hoveredLine.side,
+										}
+									: null);
+
+							if (!range) return null;
+
+							return (
+								<IconButton
+									aria-label={`Comment on ${formatReviewRange(range)}`}
+									size="2xs"
+									variant="solid"
+									colorPalette="blue"
+									onClick={(event) => {
+										event.preventDefault();
+										event.stopPropagation();
+										handleOpenReviewComposer(range);
+									}}
+								>
+									<FiPlus />
+								</IconButton>
+							);
+						}}
 					/>
 					{canReviewDiff && selectedLines && isCommentInputOpen && (
 						<Box

--- a/src/features/git/components/GitDiffPane.tsx
+++ b/src/features/git/components/GitDiffPane.tsx
@@ -6,7 +6,7 @@ import {
 	shift,
 	size,
 } from "@floating-ui/dom";
-import type { Strategy } from "@floating-ui/dom";
+import type { ReferenceElement, VirtualElement } from "@floating-ui/dom";
 import {
 	Badge,
 	Box,
@@ -176,6 +176,45 @@ function RenameOnlyDiff({ file }: { file: FileDiffMetadata }) {
 	);
 }
 
+function getElementsVirtualReference(
+	elements: HTMLElement[],
+): VirtualElement | null {
+	if (elements.length === 0) return null;
+
+	return {
+		contextElement: elements[0],
+		getBoundingClientRect: () => {
+			const rects = elements
+				.map((element) => element.getBoundingClientRect())
+				.filter((rect) => rect.width > 0 || rect.height > 0);
+
+			if (rects.length === 0) {
+				const fallbackRect = elements[0].getBoundingClientRect();
+				return fallbackRect;
+			}
+
+			const left = Math.min(...rects.map((rect) => rect.left));
+			const top = Math.min(...rects.map((rect) => rect.top));
+			const right = Math.max(...rects.map((rect) => rect.right));
+			const bottom = Math.max(...rects.map((rect) => rect.bottom));
+
+			return {
+				x: left,
+				y: top,
+				left,
+				top,
+				right,
+				bottom,
+				width: right - left,
+				height: bottom - top,
+				toJSON() {
+					return this;
+				},
+			};
+		},
+	};
+}
+
 function ActiveGitDiffFilePane({
 	activeFile,
 	options,
@@ -195,8 +234,9 @@ function ActiveGitDiffFilePane({
 		useState<SelectedLineRange | null>(null);
 	const [commentBody, setCommentBody] = useState("");
 	const [isCommentInputOpen, setIsCommentInputOpen] = useState(false);
-	const [commentAnchorElement, setCommentAnchorElement] =
-		useState<HTMLElement | null>(null);
+	const [commentAnchor, setCommentAnchor] = useState<ReferenceElement | null>(
+		null,
+	);
 	const diffContentRef = useRef<HTMLDivElement>(null);
 	const commentComposerRef = useRef<HTMLDivElement>(null);
 	const { additions, deletions } = useMemo(
@@ -216,33 +256,49 @@ function ActiveGitDiffFilePane({
 		!showBinaryPreview &&
 		!showLargeDiffGuardrail &&
 		!showRenameOnlyDiff;
-	const getCommentAnchorElement = useCallback(
+	const getCommentAnchor = useCallback(
 		(range: SelectedLineRange, lineElement?: HTMLElement) => {
 			const diffContent = diffContentRef.current;
+			if (lineElement) return lineElement;
+			if (!diffContent) return null;
+
+			const selectedElements = Array.from(
+				diffContent.querySelectorAll<HTMLElement>("[data-selected-line]"),
+			);
+			const selectedReference =
+				getElementsVirtualReference(selectedElements);
+			if (selectedReference) return selectedReference;
+
+			const start = Math.min(range.start, range.end);
+			const end = Math.max(range.start, range.end);
+			const fallbackElements = Array.from(
+				diffContent.querySelectorAll<HTMLElement>(
+					[
+						`[data-column-number="${start}"]`,
+						`[data-column-number="${end}"]`,
+						`[data-line="${start}"]`,
+						`[data-line="${end}"]`,
+					].join(", "),
+				),
+			);
+
 			return (
-				lineElement ??
-				diffContent?.querySelector<HTMLElement>(
-					'[data-selected-line="first"], [data-selected-line="single"], [data-selected-line]',
-				) ??
-				diffContent?.querySelector<HTMLElement>(
-					`[data-column-number="${Math.min(range.start, range.end)}"]`,
-				) ??
-				diffContent?.querySelector<HTMLElement>(
-					`[data-line="${Math.min(range.start, range.end)}"]`,
-				) ??
-				null
+				getElementsVirtualReference(fallbackElements) ??
+				diffContent.querySelector<HTMLElement>(
+					`[data-line-index="${start}"], [data-line-index="${end}"]`,
+				)
 			);
 		},
 		[],
 	);
 	const updateFloatingComposer = useCallback(() => {
-		const anchorElement = commentAnchorElement;
+		const anchorElement = commentAnchor;
 		const composerElement = commentComposerRef.current;
 		if (!anchorElement || !composerElement) return;
 
 		void computePosition(anchorElement, composerElement, {
 			placement: "right-start",
-			strategy: "fixed" satisfies Strategy,
+			strategy: "fixed",
 			middleware: [
 				offset(12),
 				flip({
@@ -259,38 +315,42 @@ function ActiveGitDiffFilePane({
 				}),
 			],
 		}).then(({ x, y }) => {
+			if (commentComposerRef.current !== composerElement) return;
+
 			Object.assign(composerElement.style, {
 				left: `${x}px`,
 				top: `${y}px`,
 			});
 		});
-	}, [commentAnchorElement]);
+	}, [commentAnchor]);
 	const openCommentComposer = useCallback(
 		(range: SelectedLineRange, lineElement?: HTMLElement) => {
 			setSelectedLines(range);
-			setCommentAnchorElement(getCommentAnchorElement(range, lineElement));
+			setCommentAnchor(getCommentAnchor(range, lineElement));
 			setIsCommentInputOpen(true);
 		},
-		[getCommentAnchorElement],
+		[getCommentAnchor],
 	);
 	const syncCommentAnchorFromSelection = useCallback(
 		(range: SelectedLineRange | null) => {
-			setCommentAnchorElement(range ? getCommentAnchorElement(range) : null);
+			setCommentAnchor(range ? getCommentAnchor(range) : null);
 			if (!range) return;
 
 			requestAnimationFrame(() => {
-				setCommentAnchorElement(getCommentAnchorElement(range));
+				setCommentAnchor(getCommentAnchor(range));
 			});
 		},
-		[getCommentAnchorElement],
+		[getCommentAnchor],
 	);
 	useEffect(() => {
-		const anchorElement = commentAnchorElement;
+		const anchorElement = commentAnchor;
 		const composerElement = commentComposerRef.current;
 		if (!isCommentInputOpen || !anchorElement || !composerElement) return;
 
-		return autoUpdate(anchorElement, composerElement, updateFloatingComposer);
-	}, [commentAnchorElement, isCommentInputOpen, updateFloatingComposer]);
+		return autoUpdate(anchorElement, composerElement, updateFloatingComposer, {
+			animationFrame: true,
+		});
+	}, [commentAnchor, isCommentInputOpen, updateFloatingComposer]);
 	const interactiveOptions = useMemo<FileDiffOptions<unknown>>(
 		() => ({
 			...options,

--- a/src/features/git/components/GitReviewQueueDialog.tsx
+++ b/src/features/git/components/GitReviewQueueDialog.tsx
@@ -203,7 +203,7 @@ export default function GitReviewQueueDialog({
 						</Dialog.Body>
 						<Dialog.Footer gap="2">
 							<Button
-								variant="subtle"
+								variant="outline"
 								onClick={handleCopyAll}
 								disabled={comments.length === 0}
 							>

--- a/src/features/git/components/GitReviewQueueDialog.tsx
+++ b/src/features/git/components/GitReviewQueueDialog.tsx
@@ -9,8 +9,11 @@ import {
 	Text,
 	Textarea,
 } from "@chakra-ui/react";
+import type { FileDiffOptions } from "@pierre/diffs";
 import { FileDiff } from "@pierre/diffs/react";
+import { useMemo } from "react";
 import { FiCopy, FiTrash2 } from "react-icons/fi";
+import { useTerminalSettingsStore } from "@/features/settings/stores/terminalSettingsStore";
 import { copyTextToClipboard } from "@/shared/lib/clipboard";
 import { toaster } from "@/shared/providers/appToaster";
 import {
@@ -22,6 +25,7 @@ import {
 interface GitReviewQueueDialogProps {
 	isOpen: boolean;
 	comments: DiffReviewComment[];
+	options: FileDiffOptions<unknown>;
 	onClose: () => void;
 	onClear: () => void;
 	onDelete: (id: string) => void;
@@ -31,11 +35,24 @@ interface GitReviewQueueDialogProps {
 export default function GitReviewQueueDialog({
 	isOpen,
 	comments,
+	options,
 	onClose,
 	onClear,
 	onDelete,
 	onUpdate,
 }: GitReviewQueueDialogProps) {
+	const fontFamily = useTerminalSettingsStore((s) => s.fontFamily);
+	const fontSize = useTerminalSettingsStore((s) => s.fontSize);
+	const reviewDiffOptions = useMemo<FileDiffOptions<unknown>>(
+		() => ({
+			...options,
+			disableFileHeader: true,
+			enableGutterUtility: false,
+			enableLineSelection: false,
+		}),
+		[options],
+	);
+
 	async function handleCopyAll() {
 		await copyTextToClipboard(formatReviewCommentsForAgent(comments));
 		toaster.create({
@@ -122,13 +139,14 @@ export default function GitReviewQueueDialog({
 											borderWidth="1px"
 											borderColor="border.subtle"
 											borderRadius="md"
+											css={{
+												"--diffs-font-family": `"${fontFamily}", monospace`,
+												"--diffs-font-size": `${fontSize}px`,
+											}}
 										>
 											<FileDiff
 												fileDiff={comment.fileDiff}
-												options={{
-													disableFileHeader: true,
-													hunkSeparators: "line-info-basic",
-												}}
+												options={reviewDiffOptions}
 												selectedLines={comment.range}
 												disableWorkerPool
 											/>

--- a/src/features/git/components/GitReviewQueueDialog.tsx
+++ b/src/features/git/components/GitReviewQueueDialog.tsx
@@ -18,6 +18,7 @@ import { FiCopy, FiTrash2 } from "react-icons/fi";
 import { useTerminalSettingsStore } from "@/features/settings/stores/terminalSettingsStore";
 import { copyTextToClipboard } from "@/shared/lib/clipboard";
 import { toaster } from "@/shared/providers/appToaster";
+import { SECONDARY_BUTTON_VARIANT } from "@/theme/buttonVariants";
 import {
 	type DiffReviewComment,
 	formatReviewCommentsForAgent,
@@ -203,7 +204,7 @@ export default function GitReviewQueueDialog({
 						</Dialog.Body>
 						<Dialog.Footer gap="2">
 							<Button
-								variant="outline"
+								variant={SECONDARY_BUTTON_VARIANT}
 								onClick={handleCopyAll}
 								disabled={comments.length === 0}
 							>

--- a/src/features/git/components/GitReviewQueueDialog.tsx
+++ b/src/features/git/components/GitReviewQueueDialog.tsx
@@ -151,7 +151,7 @@ export default function GitReviewQueueDialog({
 						</Dialog.Body>
 						<Dialog.Footer gap="2">
 							<Button
-								variant="outline"
+								variant="subtle"
 								onClick={handleCopyAll}
 								disabled={comments.length === 0}
 							>

--- a/src/features/git/components/GitReviewQueueDialog.tsx
+++ b/src/features/git/components/GitReviewQueueDialog.tsx
@@ -1,0 +1,150 @@
+import {
+	Box,
+	Button,
+	CloseButton,
+	Dialog,
+	Flex,
+	HStack,
+	Portal,
+	Text,
+	Textarea,
+} from "@chakra-ui/react";
+import { FiCopy, FiTrash2 } from "react-icons/fi";
+import { copyTextToClipboard } from "@/shared/lib/clipboard";
+import { toaster } from "@/shared/providers/appToaster";
+import {
+	type DiffReviewComment,
+	formatReviewCommentsForAgent,
+	formatReviewRange,
+} from "../reviewQueue";
+
+interface GitReviewQueueDialogProps {
+	isOpen: boolean;
+	comments: DiffReviewComment[];
+	onClose: () => void;
+	onDelete: (id: string) => void;
+	onUpdate: (id: string, body: string) => void;
+}
+
+export default function GitReviewQueueDialog({
+	isOpen,
+	comments,
+	onClose,
+	onDelete,
+	onUpdate,
+}: GitReviewQueueDialogProps) {
+	async function handleCopyAll() {
+		await copyTextToClipboard(formatReviewCommentsForAgent(comments));
+		toaster.create({
+			title: "Review comments copied",
+			type: "success",
+			closable: true,
+		});
+	}
+
+	return (
+		<Dialog.Root
+			open={isOpen}
+			size="xl"
+			onOpenChange={(event) => {
+				if (!event.open) onClose();
+			}}
+		>
+			<Portal>
+				<Dialog.Backdrop />
+				<Dialog.Positioner>
+					<Dialog.Content maxH="80vh">
+						<Dialog.Header>
+							<Dialog.Title>Review Queue</Dialog.Title>
+							<Dialog.CloseTrigger asChild>
+								<CloseButton size="sm" />
+							</Dialog.CloseTrigger>
+						</Dialog.Header>
+						<Dialog.Body overflow="auto">
+							<Flex direction="column" gap="3">
+								{comments.map((comment) => (
+									<Box
+										key={comment.id}
+										borderWidth="1px"
+										borderColor="border.subtle"
+										borderRadius="md"
+										p="3"
+									>
+										<HStack align="start" gap="3">
+											<Box flex="1" minW="0">
+												<Text
+													fontSize="sm"
+													fontFamily="mono"
+													fontWeight="semibold"
+													truncate
+												>
+													{comment.displayName}
+												</Text>
+												<Text
+													mt="0.5"
+													fontSize="xs"
+													color="fg.muted"
+												>
+													{formatReviewRange(
+														comment.range,
+													)}
+												</Text>
+											</Box>
+											<Button
+												size="xs"
+												variant="ghost"
+												colorPalette="red"
+												onClick={() =>
+													onDelete(comment.id)
+												}
+											>
+												<FiTrash2 />
+											</Button>
+										</HStack>
+										<Box
+											mt="2"
+											maxH="8rem"
+											overflow="auto"
+											whiteSpace="pre-wrap"
+											fontFamily="mono"
+											fontSize="xs"
+											color="fg.muted"
+											bg="bg.subtle"
+											borderRadius="sm"
+											p="2"
+										>
+											{comment.selectedText ||
+												"(no selected text available)"}
+										</Box>
+										<Textarea
+											mt="2"
+											value={comment.body}
+											autoresize
+											minH="5rem"
+											onChange={(event) =>
+												onUpdate(
+													comment.id,
+													event.target.value,
+												)
+											}
+										/>
+									</Box>
+								))}
+							</Flex>
+						</Dialog.Body>
+						<Dialog.Footer>
+							<Button
+								variant="outline"
+								onClick={handleCopyAll}
+								disabled={comments.length === 0}
+							>
+								<FiCopy />
+								Copy all
+							</Button>
+						</Dialog.Footer>
+					</Dialog.Content>
+				</Dialog.Positioner>
+			</Portal>
+		</Dialog.Root>
+	);
+}

--- a/src/features/git/components/GitReviewQueueDialog.tsx
+++ b/src/features/git/components/GitReviewQueueDialog.tsx
@@ -23,6 +23,7 @@ interface GitReviewQueueDialogProps {
 	isOpen: boolean;
 	comments: DiffReviewComment[];
 	onClose: () => void;
+	onClear: () => void;
 	onDelete: (id: string) => void;
 	onUpdate: (id: string, body: string) => void;
 }
@@ -31,6 +32,7 @@ export default function GitReviewQueueDialog({
 	isOpen,
 	comments,
 	onClose,
+	onClear,
 	onDelete,
 	onUpdate,
 }: GitReviewQueueDialogProps) {
@@ -38,6 +40,17 @@ export default function GitReviewQueueDialog({
 		await copyTextToClipboard(formatReviewCommentsForAgent(comments));
 		toaster.create({
 			title: "Review comments copied",
+			type: "success",
+			closable: true,
+		});
+	}
+
+	async function handleCopyAndClearAll() {
+		await copyTextToClipboard(formatReviewCommentsForAgent(comments));
+		onClear();
+		onClose();
+		toaster.create({
+			title: "Review comments copied and cleared",
 			type: "success",
 			closable: true,
 		});
@@ -136,14 +149,23 @@ export default function GitReviewQueueDialog({
 								))}
 							</Flex>
 						</Dialog.Body>
-						<Dialog.Footer>
+						<Dialog.Footer gap="2">
 							<Button
 								variant="outline"
 								onClick={handleCopyAll}
 								disabled={comments.length === 0}
 							>
 								<FiCopy />
-								Copy all
+								Copy
+							</Button>
+							<Button
+								variant="solid"
+								colorPalette="red"
+								onClick={handleCopyAndClearAll}
+								disabled={comments.length === 0}
+							>
+								<FiCopy />
+								Copy and clear all
 							</Button>
 						</Dialog.Footer>
 					</Dialog.Content>

--- a/src/features/git/components/GitReviewQueueDialog.tsx
+++ b/src/features/git/components/GitReviewQueueDialog.tsx
@@ -9,6 +9,7 @@ import {
 	Text,
 	Textarea,
 } from "@chakra-ui/react";
+import { FileDiff } from "@pierre/diffs/react";
 import { FiCopy, FiTrash2 } from "react-icons/fi";
 import { copyTextToClipboard } from "@/shared/lib/clipboard";
 import { toaster } from "@/shared/providers/appToaster";
@@ -105,16 +106,19 @@ export default function GitReviewQueueDialog({
 											mt="2"
 											maxH="8rem"
 											overflow="auto"
-											whiteSpace="pre-wrap"
-											fontFamily="mono"
-											fontSize="xs"
-											color="fg.muted"
-											bg="bg.subtle"
-											borderRadius="sm"
-											p="2"
+											borderWidth="1px"
+											borderColor="border.subtle"
+											borderRadius="md"
 										>
-											{comment.selectedText ||
-												"(no selected text available)"}
+											<FileDiff
+												fileDiff={comment.fileDiff}
+												options={{
+													disableFileHeader: true,
+													hunkSeparators: "line-info-basic",
+												}}
+												selectedLines={comment.range}
+												disableWorkerPool
+											/>
 										</Box>
 										<Textarea
 											mt="2"

--- a/src/features/git/components/GitReviewQueueDialog.tsx
+++ b/src/features/git/components/GitReviewQueueDialog.tsx
@@ -1,10 +1,12 @@
 import {
+	Badge,
 	Box,
 	Button,
 	CloseButton,
 	Dialog,
 	Flex,
 	HStack,
+	IconButton,
 	Portal,
 	Text,
 	Textarea,
@@ -99,9 +101,17 @@ export default function GitReviewQueueDialog({
 										borderWidth="1px"
 										borderColor="border.subtle"
 										borderRadius="md"
-										p="3"
+										overflow="hidden"
 									>
-										<HStack align="start" gap="3">
+										<HStack
+											align="start"
+											gap="3"
+											px="3"
+											py="2.5"
+											bg="bg.subtle"
+											borderBottomWidth="1px"
+											borderColor="border.subtle"
+										>
 											<Box flex="1" minW="0">
 												<Text
 													fontSize="sm"
@@ -111,29 +121,41 @@ export default function GitReviewQueueDialog({
 												>
 													{comment.displayName}
 												</Text>
-												<Text
-													mt="0.5"
-													fontSize="xs"
-													color="fg.muted"
-												>
-													{formatReviewRange(
-														comment.range,
-													)}
-												</Text>
+												<HStack mt="1" gap="2">
+													<Badge
+														size="xs"
+														variant="subtle"
+														colorPalette="blue"
+														fontFamily="mono"
+													>
+														{formatReviewRange(
+															comment.range,
+														)}
+													</Badge>
+													<Text
+														fontSize="xs"
+														color="fg.muted"
+													>
+														Selected diff
+													</Text>
+												</HStack>
 											</Box>
-											<Button
+											<IconButton
+												aria-label="Delete review comment"
 												size="xs"
 												variant="ghost"
 												colorPalette="red"
+												flexShrink={0}
 												onClick={() =>
 													onDelete(comment.id)
 												}
 											>
 												<FiTrash2 />
-											</Button>
+											</IconButton>
 										</HStack>
 										<Box
-											mt="2"
+											mx="3"
+											mt="3"
 											maxH="8rem"
 											overflow="auto"
 											borderWidth="1px"
@@ -151,8 +173,20 @@ export default function GitReviewQueueDialog({
 												disableWorkerPool
 											/>
 										</Box>
+										<Text
+											px="3"
+											pt="3"
+											fontSize="xs"
+											fontWeight="semibold"
+											color="fg.muted"
+										>
+											Comment
+										</Text>
 										<Textarea
-											mt="2"
+											mx="3"
+											mt="1.5"
+											mb="3"
+											w="calc(100% - 1.5rem)"
 											value={comment.body}
 											autoresize
 											minH="5rem"

--- a/src/features/git/reviewQueue.test.ts
+++ b/src/features/git/reviewQueue.test.ts
@@ -1,0 +1,40 @@
+import type { FileDiffMetadata } from "@pierre/diffs";
+import { describe, expect, it } from "vitest";
+import {
+	createReviewComment,
+	formatReviewCommentsForAgent,
+} from "./reviewQueue";
+
+function makeFile(): FileDiffMetadata {
+	return {
+		name: "src/example.ts",
+		additionLines: [
+			"  const value = 1;  ",
+			"",
+			"    return value;",
+		],
+		deletionLines: [],
+	} as unknown as FileDiffMetadata;
+}
+
+describe("reviewQueue formatting", () => {
+	it("copies selected diff without extra prefix spaces or trailing whitespace", () => {
+		const comment = createReviewComment(
+			makeFile(),
+			{ start: 1, end: 3, side: "additions" },
+			"\n  tighten this up  \n\n",
+		);
+
+		expect(formatReviewCommentsForAgent([comment])).toContain(
+			[
+				"```diff",
+				"+  const value = 1;",
+				"+",
+				"+    return value;",
+				"```",
+				"Comment:",
+				"  tighten this up",
+			].join("\n"),
+		);
+	});
+});

--- a/src/features/git/reviewQueue.test.ts
+++ b/src/features/git/reviewQueue.test.ts
@@ -27,6 +27,8 @@ describe("reviewQueue formatting", () => {
 
 		expect(formatReviewCommentsForAgent([comment])).toContain(
 			[
+				"1. src/example.ts:1-3",
+				"Selected diff:",
 				"```diff",
 				"+  const value = 1;",
 				"+",

--- a/src/features/git/reviewQueue.ts
+++ b/src/features/git/reviewQueue.ts
@@ -4,6 +4,7 @@ export interface DiffReviewComment {
 	id: string;
 	fileName: string;
 	displayName: string;
+	fileDiff: FileDiffMetadata;
 	range: SelectedLineRange;
 	selectedText: string;
 	body: string;
@@ -60,6 +61,7 @@ export function createReviewComment(
 		id: crypto.randomUUID(),
 		fileName: file.name,
 		displayName,
+		fileDiff: file,
 		range,
 		selectedText: getSelectedDiffText(file, range),
 		body,

--- a/src/features/git/reviewQueue.ts
+++ b/src/features/git/reviewQueue.ts
@@ -1,0 +1,101 @@
+import type { FileDiffMetadata, SelectedLineRange } from "@pierre/diffs";
+
+export interface DiffReviewComment {
+	id: string;
+	fileName: string;
+	displayName: string;
+	range: SelectedLineRange;
+	selectedText: string;
+	body: string;
+	createdAt: number;
+}
+
+export function formatReviewRange(range: SelectedLineRange) {
+	const startSide = range.side ?? "additions";
+	const endSide = range.endSide ?? startSide;
+	const side =
+		startSide === endSide
+			? startSide
+			: `${startSide}->${endSide}`;
+	const start = Math.min(range.start, range.end);
+	const end = Math.max(range.start, range.end);
+	const lineRange = start === end ? `${start}` : `${start}-${end}`;
+	return `${lineRange} (${side})`;
+}
+
+export function getSelectedDiffText(
+	file: FileDiffMetadata,
+	range: SelectedLineRange,
+) {
+	const start = Math.min(range.start, range.end);
+	const end = Math.max(range.start, range.end);
+	const startSide = range.side ?? "additions";
+	const endSide = range.endSide ?? startSide;
+
+	if (startSide === endSide) {
+		return getSideLines(file, startSide, start, end);
+	}
+
+	const deletionText = getSideLines(file, "deletions", start, end);
+	const additionText = getSideLines(file, "additions", start, end);
+	return [
+		deletionText ? `# deletions\n${deletionText}` : "",
+		additionText ? `# additions\n${additionText}` : "",
+	]
+		.filter(Boolean)
+		.join("\n");
+}
+
+export function createReviewComment(
+	file: FileDiffMetadata,
+	range: SelectedLineRange,
+	body: string,
+): DiffReviewComment {
+	const displayName =
+		file.prevName && file.prevName !== file.name
+			? `${file.prevName} -> ${file.name}`
+			: file.name;
+
+	return {
+		id: crypto.randomUUID(),
+		fileName: file.name,
+		displayName,
+		range,
+		selectedText: getSelectedDiffText(file, range),
+		body,
+		createdAt: Date.now(),
+	};
+}
+
+export function formatReviewCommentsForAgent(
+	comments: readonly DiffReviewComment[],
+) {
+	return [
+		"Please address these review comments:",
+		"",
+		...comments.flatMap((comment, index) => [
+			`${index + 1}. ${comment.fileName}:${formatReviewRange(comment.range)}`,
+			"Selected diff:",
+			"```diff",
+			comment.selectedText || "(no selected text available)",
+			"```",
+			"Comment:",
+			comment.body,
+			"",
+		]),
+	].join("\n");
+}
+
+function getSideLines(
+	file: FileDiffMetadata,
+	side: "additions" | "deletions",
+	start: number,
+	end: number,
+) {
+	const lines =
+		side === "additions" ? file.additionLines : file.deletionLines;
+	return lines
+		.slice(Math.max(start - 1, 0), Math.max(end, 0))
+		.map((line) => `${side === "additions" ? "+" : "-"} ${line}`)
+		.join("\n");
+}

--- a/src/features/git/reviewQueue.ts
+++ b/src/features/git/reviewQueue.ts
@@ -12,16 +12,9 @@ export interface DiffReviewComment {
 }
 
 export function formatReviewRange(range: SelectedLineRange) {
-	const startSide = range.side ?? "additions";
-	const endSide = range.endSide ?? startSide;
-	const side =
-		startSide === endSide
-			? startSide
-			: `${startSide}->${endSide}`;
 	const start = Math.min(range.start, range.end);
 	const end = Math.max(range.start, range.end);
-	const lineRange = start === end ? `${start}` : `${start}-${end}`;
-	return `${lineRange} (${side})`;
+	return start === end ? `${start}` : `${start}-${end}`;
 }
 
 export function getSelectedDiffText(

--- a/src/features/git/reviewQueue.ts
+++ b/src/features/git/reviewQueue.ts
@@ -79,13 +79,21 @@ export function formatReviewCommentsForAgent(
 			`${index + 1}. ${comment.fileName}:${formatReviewRange(comment.range)}`,
 			"Selected diff:",
 			"```diff",
-			comment.selectedText || "(no selected text available)",
+			normalizeClipboardBlock(comment.selectedText) ||
+				"(no selected text available)",
 			"```",
 			"Comment:",
-			comment.body,
+			normalizeClipboardBlock(comment.body),
 			"",
 		]),
 	].join("\n");
+}
+
+function normalizeClipboardBlock(text: string) {
+	const lines = text.split(/\r?\n/).map((line) => line.trimEnd());
+	while (lines[0] === "") lines.shift();
+	while (lines[lines.length - 1] === "") lines.pop();
+	return lines.join("\n");
 }
 
 function getSideLines(
@@ -98,6 +106,6 @@ function getSideLines(
 		side === "additions" ? file.additionLines : file.deletionLines;
 	return lines
 		.slice(Math.max(start - 1, 0), Math.max(end, 0))
-		.map((line) => `${side === "additions" ? "+" : "-"} ${line}`)
+		.map((line) => `${side === "additions" ? "+" : "-"}${line.trimEnd()}`)
 		.join("\n");
 }

--- a/src/shared/lib/queryKeys.test.ts
+++ b/src/shared/lib/queryKeys.test.ts
@@ -20,6 +20,7 @@ describe("queryNamespaces", () => {
 			"profile-delete-check": "profile-delete-check",
 			"profile-notes": "profile-notes",
 			"topbar-apps": "topbar-apps",
+			"browser-apps": "browser-apps",
 			"fs-file": "fs-file",
 			"fs-file-preview": "fs-file-preview",
 			"fs-search": "fs-search",
@@ -66,6 +67,12 @@ describe("queryKeys", () => {
 	describe("topbar", () => {
 		it("returns static key for supported apps", () => {
 			expect(queryKeys.topbar.apps).toEqual(["topbar-apps"]);
+		});
+	});
+
+	describe("browser", () => {
+		it("returns static key for installed apps", () => {
+			expect(queryKeys.browser.installed).toEqual(["browser-apps"]);
 		});
 	});
 

--- a/src/theme/buttonVariants.ts
+++ b/src/theme/buttonVariants.ts
@@ -1,0 +1,4 @@
+import type { ButtonProps } from "@chakra-ui/react";
+
+export const SECONDARY_BUTTON_VARIANT =
+	"secondary" as unknown as NonNullable<ButtonProps["variant"]>;

--- a/src/theme/system.ts
+++ b/src/theme/system.ts
@@ -110,6 +110,23 @@ export const appThemeConfig = defineConfig({
       },
     },
     recipes: {
+      button: {
+        variants: {
+          variant: {
+            secondary: {
+              bg: "bg.muted",
+              color: "fg",
+              borderColor: "transparent",
+              _hover: {
+                bg: "bg.emphasized",
+              },
+              _expanded: {
+                bg: "bg.emphasized",
+              },
+            },
+          },
+        },
+      },
       input: {
         variants: {
           variant: {


### PR DESCRIPTION
## Summary
- enable @pierre/diffs line selection in the working-tree diff pane
- add a floating review comment composer for selected diff ranges
- add a review queue dialog with edit/delete and copy-all formatting for agent handoff

## Verification
- bunx tsc --noEmit
- bunx eslint src/features/git/components/GitDiffPane.tsx src/features/git/components/GitDiffContent.tsx src/features/git/components/GitDiffChangesPanel.tsx src/features/git/components/GitReviewQueueDialog.tsx src/features/git/reviewQueue.ts --max-warnings=0
- bun run build
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-diff review comments: select line ranges and compose inline comments via a sticky composer.
  * Review Queue: floating button shows queued count and opens a dialog to view, edit, delete, copy, or "copy and clear" queued comments.
  * Clipboard feedback: copy actions show success toasts.

* **Tests**
  * Added unit and integration tests covering the review-comment selection flow and queue formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->