### PR TITLE
fix(terminal): handle OSC 8 links

### DIFF
--- a/src/features/terminal/Terminal.tsx
+++ b/src/features/terminal/Terminal.tsx
@@ -203,6 +203,9 @@ export function Terminal({ profileId, sessionId, isActive }: TerminalProps) {
 				cursorBlink: true,
 				cursorStyle: "bar",
 				cursorWidth: 4,
+				linkHandler: {
+					activate: handleTerminalLinkOpen,
+				},
 				// ImageAddon mutates windowOptions during activation; keep it per-terminal.
 				windowOptions: {
 					getCellSizePixels: true,


### PR DESCRIPTION
## Summary
- route xterm OSC 8 hyperlink activation through the existing terminal link opener
- keep plain URL links and terminal-native links on the same confirmation/browser-selection path

## Validation
- bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved link handling in the terminal to ensure consistent activation through the application's built-in confirmation and bypass logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->