### PR TITLE
perf(git): reduce background refresh work

### DIFF
--- a/src/features/git/components/GitDiffContent.tsx
+++ b/src/features/git/components/GitDiffContent.tsx
@@ -97,6 +97,7 @@ export default function GitDiffContent({
 	const [commitBody, setCommitBody] = useState("");
 	const sidebarRef = useRef<HTMLDivElement>(null);
 	const previousChangeFileNamesRef = useRef<Set<string>>(new Set());
+	const isChanges = state.activeTab === "changes";
 
 	const changesFiles = useGitDiffFiles(profileId);
 	const { data: logData } = useGitLog(profileId);
@@ -104,7 +105,7 @@ export default function GitDiffContent({
 	const openFileTab = useFileViewerTabsStore((store) => store.openFile);
 	const commitGitChanges = useCommitGitChanges(profileId);
 	const discardGitFileChanges = useDiscardGitFileChanges(profileId);
-	const aheadCount = useGitAheadCount(profileId);
+	const aheadCount = useGitAheadCount(profileId, isChanges);
 	const gitPush = useGitPush(profileId);
 	const orderedIncludedFileNames = useMemo(
 		() => collectOrderedIncludedFileNames(changesFiles, includedFileNames),
@@ -342,8 +343,6 @@ export default function GitDiffContent({
 			});
 		}
 	}, [changesFiles.length, dispatch, state.selectedFileIndex]);
-
-	const isChanges = state.activeTab === "changes";
 
 	const ctxValue = useMemo(
 		() => ({ state, dispatch, profileId, changesFiles, commits, options }),

--- a/src/features/git/hooks.test.tsx
+++ b/src/features/git/hooks.test.tsx
@@ -10,16 +10,19 @@ import {
 	useCommitGitChanges,
 	useGitDiffFiles,
 	useGitDiffStats,
+	useGitLog,
 } from "./hooks";
 
 const {
 	commitGitChangesMock,
 	getGitDiffMock,
 	getGitDiffStatsMock,
+	getGitLogMock,
 } = vi.hoisted(() => ({
 	commitGitChangesMock: vi.fn(),
 	getGitDiffMock: vi.fn(),
 	getGitDiffStatsMock: vi.fn(),
+	getGitLogMock: vi.fn(),
 }));
 
 vi.mock("@/generated", async () => {
@@ -31,6 +34,7 @@ vi.mock("@/generated", async () => {
 		commitGitChanges: commitGitChangesMock,
 		getGitDiff: getGitDiffMock,
 		getGitDiffStats: getGitDiffStatsMock,
+		getGitLog: getGitLogMock,
 	};
 });
 
@@ -66,9 +70,10 @@ describe("git query refresh policy", () => {
 		commitGitChangesMock.mockReset();
 		getGitDiffMock.mockReset();
 		getGitDiffStatsMock.mockReset();
+		getGitLogMock.mockReset();
 	});
 
-	it("keeps full diff snapshots out of the background polling loop", async () => {
+	it("keeps full diff snapshots on the low-frequency fallback refresh", async () => {
 		const queryClient = createQueryClient();
 		getGitDiffMock.mockResolvedValue("");
 
@@ -85,8 +90,29 @@ describe("git query refresh policy", () => {
 			queryClient,
 			queryKeys.git.diff("profile-1"),
 		);
-		expect(options?.refetchInterval).toBe(false);
+		expect(options?.refetchInterval).toBe(10_000);
 		expect(options?.staleTime).toBe(30_000);
+		expect(options?.refetchOnMount).toBe("always");
+	});
+
+	it("keeps commit history on the low-frequency fallback refresh", async () => {
+		const queryClient = createQueryClient();
+		getGitLogMock.mockResolvedValue([]);
+
+		const { result } = renderHook(() => useGitLog("profile-1"), {
+			wrapper: createWrapper(queryClient),
+		});
+
+		await waitFor(() => {
+			expect(result.current.data).toEqual([]);
+		});
+
+		const options = getRuntimeQueryOptions(
+			queryClient,
+			queryKeys.git.log("profile-1"),
+		);
+		expect(options?.refetchInterval).toBe(10_000);
+		expect(options?.staleTime).toBe(60_000);
 		expect(options?.refetchOnMount).toBe("always");
 	});
 
@@ -117,6 +143,36 @@ describe("git query refresh policy", () => {
 		);
 		expect(options?.refetchInterval).toBe(10_000);
 		expect(options?.staleTime).toBe(10_000);
+	});
+
+	it("refetches diff stats when an enabled-gated profile reactivates", async () => {
+		const queryClient = createQueryClient();
+		queryClient.setQueryData(queryKeys.git.diffStats("profile-1"), {
+			files_changed: 1,
+			insertions: 2,
+			deletions: 3,
+		});
+		getGitDiffStatsMock.mockResolvedValue({
+			files_changed: 2,
+			insertions: 5,
+			deletions: 8,
+		});
+
+		const { rerender } = renderHook(
+			({ enabled }) => useGitDiffStats("profile-1", enabled),
+			{
+				initialProps: { enabled: false },
+				wrapper: createWrapper(queryClient),
+			},
+		);
+
+		expect(getGitDiffStatsMock).not.toHaveBeenCalled();
+
+		rerender({ enabled: true });
+
+		await waitFor(() => {
+			expect(getGitDiffStatsMock).toHaveBeenCalledTimes(1);
+		});
 	});
 });
 

--- a/src/features/git/hooks.test.tsx
+++ b/src/features/git/hooks.test.tsx
@@ -1,0 +1,168 @@
+import {
+	QueryClient,
+	QueryClientProvider,
+} from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { Suspense, type ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { queryKeys } from "@/shared/lib/queryKeys";
+import {
+	useCommitGitChanges,
+	useGitDiffFiles,
+	useGitDiffStats,
+} from "./hooks";
+
+const {
+	commitGitChangesMock,
+	getGitDiffMock,
+	getGitDiffStatsMock,
+} = vi.hoisted(() => ({
+	commitGitChangesMock: vi.fn(),
+	getGitDiffMock: vi.fn(),
+	getGitDiffStatsMock: vi.fn(),
+}));
+
+vi.mock("@/generated", async () => {
+	const actual = await vi.importActual<typeof import("@/generated")>(
+		"@/generated",
+	);
+	return {
+		...actual,
+		commitGitChanges: commitGitChangesMock,
+		getGitDiff: getGitDiffMock,
+		getGitDiffStats: getGitDiffStatsMock,
+	};
+});
+
+function createQueryClient() {
+	return new QueryClient({
+		defaultOptions: {
+			queries: {
+				retry: false,
+			},
+		},
+	});
+}
+
+function createWrapper(queryClient: QueryClient) {
+	return ({ children }: { children: ReactNode }) => (
+		<QueryClientProvider client={queryClient}>
+			<Suspense fallback={null}>{children}</Suspense>
+		</QueryClientProvider>
+	);
+}
+
+function getRuntimeQueryOptions(
+	queryClient: QueryClient,
+	queryKey: readonly unknown[],
+) {
+	return queryClient.getQueryCache().find({ queryKey })?.options as
+		| Record<string, unknown>
+		| undefined;
+}
+
+describe("git query refresh policy", () => {
+	beforeEach(() => {
+		commitGitChangesMock.mockReset();
+		getGitDiffMock.mockReset();
+		getGitDiffStatsMock.mockReset();
+	});
+
+	it("keeps full diff snapshots out of the background polling loop", async () => {
+		const queryClient = createQueryClient();
+		getGitDiffMock.mockResolvedValue("");
+
+		const { result } = renderHook(
+			() => useGitDiffFiles("profile-1"),
+			{ wrapper: createWrapper(queryClient) },
+		);
+
+		await waitFor(() => {
+			expect(result.current).toEqual([]);
+		});
+
+		const options = getRuntimeQueryOptions(
+			queryClient,
+			queryKeys.git.diff("profile-1"),
+		);
+		expect(options?.refetchInterval).toBe(false);
+		expect(options?.staleTime).toBe(30_000);
+		expect(options?.refetchOnMount).toBe("always");
+	});
+
+	it("uses a low-frequency fallback refresh for visible diff stats", async () => {
+		const queryClient = createQueryClient();
+		getGitDiffStatsMock.mockResolvedValue({
+			files_changed: 1,
+			insertions: 2,
+			deletions: 3,
+		});
+
+		const { result } = renderHook(
+			() => useGitDiffStats("profile-1", true),
+			{ wrapper: createWrapper(queryClient) },
+		);
+
+		await waitFor(() => {
+			expect(result.current).toEqual({
+				additions: 2,
+				deletions: 3,
+				filesChanged: 1,
+			});
+		});
+
+		const options = getRuntimeQueryOptions(
+			queryClient,
+			queryKeys.git.diffStats("profile-1"),
+		);
+		expect(options?.refetchInterval).toBe(10_000);
+		expect(options?.staleTime).toBe(10_000);
+	});
+});
+
+describe("git mutations", () => {
+	beforeEach(() => {
+		commitGitChangesMock.mockReset();
+	});
+
+	it("refreshes status, diff, stats, log, and ahead caches after committing", async () => {
+		const queryClient = createQueryClient();
+		const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries");
+		commitGitChangesMock.mockResolvedValue("abc1234");
+
+		const { result } = renderHook(
+			() => useCommitGitChanges("profile-1"),
+			{ wrapper: createWrapper(queryClient) },
+		);
+
+		await act(async () => {
+			await result.current.mutateAsync({
+				files: ["src/index.ts"],
+				message: "test commit",
+			});
+		});
+
+		expect(commitGitChangesMock).toHaveBeenCalledWith({
+			profileId: "profile-1",
+			files: ["src/index.ts"],
+			message: "test commit",
+			body: undefined,
+		});
+		expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+			queryKey: queryKeys.git.diff("profile-1"),
+		});
+		expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+			queryKey: queryKeys.git.diffStats("profile-1"),
+		});
+		expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+			queryKey: queryKeys.git.log("profile-1"),
+		});
+		expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+			queryKey: queryKeys.git.status("profile-1"),
+		});
+		expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+			queryKey: queryKeys.git.aheadCount("profile-1"),
+		});
+		invalidateQueriesSpy.mockRestore();
+	});
+});

--- a/src/features/git/hooks.ts
+++ b/src/features/git/hooks.ts
@@ -22,15 +22,18 @@ import { queryKeys } from "@/shared/lib/queryKeys";
 import { collectPatchFiles } from "./patchFiles";
 import type { GitBinaryPreviewSource } from "./utils";
 
-const GIT_STATUS_REFRESH_INTERVAL_MS = 1_000;
+const GIT_LIGHT_REFRESH_INTERVAL_MS = 10_000;
+const GIT_DIFF_SNAPSHOT_STALE_MS = 30_000;
+const GIT_HISTORY_STALE_MS = 60_000;
 const PR_STATUS_REFRESH_INTERVAL_MS = 2 * 60 * 1_000;
 
 function useGitDiff(profileId: string) {
 	return useSuspenseQuery({
 		queryKey: queryKeys.git.diff(profileId),
 		queryFn: () => getGitDiff({ profileId }),
-		staleTime: 0,
-		refetchInterval: GIT_STATUS_REFRESH_INTERVAL_MS,
+		staleTime: GIT_DIFF_SNAPSHOT_STALE_MS,
+		refetchOnMount: "always",
+		refetchInterval: false,
 	});
 }
 
@@ -38,8 +41,9 @@ export function useGitLog(profileId: string) {
 	return useSuspenseQuery({
 		queryKey: queryKeys.git.log(profileId),
 		queryFn: () => getGitLog({ profileId }),
-		staleTime: 0,
-		refetchInterval: GIT_STATUS_REFRESH_INTERVAL_MS,
+		staleTime: GIT_HISTORY_STALE_MS,
+		refetchOnMount: "always",
+		refetchInterval: false,
 	});
 }
 
@@ -55,8 +59,8 @@ export function useGitDiffStats(profileId: string, enabled = true) {
 		queryKey: queryKeys.git.diffStats(profileId),
 		queryFn: () => getGitDiffStats({ profileId }),
 		enabled,
-		staleTime: 0,
-		refetchInterval: enabled ? GIT_STATUS_REFRESH_INTERVAL_MS : false,
+		staleTime: GIT_LIGHT_REFRESH_INTERVAL_MS,
+		refetchInterval: enabled ? GIT_LIGHT_REFRESH_INTERVAL_MS : false,
 	});
 
 	return useMemo(() => {
@@ -70,12 +74,13 @@ export function useGitDiffStats(profileId: string, enabled = true) {
 	}, [data]);
 }
 
-export function useGitAheadCount(profileId: string) {
+export function useGitAheadCount(profileId: string, enabled = true) {
 	const { data } = useQuery({
 		queryKey: queryKeys.git.aheadCount(profileId),
 		queryFn: () => getGitAheadCount({ profileId }),
-		staleTime: 0,
-		refetchInterval: GIT_STATUS_REFRESH_INTERVAL_MS,
+		enabled,
+		staleTime: GIT_LIGHT_REFRESH_INTERVAL_MS,
+		refetchInterval: enabled ? GIT_LIGHT_REFRESH_INTERVAL_MS : false,
 	});
 	return data ?? 0;
 }
@@ -137,6 +142,12 @@ export function useCommitGitChanges(profileId: string) {
 				queryClient.invalidateQueries({
 					queryKey: queryKeys.git.log(profileId),
 				}),
+				queryClient.invalidateQueries({
+					queryKey: queryKeys.git.status(profileId),
+				}),
+				queryClient.invalidateQueries({
+					queryKey: queryKeys.git.aheadCount(profileId),
+				}),
 			]);
 		},
 	});
@@ -161,6 +172,9 @@ export function useDiscardGitFileChanges(profileId: string) {
 				}),
 				queryClient.invalidateQueries({
 					queryKey: queryKeys.git.diffStats(profileId),
+				}),
+				queryClient.invalidateQueries({
+					queryKey: queryKeys.git.status(profileId),
 				}),
 				...filePathsToRefresh.map((filePath) =>
 					queryClient.invalidateQueries({

--- a/src/features/git/hooks.ts
+++ b/src/features/git/hooks.ts
@@ -5,7 +5,7 @@ import {
 	useQueryClient,
 	useSuspenseQuery,
 } from "@tanstack/react-query";
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import {
 	commitGitChanges,
 	discardGitFileChanges,
@@ -19,13 +19,24 @@ import {
 	gitPush,
 } from "@/generated";
 import { queryKeys } from "@/shared/lib/queryKeys";
+import { GIT_LIGHT_REFRESH_INTERVAL_MS } from "@/shared/lib/queryRefresh";
 import { collectPatchFiles } from "./patchFiles";
 import type { GitBinaryPreviewSource } from "./utils";
 
-const GIT_LIGHT_REFRESH_INTERVAL_MS = 10_000;
 const GIT_DIFF_SNAPSHOT_STALE_MS = 30_000;
 const GIT_HISTORY_STALE_MS = 60_000;
 const PR_STATUS_REFRESH_INTERVAL_MS = 2 * 60 * 1_000;
+
+function useRefreshOnEnable(enabled: boolean, refetch: () => Promise<unknown>) {
+	const wasEnabledRef = useRef(enabled);
+
+	useEffect(() => {
+		if (!wasEnabledRef.current && enabled) {
+			void refetch();
+		}
+		wasEnabledRef.current = enabled;
+	}, [enabled, refetch]);
+}
 
 function useGitDiff(profileId: string) {
 	return useSuspenseQuery({
@@ -33,7 +44,7 @@ function useGitDiff(profileId: string) {
 		queryFn: () => getGitDiff({ profileId }),
 		staleTime: GIT_DIFF_SNAPSHOT_STALE_MS,
 		refetchOnMount: "always",
-		refetchInterval: false,
+		refetchInterval: GIT_LIGHT_REFRESH_INTERVAL_MS,
 	});
 }
 
@@ -43,7 +54,7 @@ export function useGitLog(profileId: string) {
 		queryFn: () => getGitLog({ profileId }),
 		staleTime: GIT_HISTORY_STALE_MS,
 		refetchOnMount: "always",
-		refetchInterval: false,
+		refetchInterval: GIT_LIGHT_REFRESH_INTERVAL_MS,
 	});
 }
 
@@ -55,13 +66,14 @@ function useCommitDiff(profileId: string, commitHash: string) {
 }
 
 export function useGitDiffStats(profileId: string, enabled = true) {
-	const { data } = useQuery({
+	const { data, refetch } = useQuery({
 		queryKey: queryKeys.git.diffStats(profileId),
 		queryFn: () => getGitDiffStats({ profileId }),
 		enabled,
 		staleTime: GIT_LIGHT_REFRESH_INTERVAL_MS,
 		refetchInterval: enabled ? GIT_LIGHT_REFRESH_INTERVAL_MS : false,
 	});
+	useRefreshOnEnable(enabled, refetch);
 
 	return useMemo(() => {
 		if (!data) return null;
@@ -75,13 +87,14 @@ export function useGitDiffStats(profileId: string, enabled = true) {
 }
 
 export function useGitAheadCount(profileId: string, enabled = true) {
-	const { data } = useQuery({
+	const { data, refetch } = useQuery({
 		queryKey: queryKeys.git.aheadCount(profileId),
 		queryFn: () => getGitAheadCount({ profileId }),
 		enabled,
 		staleTime: GIT_LIGHT_REFRESH_INTERVAL_MS,
 		refetchInterval: enabled ? GIT_LIGHT_REFRESH_INTERVAL_MS : false,
 	});
+	useRefreshOnEnable(enabled, refetch);
 	return data ?? 0;
 }
 

--- a/src/features/projects/hooks.ts
+++ b/src/features/projects/hooks.ts
@@ -42,7 +42,7 @@ import {
 } from "@/generated";
 import { queryKeys, queryNamespaces } from "@/shared/lib/queryKeys";
 
-const GIT_STATUS_REFRESH_INTERVAL_MS = 1_000;
+const GIT_LIGHT_REFRESH_INTERVAL_MS = 10_000;
 interface UseProjectAvatarOptions {
 	enabled?: boolean;
 }
@@ -66,8 +66,8 @@ export function useGitBranch(folder: string, enabled = true) {
 		queryKey: queryKeys.git.branch(folder),
 		queryFn: () => getGitBranch({ folder }),
 		enabled,
-		staleTime: 0,
-		refetchInterval: enabled ? GIT_STATUS_REFRESH_INTERVAL_MS : false,
+		staleTime: GIT_LIGHT_REFRESH_INTERVAL_MS,
+		refetchInterval: enabled ? GIT_LIGHT_REFRESH_INTERVAL_MS : false,
 	});
 }
 
@@ -310,8 +310,8 @@ export function useFileTreeGitStatus(profileId: string, enabled = true) {
 		queryKey: queryKeys.git.status(profileId),
 		queryFn: () => getFileTreeGitStatus({ profileId }),
 		enabled: !!profileId && enabled,
-		staleTime: 0,
-		refetchInterval: enabled ? GIT_STATUS_REFRESH_INTERVAL_MS : false,
+		staleTime: GIT_LIGHT_REFRESH_INTERVAL_MS,
+		refetchInterval: enabled ? GIT_LIGHT_REFRESH_INTERVAL_MS : false,
 	});
 }
 

--- a/src/features/projects/hooks.ts
+++ b/src/features/projects/hooks.ts
@@ -41,8 +41,8 @@ import {
 	writeFileContent,
 } from "@/generated";
 import { queryKeys, queryNamespaces } from "@/shared/lib/queryKeys";
+import { GIT_LIGHT_REFRESH_INTERVAL_MS } from "@/shared/lib/queryRefresh";
 
-const GIT_LIGHT_REFRESH_INTERVAL_MS = 10_000;
 interface UseProjectAvatarOptions {
 	enabled?: boolean;
 }

--- a/src/features/watcher/fileWatcher.test.ts
+++ b/src/features/watcher/fileWatcher.test.ts
@@ -76,6 +76,18 @@ describe("fileWatcher", () => {
 			],
 			[
 				{
+					queryKey: ["git-branch"],
+					exact: false,
+				},
+			],
+			[
+				{
+					queryKey: ["git-ahead-count"],
+					exact: false,
+				},
+			],
+			[
+				{
 					queryKey: ["fs-tree"],
 					exact: false,
 				},
@@ -93,6 +105,6 @@ describe("fileWatcher", () => {
 		expect(invalidateQueriesMock).not.toHaveBeenCalled();
 
 		vi.advanceTimersByTime(1);
-		expect(invalidateQueriesMock).toHaveBeenCalledTimes(5);
+		expect(invalidateQueriesMock).toHaveBeenCalledTimes(7);
 	});
 });

--- a/src/features/watcher/fileWatcher.ts
+++ b/src/features/watcher/fileWatcher.ts
@@ -37,6 +37,14 @@ channel.onmessage = () => {
 			exact: false,
 		});
 		queryClient.invalidateQueries({
+			queryKey: [queryNamespaces["git-branch"]],
+			exact: false,
+		});
+		queryClient.invalidateQueries({
+			queryKey: [queryNamespaces["git-ahead-count"]],
+			exact: false,
+		});
+		queryClient.invalidateQueries({
 			queryKey: [queryNamespaces["fs-tree"]],
 			exact: false,
 		});

--- a/src/shared/lib/queryRefresh.ts
+++ b/src/shared/lib/queryRefresh.ts
@@ -1,0 +1,1 @@
+export const GIT_LIGHT_REFRESH_INTERVAL_MS = 10_000;


### PR DESCRIPTION
## Summary
- stop polling full git diff and log snapshots every second
- move visible git badges/status to a 10s fallback refresh while relying on watcher invalidation for immediacy
- invalidate branch/ahead/status caches after watcher events and git mutations
- add focused tests for git query refresh policy and watcher invalidation

## Verification
- bunx vitest run src/features/git/hooks.test.tsx src/features/watcher/fileWatcher.test.ts src/features/git/components/GitDiffContent.test.tsx
- bunx tsc --noEmit
- bun run lint:check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incomplete cache invalidation after git commit and discard operations; branch status and ahead-count information now properly refresh
  * Optimized git data refresh intervals for improved performance

* **Tests**
  * Added comprehensive test coverage for git-related data fetching, caching strategies, and mutation cache invalidation behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->