### PR TITLE
fix(sidebar): remove persistent scrollbar gutter on macOS

### DIFF
--- a/src/layout/AppSidebar.tsx
+++ b/src/layout/AppSidebar.tsx
@@ -546,7 +546,7 @@ export default function AppSidebar() {
 						<Box
 							flex="1"
 							minH="0"
-							overflowY="scroll"
+							overflowY="auto"
 							overflowX="hidden"
 							css={{ scrollbarGutter: "stable" }}
 						>


### PR DESCRIPTION
## Summary
- 修复 macOS 上侧栏右侧始终可见的一条白色 gutter
- 原因：`overflowY: scroll` 强制始终显示滚动条，叠加 `scrollbar-gutter: stable` 后变成常驻白条
- 修法：将 `overflowY` 从 `scroll` 改为 `auto`；保留 `scrollbar-gutter: stable`（macOS overlay 模式下 gutter 宽度为 0，无视觉影响；Windows 上仍可防止内容溢出时的 layout shift，沿用 3bc818e 的修复意图）

## 触发场景
进入项目编辑模式后内容溢出，退出编辑模式后白条仍保留。修复后 macOS 上无任何状态会看到白条；Windows 行为不变。

## Test plan
- [ ] macOS：正常模式与编辑模式切换，确认无白条残留
- [ ] macOS：内容超出滚动区时滚动条按需出现
- [ ] Windows：编辑模式进出无横向 layout shift

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sidebar scrollbar now appears only when needed rather than always being visible, improving visual clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->