### PR TITLE
fix(profile): preserve conflicting branches during worktree add

### DIFF
--- a/src-tauri/crates/infra/src/git.rs
+++ b/src-tauri/crates/infra/src/git.rs
@@ -691,8 +691,8 @@ pub fn pull_request_status_for_branch(
 
 /// Try `git worktree add -b <branch> <path>` (new branch).
 /// If the branch already exists, return an error.
-/// If a ref conflict blocks creation (e.g. `feat` exists, blocking `feat/auth`),
-/// delete the conflicting branch and retry once.
+/// If a ref namespace conflict blocks creation (e.g. `feat` exists, blocking `feat/auth`),
+/// return a clear GitError naming the conflicting branch; never delete user branches.
 pub fn worktree_add(
 	project_folder: &str,
 	branch_name: &str,
@@ -716,26 +716,13 @@ pub fn worktree_add(
 		)));
 	}
 
-	// Ref conflict: e.g. 'refs/heads/feat' blocks 'refs/heads/feat/auth'.
-	// Try to delete the conflicting branch and retry once.
+	// Ref namespace conflict: e.g. 'refs/heads/feat' blocks 'refs/heads/feat/auth'.
+	// Never delete the conflicting branch (that would destroy unrelated user work).
+	// Return a specific error so callers (profile creation) can surface a clear message.
 	if stderr.contains("cannot lock ref") {
 		if let Some(conflicting) = extract_conflicting_ref(&stderr) {
-			let _ = command_without_windows_console("git")
-				.args(["branch", "-D", &conflicting])
-				.current_dir(project_folder)
-				.output();
-
-			// Retry
-			let retry = command_without_windows_console("git")
-				.args(["worktree", "add", "-b", branch_name, worktree_path])
-				.current_dir(project_folder)
-				.output()?;
-			if retry.status.success() {
-				return Ok(());
-			}
-			let retry_err = String::from_utf8_lossy(&retry.stderr);
 			return Err(AppError::GitError(format!(
-				"git worktree add failed: {retry_err}"
+				"Branch namespace conflict: '{conflicting}' exists and blocks creation of '{branch_name}'"
 			)));
 		}
 	}

--- a/src-tauri/tests/integration_project.rs
+++ b/src-tauri/tests/integration_project.rs
@@ -6,6 +6,7 @@ use common::{
 	add_commit, cleanup, create_project_with_git_repo, create_temp_git_repo,
 	setup_db,
 };
+use infra::no_window::command_without_windows_console;
 
 fn create_project_named(
 	conn: &mut SqliteConnection,
@@ -597,6 +598,60 @@ fn create_profile_for_nonexistent_project_returns_error() {
 	let result =
 		service::profile::create(&mut conn, "nonexistent-project-id", "branch");
 	assert!(result.is_err());
+}
+
+#[test]
+fn profile_branch_namespace_conflict_does_not_delete_existing_branch() {
+	let mut conn = setup_db();
+	let (project, _default, dir) = create_project_with_git_repo(&mut conn);
+
+	// Create an existing "feat" branch that will namespace-conflict with "feat/auth"
+	command_without_windows_console("git")
+		.args(["branch", "feat"])
+		.current_dir(&dir)
+		.output()
+		.unwrap();
+
+	// Attempt to create profile with branch that conflicts: feat/auth blocked by feat
+	let result = service::profile::create(&mut conn, &project.id, "feat/auth");
+
+	let error = match result {
+		Ok(_) => panic!("expected error for namespace ref conflict"),
+		Err(error) => error,
+	};
+	let error_message = error.to_string();
+	assert!(
+		error_message.to_lowercase().contains("conflict")
+			&& error_message.contains("feat")
+			&& error_message.contains("feat/auth"),
+		"expected namespace conflict error, got: {error_message}"
+	);
+
+	// The 'feat' branch must still exist (core assertion: creation must not delete it)
+	let branch_list = command_without_windows_console("git")
+		.args(["branch", "--list", "feat"])
+		.current_dir(&dir)
+		.output()
+		.unwrap();
+	let branch_out = String::from_utf8_lossy(&branch_list.stdout);
+	assert!(
+		branch_out.contains("feat"),
+		"existing 'feat' branch must survive failed profile creation, got: {branch_out}"
+	);
+
+	// No profile row for the conflicting branch name should have been inserted
+	let list = service::project::list(&mut conn).unwrap();
+	let pwp = list.iter().find(|p| p.id == project.id).unwrap();
+	let has_conflict_profile = pwp
+		.profiles
+		.iter()
+		.any(|p| p.branch_name == "feat/auth");
+	assert!(
+		!has_conflict_profile,
+		"no profile for 'feat/auth' should be inserted on conflict"
+	);
+
+	cleanup(&dir);
 }
 
 // ============================================================


### PR DESCRIPTION
# Plan 001: Stop profile creation from deleting existing branches

> **Executor instructions**: Follow this plan step by step. Run every verification command and confirm the expected result before moving on. If a STOP condition occurs, stop and report; do not improvise. When done, update this plan's row in `plans/README.md`.
>
> **Drift check (run first)**: `git diff --stat 3ee5b79..HEAD -- src-tauri/crates/infra/src/git.rs src-tauri/tests/integration_project.rs src-tauri/tests/integration_git.rs`
> If these files changed, compare the excerpts below with live code before proceeding.

## Status

- **Priority**: P1
- **Effort**: S
- **Risk**: LOW
- **Depends on**: none
- **Category**: bug
- **Planned at**: commit `3ee5b79`, 2026-06-13

## Why this matters

Creating a worktree profile must never delete an unrelated user branch. Today, when Git reports a ref namespace conflict such as existing branch `feat` blocking new branch `feat/auth`, the code force-deletes the conflicting branch and retries. That can destroy unmerged user work as a side effect of profile creation.

## Current state

Relevant files:
- `src-tauri/crates/infra/src/git.rs` — Git command helpers, including `worktree_add`.
- `src-tauri/tests/integration_project.rs` or `src-tauri/tests/integration_git.rs` — integration tests for profile/worktree behavior.

Current excerpts:
- `src-tauri/crates/infra/src/git.rs:719` comment says ref conflict will delete the conflicting branch and retry.
- `src-tauri/crates/infra/src/git.rs:723` runs `git branch -D <conflicting>` before retrying `git worktree add`.
- `src-tauri/crates/infra/src/git.rs:1111` has `extract_conflicting_ref(stderr)` tests that can remain useful for building a clearer error.

Repo conventions:
- Rust tests use temp git repos and `command_without_windows_console`; see existing profile/worktree tests in `src-tauri/tests/integration_project.rs`.
- Return `AppError::GitError` for git failure messages.

## Commands you will need

| Purpose | Command | Expected on success |
|---|---|---|
| Focused Rust test | `cargo test --manifest-path src-tauri/Cargo.toml profile_branch_namespace_conflict_does_not_delete_existing_branch` | exit 0; new test passes |
| Rust tests | `cargo test --manifest-path src-tauri/Cargo.toml` | exit 0; all tests pass |
| Frontend baseline | `bun run lint:check && ./node_modules/.bin/tsc --noEmit` | exit 0; no errors |

## Scope

**In scope**:
- `src-tauri/crates/infra/src/git.rs`
- `src-tauri/tests/integration_project.rs` or `src-tauri/tests/integration_git.rs`

**Out of scope**:
- UI changes to profile creation dialogs.
- Any branch deletion behavior in explicit profile deletion (`branch_delete`) — plan 002 handles deletion lifecycle.

## Git workflow

Use branch `advisor/001-stop-profile-branch-deletion`. Commit message style: conventional commits, e.g. `fix(profile): preserve conflicting branches during worktree add`.

## Steps

### Step 1: Add a failing integration test

Create a temp git repo with an existing branch named `feat`, then attempt to create a profile with branch name `feat/auth`. Assert:
- profile creation returns an error;
- `git branch --list feat` still shows `feat` after the failed creation;
- no profile row for `feat/auth` is inserted.

Use existing temp repo helpers in `src-tauri/tests/common/mod.rs` if available.

**Verify**: `cargo test --manifest-path src-tauri/Cargo.toml profile_branch_namespace_conflict_does_not_delete_existing_branch` → fails before the code change for the right reason, then passes after Step 2.

### Step 2: Remove force-delete retry from `worktree_add`

In `src-tauri/crates/infra/src/git.rs::worktree_add`, replace the `cannot lock ref` branch with a clear `AppError::GitError` that names the conflicting branch when `extract_conflicting_ref` succeeds. Do not run `git branch -D`.

Keep `extract_conflicting_ref` if it improves the error message; remove only dead tests if the helper becomes unused.

**Verify**: focused test from Step 1 exits 0.

### Step 3: Run full validation

Run the full Rust suite and fast frontend checks.

**Verify**:
- `cargo test --manifest-path src-tauri/Cargo.toml` → all pass.
- `bun run lint:check && ./node_modules/.bin/tsc --noEmit` → exit 0.

## Test plan

- New regression test for namespace conflict preserving existing branch.
- Existing worktree creation tests must still pass.

## Done criteria

- [x] No code path in `worktree_add` invokes `git branch -D` for create-time ref conflicts.
- [x] New regression test proves the existing branch survives.
- [x] Full Rust tests pass.
- [x] No unrelated files outside the plan scopes are modified.

## STOP conditions

- Git now reports namespace conflicts with a format that `extract_conflicting_ref` cannot parse and a clear error cannot be produced without broader parser work.
- The required test helpers do not create real branches/worktrees.

## Maintenance notes

Reviewers should scrutinize that profile deletion still deletes branches when intentionally invoked; this plan changes only creation-time conflict behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved branch conflict handling—profile creation now fails gracefully when a branch name conflicts with an existing branch, rather than automatically deleting the existing branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->