### PR TITLE
feat(terminal): show agent hook status dots

### DIFF
--- a/src-tauri/bins/2code-helper/AGENTS.md
+++ b/src-tauri/bins/2code-helper/AGENTS.md
@@ -1,19 +1,22 @@
 # AGENTS.md — src-tauri/bins/2code-helper
 
 ## OVERVIEW
-CLI sidecar binary that PTY shells invoke to trigger desktop notifications. Single source file.
+CLI sidecar binary that PTY shells invoke to trigger desktop notification sounds and agent status updates. Single source file.
 
 ## FILE
-`src/main.rs` — Reads `_2CODE_HELPER_URL` env var, sends `GET /notify?session_id={_2CODE_SESSION_ID}` to the Axum server in `infra::helper.rs`.
+`src/main.rs` — Reads `_2CODE_HELPER_URL` env var, sends `GET /notify` or `GET /status?session_id={_2CODE_SESSION_ID}&status=...` to the Axum server in `infra::helper.rs`.
 
 ## NOTIFICATION FLOW
 ```
-PTY shell calls: $_2CODE_HELPER notify
+PTY shell calls: $_2CODE_HELPER status running|waiting|idle
   → 2code-helper reads env vars
   → HTTP GET to infra::helper.rs Axum server
-  → helper plays sound + emits pty-notify Tauri event
-  → frontend terminalStore.markNotified(sessionId)
-  → green dot on terminal tab + sidebar profile item
+  → helper emits pty-agent-status Tauri event
+  → frontend terminalStore.setAgentStatus(sessionId, status)
+  → blinking green/yellow dot on terminal tab + sidebar profile item
+
+PTY shell calls: $_2CODE_HELPER notify
+  → helper plays the configured sound only
 ```
 
 ## BUILDING

--- a/src-tauri/bins/2code-helper/src/main.rs
+++ b/src-tauri/bins/2code-helper/src/main.rs
@@ -1,4 +1,4 @@
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -13,22 +13,37 @@ struct Cli {
 	command: Commands,
 }
 
+#[derive(Clone, Copy, ValueEnum)]
+enum AgentStatusArg {
+	Running,
+	Waiting,
+	Idle,
+}
+
+impl AgentStatusArg {
+	fn as_str(self) -> &'static str {
+		match self {
+			Self::Running => "running",
+			Self::Waiting => "waiting",
+			Self::Idle => "idle",
+		}
+	}
+}
+
 #[derive(Subcommand)]
 enum Commands {
 	/// Trigger a notification sound
 	Notify,
+	/// Update the agent status indicator for the current PTY session
+	Status { status: AgentStatusArg },
 }
 
 fn main() {
 	let cli = Cli::parse();
 	match cli.command {
 		Commands::Notify => {
-			let url = std::env::var("_2CODE_HELPER_URL")
-				.expect("_2CODE_HELPER_URL not set");
-			let notify_url = match std::env::var("_2CODE_SESSION_ID").ok() {
-				Some(sid) => format!("{url}/notify?session_id={sid}"),
-				None => format!("{url}/notify"),
-			};
+			let url = helper_url();
+			let notify_url = format!("{url}/notify");
 			match ureq::get(&notify_url).call() {
 				Ok(mut resp) => {
 					let body: NotifyResponse = resp
@@ -45,5 +60,29 @@ fn main() {
 				}
 			}
 		}
+		Commands::Status { status } => {
+			let Some(session_id) = session_id() else {
+				return;
+			};
+			let url = helper_url();
+			let status_url = format!(
+				"{url}/status?session_id={session_id}&status={}",
+				status.as_str(),
+			);
+			if let Err(e) = ureq::get(&status_url).call() {
+				eprintln!("status failed: {e}");
+				std::process::exit(1);
+			}
+		}
 	}
+}
+
+fn helper_url() -> String {
+	std::env::var("_2CODE_HELPER_URL").expect("_2CODE_HELPER_URL not set")
+}
+
+fn session_id() -> Option<String> {
+	std::env::var("_2CODE_SESSION_ID")
+		.ok()
+		.filter(|sid| !sid.is_empty())
 }

--- a/src-tauri/crates/infra/AGENTS.md
+++ b/src-tauri/crates/infra/AGENTS.md
@@ -10,7 +10,7 @@ Cross-cutting infrastructure. All I/O, OS interaction, and external process mana
 | `pty.rs` | PTY session lifecycle: spawn shell, 4KB read loop, UTF-8 boundary detection, 1MB cap with oldest-chunk pruning |
 | `git.rs` | Git command execution via `std::process::Command` |
 | `shell_init.rs` | ZDOTDIR-based shell init injection — sets `_2CODE_HELPER`, `_2CODE_HELPER_URL`, `_2CODE_SESSION_ID` env vars |
-| `helper.rs` | Axum HTTP server (sidecar endpoint) — receives `/notify?session_id=` → plays sound + emits `pty-notify` event |
+| `helper.rs` | Axum HTTP server (sidecar endpoint) — `/notify` plays sound, `/status` emits `pty-agent-status` |
 | `config.rs` | Load `2code.json` from project root + execute `setup_script`/`teardown_script` via `sh -c` |
 | `logger.rs` | Debug log capture + `start_debug_log`/`stop_debug_log` implementation |
 | `slug.rs` | CJK-aware slug generation using `pinyin` crate — for profile worktree directory/branch names |

--- a/src-tauri/crates/infra/scripts/default_init_common.sh
+++ b/src-tauri/crates/infra/scripts/default_init_common.sh
@@ -1,10 +1,16 @@
 _2CODE_HOME="${HOME}/.2code"
 _2CODE_BIN="${_2CODE_HOME}/bin"
 _2CODE_HOOKS="${_2CODE_HOME}/hooks"
+_2CODE_OPENCODE_DIR="${_2CODE_HOME}/opencode"
+_2CODE_OPENCODE_PLUGINS="${_2CODE_OPENCODE_DIR}/plugins"
+_2CODE_OPENCODE_SOURCE_DIR="${OPENCODE_CONFIG_DIR:-${HOME}/.config/opencode}"
 _2CODE_NOTIFY="${_2CODE_HOOKS}/notify.sh"
+_2CODE_STATUS_RUNNING="${_2CODE_HOOKS}/status-running.sh"
+_2CODE_STATUS_WAITING="${_2CODE_HOOKS}/status-waiting.sh"
+_2CODE_STATUS_IDLE="${_2CODE_HOOKS}/status-idle.sh"
 _2CODE_CLAUDE_SETTINGS="${_2CODE_HOOKS}/claude-settings.json"
 
-command mkdir -p "$_2CODE_BIN" "$_2CODE_HOOKS" 2>/dev/null
+command mkdir -p "$_2CODE_BIN" "$_2CODE_HOOKS" "$_2CODE_OPENCODE_PLUGINS" 2>/dev/null
 
 _2code_json_escape() {
   printf '%s' "$1" | command sed 's/\\/\\\\/g; s/"/\\"/g'
@@ -14,17 +20,120 @@ _2code_shell_quote() {
   printf "'%s'" "$(printf '%s' "$1" | command sed "s/'/'\\\\''/g")"
 }
 
+_2code_link_opencode_items() {
+  [ -d "$1" ] || return 0
+  command find "$1" -mindepth 1 -maxdepth 1 2>/dev/null | while IFS= read -r _2code_item; do
+    _2code_name="${_2code_item##*/}"
+    [ "$_2code_name" = "$3" ] && continue
+    if [ -e "$2/$_2code_name" ] || [ -L "$2/$_2code_name" ]; then
+      continue
+    fi
+    command ln -s "$_2code_item" "$2/$_2code_name" 2>/dev/null || true
+  done
+}
+
+if [ -d "$_2CODE_OPENCODE_SOURCE_DIR" ] && [ "$_2CODE_OPENCODE_SOURCE_DIR" != "$_2CODE_OPENCODE_DIR" ]; then
+  _2code_link_opencode_items "$_2CODE_OPENCODE_SOURCE_DIR" "$_2CODE_OPENCODE_DIR" "plugins"
+  _2code_link_opencode_items "$_2CODE_OPENCODE_SOURCE_DIR/plugins" "$_2CODE_OPENCODE_PLUGINS" "2code-status.js"
+fi
+
 cat >"$_2CODE_NOTIFY" <<'NOTIFY_SH'
 #!/bin/bash
 [[ -z "$_2CODE_HELPER" ]] && exit 0
-"$_2CODE_HELPER" notify &>/dev/null &
+( "$_2CODE_HELPER" notify &>/dev/null || true ) &
+exit 0
 NOTIFY_SH
-command chmod +x "$_2CODE_NOTIFY"
 
-_2CODE_NOTIFY_COMMAND="$(_2code_json_escape "$(_2code_shell_quote "$_2CODE_NOTIFY")")"
+cat >"$_2CODE_STATUS_RUNNING" <<'STATUS_RUNNING_SH'
+#!/bin/bash
+[[ -z "$_2CODE_HELPER" ]] && exit 0
+( "$_2CODE_HELPER" status running &>/dev/null || true ) &
+exit 0
+STATUS_RUNNING_SH
 
-printf '{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"%s"}]}],"PermissionRequest":[{"matcher":"*","hooks":[{"type":"command","command":"%s"}]}]}}\n' \
-	"$_2CODE_NOTIFY_COMMAND" "$_2CODE_NOTIFY_COMMAND" >"$_2CODE_CLAUDE_SETTINGS"
+cat >"$_2CODE_STATUS_WAITING" <<'STATUS_WAITING_SH'
+#!/bin/bash
+[[ -z "$_2CODE_HELPER" ]] && exit 0
+(
+  "$_2CODE_HELPER" status waiting &>/dev/null || true
+  "$_2CODE_HELPER" notify &>/dev/null || true
+) &
+exit 0
+STATUS_WAITING_SH
+
+cat >"$_2CODE_STATUS_IDLE" <<'STATUS_IDLE_SH'
+#!/bin/bash
+[[ -z "$_2CODE_HELPER" ]] && exit 0
+(
+  "$_2CODE_HELPER" status idle &>/dev/null || true
+  "$_2CODE_HELPER" notify &>/dev/null || true
+) &
+exit 0
+STATUS_IDLE_SH
+
+command chmod +x "$_2CODE_NOTIFY" "$_2CODE_STATUS_RUNNING" "$_2CODE_STATUS_WAITING" "$_2CODE_STATUS_IDLE"
+
+_2CODE_RUNNING_COMMAND="$(_2code_json_escape "$(_2code_shell_quote "$_2CODE_STATUS_RUNNING")")"
+_2CODE_WAITING_COMMAND="$(_2code_json_escape "$(_2code_shell_quote "$_2CODE_STATUS_WAITING")")"
+_2CODE_IDLE_COMMAND="$(_2code_json_escape "$(_2code_shell_quote "$_2CODE_STATUS_IDLE")")"
+
+cat >"$_2CODE_CLAUDE_SETTINGS" <<CLAUDE_SETTINGS
+{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"$_2CODE_RUNNING_COMMAND"}]}],"PreToolUse":[{"matcher":"AskUserQuestion|Question|question","hooks":[{"type":"command","command":"$_2CODE_WAITING_COMMAND"}]}],"PermissionRequest":[{"matcher":"*","hooks":[{"type":"command","command":"$_2CODE_WAITING_COMMAND"}]}],"PostToolUse":[{"matcher":"*","hooks":[{"type":"command","command":"$_2CODE_RUNNING_COMMAND"}]}],"PostToolUseFailure":[{"matcher":"*","hooks":[{"type":"command","command":"$_2CODE_RUNNING_COMMAND"}]}],"PermissionDenied":[{"matcher":"*","hooks":[{"type":"command","command":"$_2CODE_RUNNING_COMMAND"}]}],"Stop":[{"hooks":[{"type":"command","command":"$_2CODE_IDLE_COMMAND"}]}],"StopFailure":[{"hooks":[{"type":"command","command":"$_2CODE_IDLE_COMMAND"}]}]}}
+CLAUDE_SETTINGS
+
+cat >"$_2CODE_OPENCODE_PLUGINS/2code-status.js" <<'OPENCODE_PLUGIN'
+const QUESTION_TOOL = /AskUserQuestion|(^|__|[-_])question($|__|[-_])/i;
+
+function runHelper(args) {
+  const helper = process.env._2CODE_HELPER;
+  if (!helper) return;
+
+  try {
+    const child = Bun.spawn([helper, ...args], {
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+    child.exited.catch(() => {});
+  } catch {
+    // Status hooks must never interfere with OpenCode.
+  }
+}
+
+function setStatus(status, notify = false) {
+  runHelper(["status", status]);
+  if (notify) runHelper(["notify"]);
+}
+
+function isQuestionTool(tool) {
+  return typeof tool === "string" && QUESTION_TOOL.test(tool);
+}
+
+export const TwoCodeStatusPlugin = async () => ({
+  event: async ({ event }) => {
+    switch (event.type) {
+      case "tui.prompt.append":
+        setStatus("running");
+        break;
+      case "permission.asked":
+        setStatus("waiting", true);
+        break;
+      case "permission.replied":
+        setStatus("running");
+        break;
+      case "session.idle":
+      case "session.error":
+        setStatus("idle", true);
+        break;
+    }
+  },
+  "tool.execute.before": async (input) => {
+    if (isQuestionTool(input?.tool)) setStatus("waiting", true);
+  },
+  "tool.execute.after": async (input) => {
+    if (isQuestionTool(input?.tool)) setStatus("running");
+  },
+});
+OPENCODE_PLUGIN
 
 printf '#!/bin/bash\n_SETTINGS="%s"\n' "$_2CODE_CLAUDE_SETTINGS" >"$_2CODE_BIN/claude"
 cat >>"$_2CODE_BIN/claude" <<'CLAUDE_WRAPPER'
@@ -51,7 +160,8 @@ exec "$_REAL" --settings "$_SETTINGS" "$@"
 CLAUDE_WRAPPER
 command chmod +x "$_2CODE_BIN/claude"
 
-printf '#!/bin/bash\n_NOTIFY="%s"\n' "$_2CODE_NOTIFY" >"$_2CODE_BIN/codex"
+printf '#!/bin/bash\n_RUNNING_COMMAND="%s"\n_WAITING_COMMAND="%s"\n_IDLE_COMMAND="%s"\n' \
+  "$_2CODE_RUNNING_COMMAND" "$_2CODE_WAITING_COMMAND" "$_2CODE_IDLE_COMMAND" >"$_2CODE_BIN/codex"
 cat >>"$_2CODE_BIN/codex" <<'CODEX_WRAPPER'
 _find_real() {
   local IFS=:
@@ -73,9 +183,39 @@ if [ -z "$_REAL" ]; then
   exit 127
 fi
 exec "$_REAL" \
-  -c "notify=[\"$_NOTIFY\"]" \
+  -c "hooks.UserPromptSubmit=[{hooks=[{type=\"command\",command=\"$_RUNNING_COMMAND\"}]}]" \
+  -c "hooks.PreToolUse=[{matcher=\"AskUserQuestion|Question|question\",hooks=[{type=\"command\",command=\"$_WAITING_COMMAND\"}]}]" \
+  -c "hooks.PermissionRequest=[{matcher=\"*\",hooks=[{type=\"command\",command=\"$_WAITING_COMMAND\"}]}]" \
+  -c "hooks.PostToolUse=[{matcher=\"*\",hooks=[{type=\"command\",command=\"$_RUNNING_COMMAND\"}]}]" \
+  -c "hooks.Stop=[{hooks=[{type=\"command\",command=\"$_IDLE_COMMAND\"}]}]" \
   "$@"
 CODEX_WRAPPER
 command chmod +x "$_2CODE_BIN/codex"
+
+printf '#!/bin/bash\n_CONFIG_DIR="%s"\n' "$_2CODE_OPENCODE_DIR" >"$_2CODE_BIN/opencode"
+cat >>"$_2CODE_BIN/opencode" <<'OPENCODE_WRAPPER'
+_find_real() {
+  local IFS=:
+  for dir in $PATH; do
+    [ -z "$dir" ] && continue
+    case "${dir%/}" in
+      "$HOME/.2code/bin") continue ;;
+    esac
+    if [ -x "$dir/opencode" ] && [ ! -d "$dir/opencode" ]; then
+      printf '%s\n' "$dir/opencode"
+      return 0
+    fi
+  done
+  return 1
+}
+_REAL="$(_find_real)"
+if [ -z "$_REAL" ]; then
+  echo "2code: opencode not found in PATH" >&2
+  exit 127
+fi
+export OPENCODE_CONFIG_DIR="$_CONFIG_DIR"
+exec "$_REAL" "$@"
+OPENCODE_WRAPPER
+command chmod +x "$_2CODE_BIN/opencode"
 
 export PATH="$_2CODE_BIN:$PATH"

--- a/src-tauri/crates/infra/scripts/default_init_common.sh
+++ b/src-tauri/crates/infra/scripts/default_init_common.sh
@@ -3,7 +3,7 @@ _2CODE_BIN="${_2CODE_HOME}/bin"
 _2CODE_HOOKS="${_2CODE_HOME}/hooks"
 _2CODE_OPENCODE_DIR="${_2CODE_HOME}/opencode"
 _2CODE_OPENCODE_PLUGINS="${_2CODE_OPENCODE_DIR}/plugins"
-_2CODE_OPENCODE_SOURCE_DIR="${OPENCODE_CONFIG_DIR:-${HOME}/.config/opencode}"
+_2CODE_OPENCODE_SOURCE_DIR="${OPENCODE_CONFIG_DIR:-}"
 _2CODE_NOTIFY="${_2CODE_HOOKS}/notify.sh"
 _2CODE_STATUS_RUNNING="${_2CODE_HOOKS}/status-running.sh"
 _2CODE_STATUS_WAITING="${_2CODE_HOOKS}/status-waiting.sh"
@@ -32,7 +32,7 @@ _2code_link_opencode_items() {
   done
 }
 
-if [ -d "$_2CODE_OPENCODE_SOURCE_DIR" ] && [ "$_2CODE_OPENCODE_SOURCE_DIR" != "$_2CODE_OPENCODE_DIR" ]; then
+if [ -n "$_2CODE_OPENCODE_SOURCE_DIR" ] && [ -d "$_2CODE_OPENCODE_SOURCE_DIR" ] && [ "$_2CODE_OPENCODE_SOURCE_DIR" != "$_2CODE_OPENCODE_DIR" ]; then
   _2code_link_opencode_items "$_2CODE_OPENCODE_SOURCE_DIR" "$_2CODE_OPENCODE_DIR" "plugins"
   _2code_link_opencode_items "$_2CODE_OPENCODE_SOURCE_DIR/plugins" "$_2CODE_OPENCODE_PLUGINS" "2code-status.js"
 fi

--- a/src-tauri/crates/infra/src/shell_init.rs
+++ b/src-tauri/crates/infra/src/shell_init.rs
@@ -284,7 +284,10 @@ mod tests {
 		std::fs::create_dir_all(&marker).unwrap();
 		let user_opencode_dir = home.join(".config/opencode");
 		let user_opencode_plugins = user_opencode_dir.join("plugins");
+		let custom_opencode_dir = temp.path().join("custom-opencode");
+		let custom_opencode_plugins = custom_opencode_dir.join("plugins");
 		std::fs::create_dir_all(&user_opencode_plugins).unwrap();
+		std::fs::create_dir_all(&custom_opencode_plugins).unwrap();
 		std::fs::write(
 			user_opencode_dir.join("opencode.json"),
 			r#"{"model":"test"}"#,
@@ -293,6 +296,16 @@ mod tests {
 		std::fs::write(
 			user_opencode_plugins.join("user-plugin.js"),
 			"export const UserPlugin = async () => ({});\n",
+		)
+		.unwrap();
+		std::fs::write(
+			custom_opencode_dir.join("opencode.json"),
+			r#"{"model":"custom"}"#,
+		)
+		.unwrap();
+		std::fs::write(
+			custom_opencode_plugins.join("custom-plugin.js"),
+			"export const CustomPlugin = async () => ({});\n",
 		)
 		.unwrap();
 
@@ -392,14 +405,49 @@ opencode --version
 		.unwrap();
 		assert!(opencode_plugin.contains("permission.asked"));
 		assert!(opencode_plugin.contains("tool.execute.before"));
+		assert!(!opencode_dir.join("opencode.json").exists());
+		assert!(!opencode_dir.join("plugins/user-plugin.js").exists());
+
+		let custom_home = temp.path().join("custom home");
+		std::fs::create_dir_all(&custom_home).unwrap();
+		let custom_shell = format!(
+			r#". "{}"
+opencode --version
+"#,
+			init_file.display()
+		);
+		let output = Command::new("/bin/bash")
+			.arg("--noprofile")
+			.arg("--norc")
+			.arg("-c")
+			.arg(custom_shell)
+			.env("HOME", &custom_home)
+			.env("OPENCODE_CONFIG_DIR", &custom_opencode_dir)
+			.env("MARKER", &marker)
+			.env(
+				"PATH",
+				format!("{}:/usr/bin:/bin", real_bin.to_string_lossy()),
+			)
+			.output()
+			.unwrap();
+		assert!(
+			output.status.success(),
+			"custom init failed\nstdout:\n{}\nstderr:\n{}",
+			String::from_utf8_lossy(&output.stdout),
+			String::from_utf8_lossy(&output.stderr),
+		);
+		let custom_2code_opencode_dir = custom_home.join(".2code/opencode");
 		assert_eq!(
-			std::fs::read_link(opencode_dir.join("opencode.json")).unwrap(),
-			user_opencode_dir.join("opencode.json")
+			std::fs::read_link(custom_2code_opencode_dir.join("opencode.json"))
+				.unwrap(),
+			custom_opencode_dir.join("opencode.json")
 		);
 		assert_eq!(
-			std::fs::read_link(opencode_dir.join("plugins/user-plugin.js"))
-				.unwrap(),
-			user_opencode_plugins.join("user-plugin.js")
+			std::fs::read_link(
+				custom_2code_opencode_dir.join("plugins/custom-plugin.js")
+			)
+			.unwrap(),
+			custom_opencode_plugins.join("custom-plugin.js")
 		);
 
 		let claude_settings: serde_json::Value = serde_json::from_str(

--- a/src-tauri/crates/infra/src/shell_init.rs
+++ b/src-tauri/crates/infra/src/shell_init.rs
@@ -274,7 +274,7 @@ mod tests {
 
 	#[test]
 	#[cfg(unix)]
-	fn default_common_init_wraps_claude_stop_hook_and_codex_notify() {
+	fn default_common_init_wraps_agent_status_hooks() {
 		let temp = tempfile::tempdir().unwrap();
 		let home = temp.path().join("home with space");
 		let real_bin = temp.path().join("real-bin");
@@ -282,6 +282,19 @@ mod tests {
 		std::fs::create_dir_all(&home).unwrap();
 		std::fs::create_dir_all(&real_bin).unwrap();
 		std::fs::create_dir_all(&marker).unwrap();
+		let user_opencode_dir = home.join(".config/opencode");
+		let user_opencode_plugins = user_opencode_dir.join("plugins");
+		std::fs::create_dir_all(&user_opencode_plugins).unwrap();
+		std::fs::write(
+			user_opencode_dir.join("opencode.json"),
+			r#"{"model":"test"}"#,
+		)
+		.unwrap();
+		std::fs::write(
+			user_opencode_plugins.join("user-plugin.js"),
+			"export const UserPlugin = async () => ({});\n",
+		)
+		.unwrap();
 
 		write_fake_executable(
 			&real_bin.join("claude"),
@@ -296,10 +309,17 @@ printf '%s\n' "$@" >"$MARKER/codex.args"
 "#,
 		);
 		write_fake_executable(
+			&real_bin.join("opencode"),
+			r#"#!/bin/sh
+printf '%s\n' "$OPENCODE_CONFIG_DIR" >"$MARKER/opencode.config_dir"
+printf '%s\n' "$@" >"$MARKER/opencode.args"
+"#,
+		);
+		write_fake_executable(
 			&marker.join("helper"),
 			&format!(
 				r#"#!/bin/sh
-printf '%s\n' "$@" >>"{}"
+printf '%s\n' "$*" >>"{}"
 "#,
 				marker.join("helper.args").display()
 			),
@@ -311,6 +331,7 @@ printf '%s\n' "$@" >>"{}"
 			r#". "{}"
 claude --version
 codex exec "say ok"
+opencode --version
 "#,
 			init_file.display()
 		);
@@ -346,9 +367,40 @@ codex exec "say ok"
 
 		let codex_args =
 			std::fs::read_to_string(marker.join("codex.args")).unwrap();
-		assert!(codex_args.contains("notify=[\""));
+		assert!(codex_args.contains("hooks.UserPromptSubmit"));
+		assert!(codex_args.contains("hooks.PermissionRequest"));
+		assert!(codex_args.contains("hooks.Stop"));
+		assert!(codex_args.contains(
+			&hooks_dir.join("status-running.sh").display().to_string()
+		));
+		assert!(codex_args.contains(
+			&hooks_dir.join("status-waiting.sh").display().to_string()
+		));
 		assert!(codex_args
-			.contains(&hooks_dir.join("notify.sh").display().to_string()));
+			.contains(&hooks_dir.join("status-idle.sh").display().to_string()));
+
+		let opencode_dir = home.join(".2code/opencode");
+		assert_eq!(
+			std::fs::read_to_string(marker.join("opencode.config_dir"))
+				.unwrap()
+				.trim(),
+			opencode_dir.display().to_string()
+		);
+		let opencode_plugin = std::fs::read_to_string(
+			opencode_dir.join("plugins/2code-status.js"),
+		)
+		.unwrap();
+		assert!(opencode_plugin.contains("permission.asked"));
+		assert!(opencode_plugin.contains("tool.execute.before"));
+		assert_eq!(
+			std::fs::read_link(opencode_dir.join("opencode.json")).unwrap(),
+			user_opencode_dir.join("opencode.json")
+		);
+		assert_eq!(
+			std::fs::read_link(opencode_dir.join("plugins/user-plugin.js"))
+				.unwrap(),
+			user_opencode_plugins.join("user-plugin.js")
+		);
 
 		let claude_settings: serde_json::Value = serde_json::from_str(
 			&std::fs::read_to_string(hooks_dir.join("claude-settings.json"))
@@ -356,8 +408,18 @@ codex exec "say ok"
 		)
 		.unwrap();
 		assert_eq!(
+			claude_settings["hooks"]["UserPromptSubmit"][0]["hooks"][0]
+				["command"],
+			format!("'{}'", hooks_dir.join("status-running.sh").display())
+		);
+		assert_eq!(
+			claude_settings["hooks"]["PermissionRequest"][0]["hooks"][0]
+				["command"],
+			format!("'{}'", hooks_dir.join("status-waiting.sh").display())
+		);
+		assert_eq!(
 			claude_settings["hooks"]["Stop"][0]["hooks"][0]["command"],
-			format!("'{}'", hooks_dir.join("notify.sh").display())
+			format!("'{}'", hooks_dir.join("status-idle.sh").display())
 		);
 
 		let output = Command::new("/bin/bash")
@@ -365,8 +427,10 @@ codex exec "say ok"
 			.arg("--norc")
 			.arg("-c")
 			.arg(format!(
-				"'{}'; sleep 1",
-				hooks_dir.join("notify.sh").display()
+				"'{}'; '{}'; '{}'; sleep 1",
+				hooks_dir.join("status-running.sh").display(),
+				hooks_dir.join("status-waiting.sh").display(),
+				hooks_dir.join("status-idle.sh").display()
 			))
 			.env("_2CODE_HELPER", marker.join("helper"))
 			.env("_2CODE_HELPER_URL", "http://127.0.0.1:1")
@@ -380,10 +444,12 @@ codex exec "say ok"
 			String::from_utf8_lossy(&output.stdout),
 			String::from_utf8_lossy(&output.stderr),
 		);
-		assert_eq!(
-			std::fs::read_to_string(marker.join("helper.args")).unwrap(),
-			"notify\n"
-		);
+		let helper_args =
+			std::fs::read_to_string(marker.join("helper.args")).unwrap();
+		assert!(helper_args.contains("status running"));
+		assert!(helper_args.contains("status waiting"));
+		assert!(helper_args.contains("status idle"));
+		assert!(helper_args.contains("notify"));
 	}
 
 	#[cfg(unix)]

--- a/src-tauri/crates/model/src/notification.rs
+++ b/src-tauri/crates/model/src/notification.rs
@@ -1,9 +1,29 @@
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum AgentStatus {
+	Running,
+	Waiting,
+	Idle,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentStatusEvent {
+	pub session_id: String,
+	pub status: AgentStatus,
+}
+
 /// Response from /notify endpoint — shared between server and CLI
 #[derive(Debug, Serialize, Deserialize)]
 pub struct NotifyResponse {
 	pub played: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct StatusResponse {
+	pub emitted: bool,
 }
 
 /// Notification settings as stored in settings.json

--- a/src-tauri/src/bridge.rs
+++ b/src-tauri/src/bridge.rs
@@ -4,6 +4,7 @@ use tauri::{ipc::Channel, AppHandle, Emitter, Manager};
 
 use infra::db::DbPool;
 use infra::pty::{PtyReadThreads, PtySessionMap};
+use model::notification::{AgentStatus, AgentStatusEvent};
 use model::watcher::WatchEvent;
 use service::pty::{PtyContext, PtyFlushSenders};
 use service::{PtyEventEmitter, WatchEventSender};
@@ -20,6 +21,13 @@ impl PtyEventEmitter for TauriPtyEmitter {
 
 	fn emit_exit(&self, session_id: &str) {
 		let _ = self.0.emit(&format!("pty-exit-{session_id}"), ());
+		let _ = self.0.emit(
+			"pty-agent-status",
+			AgentStatusEvent {
+				session_id: session_id.to_string(),
+				status: AgentStatus::Idle,
+			},
+		);
 	}
 }
 

--- a/src-tauri/src/helper.rs
+++ b/src-tauri/src/helper.rs
@@ -13,8 +13,9 @@ pub struct HelperState {
 }
 
 #[derive(Debug, serde::Deserialize)]
-struct NotifyQuery {
+struct StatusQuery {
 	session_id: Option<String>,
+	status: model::notification::AgentStatus,
 }
 
 fn sidecar_binary_name(target: &str) -> String {
@@ -52,13 +53,26 @@ fn resolve_sidecar_path() -> PathBuf {
 
 async fn notify_handler(
 	State(app): State<AppHandle>,
-	Query(params): Query<NotifyQuery>,
 ) -> Json<model::notification::NotifyResponse> {
 	let played = try_play_notification(&app);
-	if let Some(session_id) = params.session_id.as_deref() {
-		let _ = app.emit("pty-notify", session_id);
-	}
 	Json(model::notification::NotifyResponse { played })
+}
+
+async fn status_handler(
+	State(app): State<AppHandle>,
+	Query(params): Query<StatusQuery>,
+) -> Json<model::notification::StatusResponse> {
+	let emitted = if let Some(session_id) = params.session_id {
+		let event = model::notification::AgentStatusEvent {
+			session_id,
+			status: params.status,
+		};
+		app.emit("pty-agent-status", event).is_ok()
+	} else {
+		false
+	};
+
+	Json(model::notification::StatusResponse { emitted })
 }
 
 fn try_play_notification(app: &AppHandle) -> bool {
@@ -99,6 +113,7 @@ pub fn start(app: &AppHandle) -> HelperState {
 	tauri::async_runtime::spawn(async move {
 		let router = axum::Router::new()
 			.route("/notify", get(notify_handler))
+			.route("/status", get(status_handler))
 			.route("/health", get(health_handler))
 			.with_state(app_handle);
 

--- a/src/app.css
+++ b/src/app.css
@@ -73,6 +73,24 @@ a,
 	}
 }
 
+@keyframes agent-status-pulse {
+	50% {
+		opacity: 0.35;
+		transform: scale(0.72);
+	}
+}
+
+.agent-status-dot--running {
+	animation: agent-status-pulse 1.1s ease-in-out infinite;
+	transform-origin: center;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.agent-status-dot--running {
+		animation: none;
+	}
+}
+
 .project-command-palette__overlay {
 	position: fixed;
 	inset: 0;

--- a/src/features/projects/fileViewerTabsStore.test.ts
+++ b/src/features/projects/fileViewerTabsStore.test.ts
@@ -16,7 +16,8 @@ function resetStores() {
 	});
 	useTerminalStore.setState({
 		profiles: {},
-		notifiedTabs: new Set<string>(),
+		agentStatuses: {},
+		sessionProfileIds: {},
 	});
 	localStorage.clear();
 }

--- a/src/features/terminal/AGENTS.md
+++ b/src/features/terminal/AGENTS.md
@@ -6,11 +6,11 @@ PTY terminal management with xterm.js. The most complex frontend feature.
 ## FILES
 | File | Role |
 |------|------|
-| `store.ts` | Zustand+Immer state: `profiles` (tabs per project), `notifiedTabs` (Set) |
+| `store.ts` | Zustand+Immer state: `profiles` (tabs per project), `agentStatuses` (session → running/waiting) |
 | `state.ts` | Terminal state types and tab lifecycle logic |
 | `Terminal.tsx` | xterm.js component (~305 lines) — connects PTY to xterm |
 | `TerminalLayer.tsx` | Persistent overlay across all routes (CSS display:none) |
-| `TerminalTabs.tsx` | Tab bar with notification dots |
+| `TerminalTabs.tsx` | Tab bar with agent status dots |
 | `TerminalPreview.tsx` | Read-only terminal snapshot for non-active profiles |
 | `hooks.ts` | `useCreateTerminalTab`, `useCloseTerminalTab`, `useRestoreTerminals`, `useTerminalTheme` |
 | `themes.ts` | xterm.js color theme definitions |
@@ -28,9 +28,7 @@ PTY terminal management with xterm.js. The most complex frontend feature.
 2. Pass old `session.id` as `restoreFrom` prop
 3. Terminal writes scrollback chunks, then deletes old record
 
-**Notification system**: PTY shells call `$_2CODE_HELPER notify` → backend emits `pty-notify` → `terminalStore.markNotified(sessionId)` → green dot on tab. Cleared on tab focus via `markRead`.
-
-**Immer MapSet**: `notifiedTabs` is `Set<string>` — requires `enableMapSet()` (called at module level in `store.ts`). If adding `Set`/`Map` to other stores, enable it there too.
+**Agent status system**: agent hooks call `$_2CODE_HELPER status running|waiting|idle` → backend emits `pty-agent-status` → `terminalStore.setAgentStatus(sessionId, status)` → blinking green for running, yellow for waiting. `notify` remains sound-only.
 
 ## WHERE TO LOOK
 | Task | Location |

--- a/src/features/terminal/AgentStatusDot.tsx
+++ b/src/features/terminal/AgentStatusDot.tsx
@@ -1,0 +1,19 @@
+import { Circle } from "@chakra-ui/react";
+import type { AgentStatus } from "./store";
+
+interface AgentStatusDotProps {
+	status: AgentStatus;
+}
+
+export function AgentStatusDot({ status }: AgentStatusDotProps) {
+	return (
+		<Circle
+			aria-hidden="true"
+			size="2"
+			bg={status === "waiting" ? "yellow.400" : "green.500"}
+			alignSelf="center"
+			flexShrink={0}
+			className={status === "running" ? "agent-status-dot--running" : undefined}
+		/>
+	);
+}

--- a/src/features/terminal/TerminalTabs.test.tsx
+++ b/src/features/terminal/TerminalTabs.test.tsx
@@ -119,7 +119,7 @@ describe("terminalTabs file tree drops", () => {
 	beforeEach(() => {
 		useTerminalStore.setState({
 			profiles: {},
-			notifiedTabs: new Set<string>(),
+			agentStatuses: {},
 			sessionProfileIds: {},
 		});
 		useFileViewerTabsStore.setState({ profiles: {} });

--- a/src/features/terminal/TerminalTabs.tsx
+++ b/src/features/terminal/TerminalTabs.tsx
@@ -40,6 +40,7 @@ import {
 	readFileTreeTerminalDropPayload,
 } from "@/shared/lib/fileTreeTerminalDrop";
 import * as m from "@/paraglide/messages.js";
+import { AgentStatusDot } from "./AgentStatusDot";
 import { useCloseTerminalTab } from "./hooks";
 import { useTerminalStore } from "./store";
 import { TAB_STRIP_HEIGHT, TabStrip, type TabStripGroup } from "./TabStrip";
@@ -127,18 +128,23 @@ export default function TerminalTabs({
 		useShallow((state) => state.profiles[profileId] ?? EMPTY_TERMINAL_PROFILE),
 	);
 	// Scope to this profile's tabs only — avoids re-rendering on unrelated PTY notifications
-	const notifiedTabIds = useTerminalStore(
+	const agentStatusEntries = useTerminalStore(
 		useShallow((state) => {
 			const profile = state.profiles[profileId];
-			if (!profile) return [] as string[];
+			if (!profile) return [] as [string, "running" | "waiting"][];
 			return profile.tabs
-				.filter((tab) => state.notifiedTabs.has(tab.id))
-				.map((tab) => tab.id);
+				.map((tab): [string, "running" | "waiting" | undefined] => [
+					tab.id,
+					state.agentStatuses[tab.id],
+				])
+				.filter((entry): entry is [string, "running" | "waiting"] =>
+					Boolean(entry[1]),
+				);
 		}),
 	);
-	const notifiedTabSet = useMemo(
-		() => new Set(notifiedTabIds),
-		[notifiedTabIds],
+	const agentStatusByTabId = useMemo(
+		() => new Map(agentStatusEntries),
+		[agentStatusEntries],
 	);
 	const setActiveTab = useTerminalStore((state) => state.setActiveTab);
 
@@ -306,10 +312,9 @@ export default function TerminalTabs({
 					elementRef: createTerminalDropRef(tab),
 					isSelected:
 						!fileTabActive && !notesActive && tab.id === activeValue,
-					badge:
-						notifiedTabSet.has(tab.id) && tab.id !== activeTabId ? (
-							<Circle size="2" bg="green.500" />
-						) : undefined,
+					badge: agentStatusByTabId.has(tab.id) ? (
+						<AgentStatusDot status={agentStatusByTabId.get(tab.id)!} />
+					) : undefined,
 					onClose: () =>
 						closeTerminalTab({
 							profileId,
@@ -342,7 +347,6 @@ export default function TerminalTabs({
 			},
 		],
 		[
-			activeTabId,
 			activeValue,
 			closeTerminalTab,
 			createTerminalDropRef,
@@ -351,7 +355,7 @@ export default function TerminalTabs({
 			fileTabs,
 			handleFileTabClose,
 			notesActive,
-			notifiedTabSet,
+			agentStatusByTabId,
 			profileId,
 			tabs,
 		],

--- a/src/features/terminal/hooks.test.tsx
+++ b/src/features/terminal/hooks.test.tsx
@@ -53,7 +53,8 @@ function createWrapper(isDark = true) {
 function resetStores() {
 	useTerminalStore.setState({
 		profiles: {},
-		notifiedTabs: new Set<string>(),
+		agentStatuses: {},
+		sessionProfileIds: {},
 	});
 	useFileViewerTabsStore.setState({ profiles: {} });
 	useTerminalSettingsStore.setState({

--- a/src/features/terminal/store.test.ts
+++ b/src/features/terminal/store.test.ts
@@ -4,13 +4,14 @@ import { listen } from "@tauri-apps/api/event";
 import {
 	useTerminalStore,
 	useTerminalProfileIds,
+	useProfileAgentStatus,
 	useProfileHasNotification,
 } from "./store";
 
 function resetStore() {
 	useTerminalStore.setState({
 		profiles: {},
-		notifiedTabs: new Set(),
+		agentStatuses: {},
 		sessionProfileIds: {},
 	});
 	window.history.pushState({}, "", "/");
@@ -18,10 +19,6 @@ function resetStore() {
 
 function getState() {
 	return useTerminalStore.getState();
-}
-
-function setPathname(pathname: string) {
-	window.history.pushState({}, "", pathname);
 }
 
 describe("useTerminalStore", () => {
@@ -68,11 +65,10 @@ describe("useTerminalStore", () => {
 			expect(getState().profiles.p2.tabs).toHaveLength(1);
 		});
 
-		it("clears pending notification when a focused profile opens the tab", () => {
-			setPathname("/projects/project-1/profiles/p1");
-			getState().markNotified("s1");
+		it("keeps existing agent status when adding a matching tab", () => {
+			getState().setAgentStatus("s1", "running");
 			getState().addTab("p1", "s1", "Shell 1");
-			expect(getState().notifiedTabs.has("s1")).toBe(false);
+			expect(getState().agentStatuses.s1).toBe("running");
 		});
 	});
 
@@ -91,13 +87,13 @@ describe("useTerminalStore", () => {
 			expect(getState().profiles.p1).toBeUndefined();
 		});
 
-		it("removes the tab from notifiedTabs set", () => {
+		it("removes the tab from agentStatuses", () => {
 			getState().addTab("p1", "s1", "T1");
 			getState().addTab("p1", "s2", "T2");
-			getState().markNotified("s1");
-			expect(getState().notifiedTabs.has("s1")).toBe(true);
+			getState().setAgentStatus("s1", "running");
+			expect(getState().agentStatuses.s1).toBe("running");
 			getState().closeTab("p1", "s1");
-			expect(getState().notifiedTabs.has("s1")).toBe(false);
+			expect(getState().agentStatuses.s1).toBeUndefined();
 		});
 
 		it("reassigns activeTab when closing the active mid-list tab", () => {
@@ -156,14 +152,13 @@ describe("useTerminalStore", () => {
 			expect(getState().profiles.p1.activeTabId).toBe("s1");
 		});
 
-		it("clears notification from the newly focused tab after closing the active tab", () => {
-			setPathname("/projects/project-1/profiles/p1");
+		it("keeps agent status on the newly focused tab after closing the active tab", () => {
 			getState().addTab("p1", "s1", "T1");
 			getState().addTab("p1", "s2", "T2");
-			getState().markNotified("s1");
+			getState().setAgentStatus("s1", "running");
 			getState().closeTab("p1", "s2");
 			expect(getState().profiles.p1.activeTabId).toBe("s1");
-			expect(getState().notifiedTabs.has("s1")).toBe(false);
+			expect(getState().agentStatuses.s1).toBe("running");
 		});
 	});
 
@@ -175,12 +170,12 @@ describe("useTerminalStore", () => {
 			expect(getState().profiles.p1.activeTabId).toBe("s1");
 		});
 
-		it("removes the tab from notifiedTabs (clears notification)", () => {
+		it("does not clear agent status when the tab becomes active", () => {
 			getState().addTab("p1", "s1", "T1");
 			getState().addTab("p1", "s2", "T2");
-			getState().markNotified("s1");
+			getState().setAgentStatus("s1", "waiting");
 			getState().setActiveTab("p1", "s1");
-			expect(getState().notifiedTabs.has("s1")).toBe(false);
+			expect(getState().agentStatuses.s1).toBe("waiting");
 		});
 
 		it("no-ops when profile does not exist", () => {
@@ -258,44 +253,42 @@ describe("useTerminalStore", () => {
 		});
 	});
 
-	describe("markNotified", () => {
-		it("adds sessionId to notifiedTabs set", () => {
-			getState().markNotified("s1");
-			expect(getState().notifiedTabs.has("s1")).toBe(true);
+	describe("setAgentStatus", () => {
+		it("stores a running status for a session", () => {
+			getState().setAgentStatus("s1", "running");
+			expect(getState().agentStatuses.s1).toBe("running");
 		});
 
-		it("is idempotent (adding same ID twice)", () => {
-			getState().markNotified("s1");
-			getState().markNotified("s1");
-			expect(getState().notifiedTabs.has("s1")).toBe(true);
-			expect(getState().notifiedTabs.size).toBe(1);
+		it("overwrites the same session status", () => {
+			getState().setAgentStatus("s1", "running");
+			getState().setAgentStatus("s1", "waiting");
+			expect(getState().agentStatuses).toEqual({ s1: "waiting" });
 		});
 
-		it("does not keep unread state for the focused active tab", () => {
-			setPathname("/projects/project-1/profiles/p1");
+		it("keeps status for active tabs", () => {
 			getState().addTab("p1", "s1", "T1");
-			getState().markNotified("s1");
-			expect(getState().notifiedTabs.has("s1")).toBe(false);
+			getState().setAgentStatus("s1", "waiting");
+			expect(getState().agentStatuses.s1).toBe("waiting");
 		});
 
-		it("still marks unread for active tabs in background profiles", () => {
-			setPathname("/projects/project-1/profiles/p1");
-			getState().addTab("p1", "s1", "T1");
-			getState().addTab("p2", "s2", "T2");
-			getState().markNotified("s2");
-			expect(getState().notifiedTabs.has("s2")).toBe(true);
+		it("clears a session status when idle is received", () => {
+			getState().setAgentStatus("s1", "running");
+			getState().setAgentStatus("s1", "idle");
+			expect(getState().agentStatuses.s1).toBeUndefined();
 		});
 	});
 
-	describe("markRead", () => {
-		it("removes sessionId from notifiedTabs set", () => {
-			getState().markNotified("s1");
-			getState().markRead("s1");
-			expect(getState().notifiedTabs.has("s1")).toBe(false);
+	describe("clearAgentStatus", () => {
+		it("removes a session from agentStatuses", () => {
+			getState().setAgentStatus("s1", "running");
+			getState().clearAgentStatus("s1");
+			expect(getState().agentStatuses.s1).toBeUndefined();
 		});
 
 		it("is idempotent (removing non-existent ID)", () => {
-			expect(() => getState().markRead("nonexistent")).not.toThrow();
+			expect(() =>
+				getState().clearAgentStatus("nonexistent"),
+			).not.toThrow();
 		});
 	});
 
@@ -328,11 +321,11 @@ describe("useTerminalStore", () => {
 			expect(getState().profiles.p2.tabs).toHaveLength(1);
 		});
 
-		it("clears notified state even when closing the last tab (profile deleted)", () => {
+		it("clears agent status even when closing the last tab (profile deleted)", () => {
 			getState().addTab("p1", "s1", "T1");
-			getState().markNotified("s1");
+			getState().setAgentStatus("s1", "running");
 			getState().closeTab("p1", "s1");
-			expect(getState().notifiedTabs.has("s1")).toBe(false);
+			expect(getState().agentStatuses.s1).toBeUndefined();
 			expect(getState().profiles.p1).toBeUndefined();
 		});
 	});
@@ -365,36 +358,40 @@ describe("useTerminalStore", () => {
 		});
 	});
 
-	describe("notification edge cases", () => {
-		it("multiple notifications on different tabs", () => {
+	describe("agent status edge cases", () => {
+		it("tracks statuses on different tabs", () => {
 			getState().addTab("p1", "s1", "T1");
 			getState().addTab("p1", "s2", "T2");
-			getState().markNotified("s1");
-			getState().markNotified("s2");
-			expect(getState().notifiedTabs.size).toBe(2);
+			getState().setAgentStatus("s1", "running");
+			getState().setAgentStatus("s2", "waiting");
+			expect(getState().agentStatuses).toEqual({
+				s1: "running",
+				s2: "waiting",
+			});
 		});
 
-		it("markNotified for non-existent session does not throw", () => {
-			expect(() => getState().markNotified("ghost")).not.toThrow();
-			expect(getState().notifiedTabs.has("ghost")).toBe(true);
+		it("setAgentStatus for non-existent session does not throw", () => {
+			expect(() =>
+				getState().setAgentStatus("ghost", "running"),
+			).not.toThrow();
+			expect(getState().agentStatuses.ghost).toBe("running");
 		});
 
-		it("closing notified tab and re-adding it starts without notification", () => {
+		it("closing a status tab and re-adding a new session starts without status", () => {
 			getState().addTab("p1", "s1", "T1");
 			getState().addTab("p1", "s2", "T2");
-			getState().markNotified("s1");
+			getState().setAgentStatus("s1", "waiting");
 			getState().closeTab("p1", "s1");
 			getState().addTab("p1", "s1-new", "T1 New");
-			expect(getState().notifiedTabs.has("s1")).toBe(false);
-			expect(getState().notifiedTabs.has("s1-new")).toBe(false);
+			expect(getState().agentStatuses.s1).toBeUndefined();
+			expect(getState().agentStatuses["s1-new"]).toBeUndefined();
 		});
 
-		it("setActiveTab on already-active tab still clears notification", () => {
+		it("setActiveTab on already-active tab still keeps status", () => {
 			getState().addTab("p1", "s1", "T1");
-			getState().markNotified("s1");
-			// s1 is already active, but markNotified added it back
+			getState().setAgentStatus("s1", "waiting");
 			getState().setActiveTab("p1", "s1");
-			expect(getState().notifiedTabs.has("s1")).toBe(false);
+			expect(getState().agentStatuses.s1).toBe("waiting");
 		});
 	});
 
@@ -436,7 +433,7 @@ describe("useTerminalStore", () => {
 			expect(result.current).toBe(false);
 		});
 
-		it("returns false when profile has no notified tabs", () => {
+		it("returns false when profile has no active agent status", () => {
 			getState().addTab("p1", "s1", "T1");
 			const { result } = renderHook(() =>
 				useProfileHasNotification("p1"),
@@ -444,29 +441,29 @@ describe("useTerminalStore", () => {
 			expect(result.current).toBe(false);
 		});
 
-		it("returns true when profile has a notified tab", () => {
+		it("returns true when profile has a running tab", () => {
 			getState().addTab("p1", "s1", "T1");
-			getState().markNotified("s1");
+			getState().setAgentStatus("s1", "running");
 			const { result } = renderHook(() =>
 				useProfileHasNotification("p1"),
 			);
 			expect(result.current).toBe(true);
 		});
 
-		it("returns true when any tab in profile is notified", () => {
+		it("returns true when any tab in profile is waiting", () => {
 			getState().addTab("p1", "s1", "T1");
 			getState().addTab("p1", "s2", "T2");
-			getState().markNotified("s2");
+			getState().setAgentStatus("s2", "waiting");
 			const { result } = renderHook(() =>
 				useProfileHasNotification("p1"),
 			);
 			expect(result.current).toBe(true);
 		});
 
-		it("returns false after notification is cleared", () => {
+		it("returns false after status is cleared", () => {
 			getState().addTab("p1", "s1", "T1");
-			getState().markNotified("s1");
-			getState().markRead("s1");
+			getState().setAgentStatus("s1", "running");
+			getState().clearAgentStatus("s1");
 			const { result } = renderHook(() =>
 				useProfileHasNotification("p1"),
 			);
@@ -474,24 +471,61 @@ describe("useTerminalStore", () => {
 		});
 	});
 
-	describe("pty-notify listener", () => {
-		it("calls markNotified when pty-notify event fires", () => {
+	describe("useProfileAgentStatus", () => {
+		it("returns null when no profile tabs have status", () => {
+			getState().addTab("p1", "s1", "T1");
+			const { result } = renderHook(() => useProfileAgentStatus("p1"));
+			expect(result.current).toBeNull();
+		});
+
+		it("returns running when the profile has a running tab", () => {
+			getState().addTab("p1", "s1", "T1");
+			getState().setAgentStatus("s1", "running");
+			const { result } = renderHook(() => useProfileAgentStatus("p1"));
+			expect(result.current).toBe("running");
+		});
+
+		it("prioritizes waiting over running", () => {
+			getState().addTab("p1", "s1", "T1");
+			getState().addTab("p1", "s2", "T2");
+			getState().setAgentStatus("s1", "running");
+			getState().setAgentStatus("s2", "waiting");
+			const { result } = renderHook(() => useProfileAgentStatus("p1"));
+			expect(result.current).toBe("waiting");
+		});
+	});
+
+	describe("pty-agent-status listener", () => {
+		it("updates status when pty-agent-status event fires", () => {
 			// The listen mock was called at module load time
 			const listenMock = vi.mocked(listen);
 			expect(listenMock).toHaveBeenCalledWith(
-				"pty-notify",
+				"pty-agent-status",
 				expect.any(Function),
 			);
 
 			// Extract the callback that was registered
 			const callback = listenMock.mock.calls.find(
-				(call) => call[0] === "pty-notify",
-			)?.[1] as (event: { payload: string }) => void;
+				(call) => call[0] === "pty-agent-status",
+			)?.[1] as (event: {
+				payload: { sessionId: string; status: "running" };
+			}) => void;
 			expect(callback).toBeDefined();
 
-			// Fire the callback and verify markNotified is triggered
-			callback({ payload: "session-xyz" });
-			expect(getState().notifiedTabs.has("session-xyz")).toBe(true);
+			callback({ payload: { sessionId: "session-xyz", status: "running" } });
+			expect(getState().agentStatuses["session-xyz"]).toBe("running");
+		});
+
+		it("clears status when an idle event fires with snake_case payload", () => {
+			const listenMock = vi.mocked(listen);
+			const callback = listenMock.mock.calls.find(
+				(call) => call[0] === "pty-agent-status",
+			)?.[1] as (event: {
+				payload: { session_id: string; status: "idle" };
+			}) => void;
+			getState().setAgentStatus("session-xyz", "waiting");
+			callback({ payload: { session_id: "session-xyz", status: "idle" } });
+			expect(getState().agentStatuses["session-xyz"]).toBeUndefined();
 		});
 	});
 

--- a/src/features/terminal/store.ts
+++ b/src/features/terminal/store.ts
@@ -8,17 +8,19 @@ interface TerminalTab {
 	title: string;
 }
 
+export type AgentStatus = "running" | "waiting";
+type AgentStatusEventStatus = AgentStatus | "idle";
+
+interface AgentStatusEvent {
+	sessionId?: string;
+	session_id?: string;
+	status?: AgentStatusEventStatus;
+}
+
 interface ProjectTerminalState {
 	tabs: TerminalTab[];
 	activeTabId: string | null;
 	counter: number;
-}
-
-const PROFILE_PATH_REGEX = /^\/projects\/[^/]+\/profiles\/([^/]+)$/;
-
-function getFocusedProfileId(): string | null {
-	if (typeof window === "undefined") return null;
-	return window.location.pathname.match(PROFILE_PATH_REGEX)?.[1] ?? null;
 }
 
 function findProfileIdBySessionId(
@@ -46,21 +48,9 @@ function refreshSessionProfileId(
 	}
 }
 
-function clearProfileActiveTabNotification(
-	state: Pick<TerminalStore, "profiles" | "notifiedTabs">,
-	profileId: string | null,
-) {
-	if (!profileId) return;
-
-	const activeTabId = state.profiles[profileId]?.activeTabId;
-	if (activeTabId) {
-		state.notifiedTabs.delete(activeTabId);
-	}
-}
-
 interface TerminalStore {
 	profiles: Record<string, ProjectTerminalState>;
-	notifiedTabs: Set<string>;
+	agentStatuses: Record<string, AgentStatus>;
 	sessionProfileIds: Record<string, string>;
 	addTab: (profileId: string, sessionId: string, title: string) => void;
 	closeTab: (profileId: string, tabId: string) => void;
@@ -68,9 +58,8 @@ interface TerminalStore {
 	removeProfile: (profileId: string) => void;
 	updateTabTitle: (profileId: string, tabId: string, title: string) => void;
 	removeStaleProfiles: (validIds: Set<string>) => void;
-	markNotified: (sessionId: string) => void;
-	markRead: (sessionId: string) => void;
-	markProfileRead: (profileId: string) => void;
+	setAgentStatus: (sessionId: string, status: AgentStatusEventStatus) => void;
+	clearAgentStatus: (sessionId: string) => void;
 }
 
 export const useTerminalStore = create<TerminalStore>()((set) => {
@@ -80,7 +69,7 @@ export const useTerminalStore = create<TerminalStore>()((set) => {
 
 	return {
 		profiles: {},
-		notifiedTabs: new Set<string>(),
+		agentStatuses: {},
 		sessionProfileIds: {},
 
 		addTab(profileId, sessionId, title) {
@@ -97,10 +86,6 @@ export const useTerminalStore = create<TerminalStore>()((set) => {
 					counter: existing.counter + 1,
 				};
 				state.sessionProfileIds[sessionId] ??= profileId;
-
-				if (getFocusedProfileId() === profileId) {
-					clearProfileActiveTabNotification(state, profileId);
-				}
 			});
 		},
 
@@ -110,7 +95,7 @@ export const useTerminalStore = create<TerminalStore>()((set) => {
 				if (!profile) return;
 				const wasActiveTab = tabId === profile.activeTabId;
 
-				state.notifiedTabs.delete(tabId);
+				delete state.agentStatuses[tabId];
 
 				const idx = profile.tabs.findIndex((t) => t.id === tabId);
 				profile.tabs = profile.tabs.filter((t) => t.id !== tabId);
@@ -124,9 +109,6 @@ export const useTerminalStore = create<TerminalStore>()((set) => {
 				if (wasActiveTab) {
 					const newIdx = Math.min(idx, profile.tabs.length - 1);
 					profile.activeTabId = profile.tabs[newIdx].id;
-					if (getFocusedProfileId() === profileId) {
-						clearProfileActiveTabNotification(state, profileId);
-					}
 				}
 			});
 		},
@@ -136,14 +118,15 @@ export const useTerminalStore = create<TerminalStore>()((set) => {
 				const profile = state.profiles[profileId];
 				if (!profile) return;
 				profile.activeTabId = tabId;
-				state.notifiedTabs.delete(tabId);
 			});
 		},
 
 		removeProfile(profileId) {
 			mutate((state) => {
 				const profile = state.profiles[profileId];
-				profile?.tabs.forEach((tab) => state.notifiedTabs.delete(tab.id));
+				profile?.tabs.forEach((tab) => {
+					delete state.agentStatuses[tab.id];
+				});
 				delete state.profiles[profileId];
 				profile?.tabs.forEach((tab) =>
 					refreshSessionProfileId(state, tab.id),
@@ -164,9 +147,9 @@ export const useTerminalStore = create<TerminalStore>()((set) => {
 			mutate((state) => {
 				for (const id of Object.keys(state.profiles)) {
 					if (!validIds.has(id)) {
-						state.profiles[id].tabs.forEach((tab) =>
-							state.notifiedTabs.delete(tab.id),
-						);
+						state.profiles[id].tabs.forEach((tab) => {
+							delete state.agentStatuses[tab.id];
+						});
 						const removedSessionIds = state.profiles[id].tabs.map(
 							(tab) => tab.id,
 						);
@@ -179,33 +162,20 @@ export const useTerminalStore = create<TerminalStore>()((set) => {
 			});
 		},
 
-		markNotified(sessionId) {
+		setAgentStatus(sessionId, status) {
 			mutate((state) => {
-				const profileId = state.sessionProfileIds[sessionId] ?? null;
-				if (
-					profileId &&
-					profileId === getFocusedProfileId() &&
-					state.profiles[profileId]?.activeTabId === sessionId
-				) {
-					state.notifiedTabs.delete(sessionId);
+				if (status === "idle") {
+					delete state.agentStatuses[sessionId];
 					return;
 				}
 
-				state.notifiedTabs.add(sessionId);
+				state.agentStatuses[sessionId] = status;
 			});
 		},
 
-		markRead(sessionId) {
+		clearAgentStatus(sessionId) {
 			mutate((state) => {
-				state.notifiedTabs.delete(sessionId);
-			});
-		},
-
-		markProfileRead(profileId) {
-			mutate((state) => {
-				const profile = state.profiles[profileId];
-				if (!profile) return;
-				profile.tabs.forEach((tab) => state.notifiedTabs.delete(tab.id));
+				delete state.agentStatuses[sessionId];
 			});
 		},
 	};
@@ -216,16 +186,39 @@ export function useTerminalProfileIds() {
 	return useTerminalStore(useShallow((s) => Object.keys(s.profiles)));
 }
 
-/** Whether a profile has any tab with an unread notification. */
-export function useProfileHasNotification(profileId: string): boolean {
+function getProfileAgentStatus(
+	state: Pick<TerminalStore, "profiles" | "agentStatuses">,
+	profileId: string,
+): AgentStatus | null {
+	const profile = state.profiles[profileId];
+	if (!profile) return null;
+
+	let hasRunning = false;
+	for (const tab of profile.tabs) {
+		const status = state.agentStatuses[tab.id];
+		if (status === "waiting") return "waiting";
+		if (status === "running") hasRunning = true;
+	}
+
+	return hasRunning ? "running" : null;
+}
+
+/** The highest-priority agent status among a profile's terminal tabs. */
+export function useProfileAgentStatus(profileId: string): AgentStatus | null {
 	return useTerminalStore((s) => {
-		const profile = s.profiles[profileId];
-		if (!profile) return false;
-		return profile.tabs.some((t) => s.notifiedTabs.has(t.id));
+		return getProfileAgentStatus(s, profileId);
 	});
 }
 
-// Module-level listener for notification events from the backend
-listen<string>("pty-notify", (event) => {
-	useTerminalStore.getState().markNotified(event.payload);
+/** Whether a profile has any active agent status. */
+export function useProfileHasNotification(profileId: string): boolean {
+	return useTerminalStore((s) => getProfileAgentStatus(s, profileId) !== null);
+}
+
+// Module-level listener for agent status events from the backend
+listen<AgentStatusEvent>("pty-agent-status", (event) => {
+	const sessionId = event.payload.sessionId ?? event.payload.session_id;
+	const status = event.payload.status;
+	if (!sessionId || !status) return;
+	useTerminalStore.getState().setAgentStatus(sessionId, status);
 });

--- a/src/layout/AGENTS.md
+++ b/src/layout/AGENTS.md
@@ -10,12 +10,12 @@ layout/
 └── sidebar/
     ├── ProjectMenuItem.tsx # Single project item + collapse/expand
     ├── ProfileList.tsx     # Profiles under a project
-    └── ProfileItem.tsx     # Single profile with notification dot + active state
+    └── ProfileItem.tsx     # Single profile with agent status dot + active state
 ```
 
 ## KEY PATTERNS
 
-**Notification dot**: `ProfileItem` reads `useProfileHasNotification(profileId)` from `features/terminal/store.ts` — renders green dot when PTY notified.
+**Agent status dot**: `ProfileItem` reads `useProfileAgentStatus(profileId)` from `features/terminal/store.ts` — renders yellow when waiting for input and blinking green while running.
 
 **Active state**: Profile items highlight based on current route params (`/projects/:id/profiles/:profileId`). Uses `react-router` `useParams`.
 
@@ -26,6 +26,6 @@ layout/
 ## WHERE TO LOOK
 | Task | Location |
 |------|----------|
-| Notification dot logic | `features/terminal/store.ts::useProfileHasNotification` |
+| Agent status dot logic | `features/terminal/store.ts::useProfileAgentStatus` |
 | Project query | `features/projects/hooks.ts::useProjects` |
 | Profile query | `features/projects/hooks.ts::useProjectProfiles` |

--- a/src/layout/sidebar/ProfileItem.tsx
+++ b/src/layout/sidebar/ProfileItem.tsx
@@ -1,8 +1,9 @@
-import { Circle, HStack, Icon, Menu, Portal } from "@chakra-ui/react";
+import { HStack, Icon, Menu, Portal } from "@chakra-ui/react";
 import { FiGitBranch } from "react-icons/fi";
 import { NavLink } from "react-router";
 import DeleteProfileDialog from "@/features/profiles/DeleteProfileDialog";
-import { useProfileHasNotification, useTerminalStore } from "@/features/terminal/store";
+import { AgentStatusDot } from "@/features/terminal/AgentStatusDot";
+import { useProfileAgentStatus } from "@/features/terminal/store";
 import type { Profile } from "@/generated";
 import * as m from "@/paraglide/messages.js";
 import OverflowTooltipText from "@/shared/components/OverflowTooltipText";
@@ -19,8 +20,7 @@ export function ProfileItem({
 	isActive: boolean;
 }) {
 	const deleteDialog = useDialogState();
-	const hasNotification = useProfileHasNotification(profile.id);
-	const markProfileRead = useTerminalStore((s) => s.markProfileRead);
+	const agentStatus = useProfileAgentStatus(profile.id);
 
 	return (
 		<>
@@ -45,10 +45,7 @@ export function ProfileItem({
 						_hover={{ bg: "bg.subtle" }}
 						_active={{ bg: "bg.muted" }}
 					>
-						<NavLink
-							to={`/projects/${projectId}/profiles/${profile.id}`}
-							onClick={() => markProfileRead(profile.id)}
-						>
+						<NavLink to={`/projects/${projectId}/profiles/${profile.id}`}>
 							{isActive && (
 								<SidebarActiveIndicator insetInlineStart="0" />
 							)}
@@ -64,14 +61,7 @@ export function ProfileItem({
 								flex="1 1 auto"
 								minW="0"
 							/>
-							{hasNotification && (
-								<Circle
-									size="2"
-									bg="green.500"
-									alignSelf="center"
-									flexShrink={0}
-								/>
-							)}
+							{agentStatus && <AgentStatusDot status={agentStatus} />}
 						</NavLink>
 					</HStack>
 				</Menu.ContextTrigger>

--- a/src/layout/sidebar/ProjectMenuItem.tsx
+++ b/src/layout/sidebar/ProjectMenuItem.tsx
@@ -1,5 +1,4 @@
 import {
-	Circle,
 	HStack,
 	Icon,
 	IconButton,
@@ -20,10 +19,8 @@ import CreateProfileDialog from "@/features/profiles/CreateProfileDialog";
 import DeleteProjectDialog from "@/features/projects/DeleteProjectDialog";
 import ProjectSettingsDialog from "@/features/projects/ProjectSettingsDialog";
 import RenameProjectDialog from "@/features/projects/RenameProjectDialog";
-import {
-	useProfileHasNotification,
-	useTerminalStore,
-} from "@/features/terminal/store";
+import { AgentStatusDot } from "@/features/terminal/AgentStatusDot";
+import { useProfileAgentStatus } from "@/features/terminal/store";
 import type { ProjectGroup, ProjectWithProfiles } from "@/generated";
 import * as m from "@/paraglide/messages.js";
 import OverflowTooltipText from "@/shared/components/OverflowTooltipText";
@@ -58,10 +55,9 @@ export function ProjectMenuItem({
 	const defaultProfileUrl = defaultProfile
 		? `/projects/${project.id}/profiles/${defaultProfile.id}`
 		: `/projects/${project.id}`;
-	const hasDefaultNotification = useProfileHasNotification(
+	const defaultAgentStatus = useProfileAgentStatus(
 		defaultProfile?.id ?? "",
 	);
-	const markProfileRead = useTerminalStore((s) => s.markProfileRead);
 	const defaultProfileLabel = m.defaultProfile();
 
 	const renameDialog = useDialogState();
@@ -71,14 +67,6 @@ export function ProjectMenuItem({
 	const [menuOpen, setMenuOpen] = useState(false);
 	const [userExpanded, setUserExpanded] = useState<boolean | null>(null);
 	const expanded = userExpanded ?? true;
-	const showProjectNotification =
-		hasOnlyDefaultProfile && hasDefaultNotification;
-
-	function handleDefaultProfileClick() {
-		if (defaultProfile) {
-			markProfileRead(defaultProfile.id);
-		}
-	}
 
 	return (
 		<>
@@ -109,10 +97,7 @@ export function ProjectMenuItem({
 						_hover={{ bg: "bg.subtle" }}
 						_active={{ bg: "bg.muted" }}
 					>
-						<NavLink
-							to={defaultProfileUrl}
-							onClick={handleDefaultProfileClick}
-						>
+						<NavLink to={defaultProfileUrl}>
 							{hasOnlyDefaultProfile && isDefaultActive && (
 								<SidebarActiveIndicator insetInlineStart="0" />
 							)}
@@ -137,14 +122,8 @@ export function ProjectMenuItem({
 								>
 									{project.name}
 								</Text>
-								{showProjectNotification && (
-									<Circle
-										aria-hidden="true"
-										size="2"
-										bg="green.500"
-										alignSelf="center"
-										flexShrink={0}
-									/>
+								{hasOnlyDefaultProfile && defaultAgentStatus && (
+									<AgentStatusDot status={defaultAgentStatus} />
 								)}
 							</HStack>
 
@@ -259,11 +238,6 @@ export function ProjectMenuItem({
 					>
 						<NavLink
 							to={defaultProfileUrl}
-							onClick={() => {
-								if (defaultProfile) {
-									markProfileRead(defaultProfile.id);
-								}
-							}}
 						>
 							{isDefaultActive && (
 								<SidebarActiveIndicator insetInlineStart="0" />
@@ -280,13 +254,8 @@ export function ProjectMenuItem({
 								flex="1 1 auto"
 								minW="0"
 							/>
-							{hasDefaultNotification && (
-								<Circle
-									size="2"
-									bg="green.500"
-									alignSelf="center"
-									flexShrink={0}
-								/>
+							{defaultAgentStatus && (
+								<AgentStatusDot status={defaultAgentStatus} />
 							)}
 						</NavLink>
 					</HStack>


### PR DESCRIPTION
## Summary
- add typed agent status events for running/waiting/idle terminal hook state
- generate Claude, Codex, and OpenCode status hooks from the 2code shell init
- render yellow waiting dots and blinking green running dots in terminal tabs and sidebar

## Verification
- cd src-tauri && cargo test -p infra shell_init
- cd src-tauri && cargo test -p twocode-helper
- cd src-tauri && cargo check
- bunx tsc --noEmit
- bunx vitest run src/features/terminal/store.test.ts src/features/terminal/TerminalTabs.test.tsx
- targeted ESLint on touched TS/TSX files
- bash -n / zsh -n src-tauri/crates/infra/scripts/default_init_common.sh
- git diff --check