### PR TITLE
fix(profile): preserve delete records until cleanup succeeds

### DIFF
--- a/src-tauri/crates/infra/src/git.rs
+++ b/src-tauri/crates/infra/src/git.rs
@@ -732,40 +732,97 @@ pub fn worktree_add(
 	)))
 }
 
-pub fn worktree_remove(project_folder: &str, worktree_path: &str) {
+pub fn worktree_remove(project_folder: &str, worktree_path: &str) -> Result<(), AppError> {
 	let output = command_without_windows_console("git")
 		.args(["worktree", "remove", worktree_path, "--force"])
 		.current_dir(project_folder)
-		.output();
+		.output()?;
 
-	match output {
-		Ok(o) if !o.status.success() => {
-			let stderr = String::from_utf8_lossy(&o.stderr);
-			tracing::warn!("git worktree remove failed: {stderr}");
+	if !output.status.success() {
+		let stderr = String::from_utf8_lossy(&output.stderr);
+		let normalized = stderr.to_lowercase();
+		if normalized.contains("not a working tree")
+			&& !Path::new(worktree_path).exists()
+		{
+			tracing::warn!(
+				"git worktree remove skipped missing worktree: {worktree_path}"
+			);
+			return Ok(());
 		}
-		Err(e) => {
-			tracing::warn!("git worktree remove error: {e}");
-		}
-		_ => {}
+
+		tracing::warn!("git worktree remove failed: {stderr}");
+		return Err(AppError::GitError(command_error(
+			"git worktree remove failed",
+			&output,
+		)));
 	}
+
+	Ok(())
 }
 
-pub fn branch_delete(project_folder: &str, branch_name: &str) {
+pub fn worktree_current_branch(worktree_path: &str) -> Result<Option<String>, AppError> {
+	let output = command_without_windows_console("git")
+		.args(["branch", "--show-current"])
+		.current_dir(worktree_path)
+		.output();
+
+	let output = match output {
+		Ok(output) => output,
+		Err(error) if !Path::new(worktree_path).exists() => {
+			tracing::warn!(
+				"git branch --show-current skipped missing worktree: {worktree_path}: {error}"
+			);
+			return Ok(None);
+		}
+		Err(error) => return Err(AppError::from(error)),
+	};
+
+	if !output.status.success() {
+		if !Path::new(worktree_path).exists() {
+			tracing::warn!(
+				"git branch --show-current skipped missing worktree: {worktree_path}"
+			);
+			return Ok(None);
+		}
+
+		return Err(AppError::GitError(command_error(
+			"git branch --show-current failed",
+			&output,
+		)));
+	}
+
+	let branch_name = String::from_utf8_lossy(&output.stdout).trim().to_string();
+	if branch_name.is_empty() {
+		return Ok(None);
+	}
+
+	Ok(Some(branch_name))
+}
+
+pub fn branch_delete(project_folder: &str, branch_name: &str) -> Result<(), AppError> {
 	let output = command_without_windows_console("git")
 		.args(["branch", "-D", branch_name])
 		.current_dir(project_folder)
-		.output();
+		.output()?;
 
-	match output {
-		Ok(o) if !o.status.success() => {
-			let stderr = String::from_utf8_lossy(&o.stderr);
-			tracing::warn!("git branch delete failed: {stderr}");
+	if !output.status.success() {
+		let stderr = String::from_utf8_lossy(&output.stderr);
+		let normalized = stderr.to_lowercase();
+		if normalized.contains("branch") && normalized.contains("not found") {
+			tracing::warn!(
+				"git branch delete skipped missing branch: {branch_name}"
+			);
+			return Ok(());
 		}
-		Err(e) => {
-			tracing::warn!("git branch delete error: {e}");
-		}
-		_ => {}
+
+		tracing::warn!("git branch delete failed: {stderr}");
+		return Err(AppError::GitError(command_error(
+			"git branch delete failed",
+			&output,
+		)));
 	}
+
+	Ok(())
 }
 
 fn refs_except_branch(

--- a/src-tauri/crates/repo/src/profile.rs
+++ b/src-tauri/crates/repo/src/profile.rs
@@ -65,8 +65,18 @@ pub fn find_by_id(
 		.map_err(|_| AppError::NotFound(format!("Profile: {id}")))
 }
 
+/// Delete the profile row only (assumes caller validated not default etc).
+/// Used internally after successful cleanup in service layer.
+pub fn delete_row(conn: &mut SqliteConnection, id: &str) -> Result<(), AppError> {
+	diesel::delete(profiles::table.find(id))
+		.execute(conn)
+		.map_err(|e| AppError::DbError(e.to_string()))?;
+	Ok(())
+}
+
 /// Delete a profile record and return the profile + project folder.
 /// Default profiles cannot be deleted directly — they are removed via cascade when the project is deleted.
+/// Note: this eagerly deletes the row (for repo unit tests and any legacy direct use); prefer service orchestration for production delete.
 pub fn delete(
 	conn: &mut SqliteConnection,
 	id: &str,
@@ -81,9 +91,7 @@ pub fn delete(
 
 	let project_folder = get_project_folder(conn, &profile.project_id)?;
 
-	diesel::delete(profiles::table.find(id))
-		.execute(conn)
-		.map_err(|e| AppError::DbError(e.to_string()))?;
+	delete_row(conn, id)?;
 
 	Ok((profile, project_folder))
 }

--- a/src-tauri/crates/service/src/profile.rs
+++ b/src-tauri/crates/service/src/profile.rs
@@ -269,15 +269,68 @@ pub fn create(
 }
 
 pub fn delete(conn: &mut SqliteConnection, id: &str) -> Result<(), AppError> {
-	let (profile, project_folder) = repo::profile::delete(conn, id)?;
-	let worktree_path = PathBuf::from(&profile.worktree_path);
+	let profile = repo::profile::find_by_id(conn, id)?;
+	if profile.is_default {
+		return Err(AppError::DbError(
+			"Cannot delete default profile".to_string(),
+		));
+	}
+	let project_folder = repo::profile::get_project_folder(conn, &profile.project_id)?;
 
-	if let Ok(cfg) = infra::config::load_project_config(&project_folder) {
-		infra::config::execute_scripts(&cfg.teardown_script, &worktree_path);
+	cleanup_profile(&profile, &project_folder)?;
+
+	// Delete DB row only after successful cleanup
+	repo::profile::delete_row(conn, id)?;
+
+	Ok(())
+}
+
+/// DB-pool variant for Tauri handler (matches create_with_db pattern).
+/// Reads identity under lock (no delete), performs teardown + git cleanup (propagating errors),
+/// then deletes the profile row only on success.
+pub fn delete_with_db(db: &DbPool, id: &str) -> Result<(), AppError> {
+	let (profile, project_folder) = {
+		let conn = &mut *db.lock().map_err(|_| AppError::LockError)?;
+		let profile = repo::profile::find_by_id(conn, id)?;
+		if profile.is_default {
+			return Err(AppError::DbError(
+				"Cannot delete default profile".to_string(),
+			));
+		}
+		let project_folder = repo::profile::get_project_folder(conn, &profile.project_id)?;
+		(profile, project_folder)
+	};
+
+	cleanup_profile(&profile, &project_folder)?;
+
+	// Delete row under fresh lock, only after cleanup succeeded
+	{
+		let conn = &mut *db.lock().map_err(|_| AppError::LockError)?;
+		repo::profile::delete_row(conn, id)?;
 	}
 
-	infra::git::worktree_remove(&project_folder, &profile.worktree_path);
-	infra::git::branch_delete(&project_folder, &profile.branch_name);
+	Ok(())
+}
+
+fn cleanup_profile(
+	profile: &Profile,
+	project_folder: &str,
+) -> Result<(), AppError> {
+	let worktree_path = PathBuf::from(&profile.worktree_path);
+
+	if let Ok(cfg) = infra::config::load_project_config(project_folder) {
+		infra::config::execute_scripts(
+			&cfg.teardown_script,
+			&worktree_path,
+		);
+	}
+
+	let branch_name =
+		infra::git::worktree_current_branch(&profile.worktree_path)?
+			.unwrap_or_else(|| profile.branch_name.clone());
+
+	infra::git::worktree_remove(project_folder, &profile.worktree_path)?;
+	infra::git::branch_delete(project_folder, &branch_name)?;
 
 	Ok(())
 }

--- a/src-tauri/src/handler/profile.rs
+++ b/src-tauri/src/handler/profile.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 use tauri::State;
 
 use infra::db::DbPool;
@@ -34,26 +32,8 @@ pub async fn delete_profile(
 	state: State<'_, DbPool>,
 ) -> Result<(), AppError> {
 	let db = state.inner().clone();
-	super::run_blocking(move || {
-		let (profile, project_folder) = {
-			let conn = &mut *db.lock().map_err(|_| AppError::LockError)?;
-			repo::profile::delete(conn, &id)?
-		};
-		let worktree_path = PathBuf::from(&profile.worktree_path);
-
-		if let Ok(cfg) = infra::config::load_project_config(&project_folder) {
-			infra::config::execute_scripts(
-				&cfg.teardown_script,
-				&worktree_path,
-			);
-		}
-
-		infra::git::worktree_remove(&project_folder, &profile.worktree_path);
-		infra::git::branch_delete(&project_folder, &profile.branch_name);
-
-		Ok(())
-	})
-	.await
+	super::run_blocking(move || service::profile::delete_with_db(&db, &id))
+		.await
 }
 
 #[tauri::command]

--- a/src-tauri/tests/integration_project.rs
+++ b/src-tauri/tests/integration_project.rs
@@ -642,10 +642,8 @@ fn profile_branch_namespace_conflict_does_not_delete_existing_branch() {
 	// No profile row for the conflicting branch name should have been inserted
 	let list = service::project::list(&mut conn).unwrap();
 	let pwp = list.iter().find(|p| p.id == project.id).unwrap();
-	let has_conflict_profile = pwp
-		.profiles
-		.iter()
-		.any(|p| p.branch_name == "feat/auth");
+	let has_conflict_profile =
+		pwp.profiles.iter().any(|p| p.branch_name == "feat/auth");
 	assert!(
 		!has_conflict_profile,
 		"no profile for 'feat/auth' should be inserted on conflict"
@@ -730,6 +728,111 @@ fn delete_nonexistent_profile_returns_error() {
 	let mut conn = setup_db();
 	let result = service::profile::delete(&mut conn, "nonexistent-profile-id");
 	assert!(result.is_err());
+}
+
+#[test]
+fn delete_profile_keeps_row_when_cleanup_fails() {
+	let mut conn = setup_db();
+	let (project, _default, dir) = create_project_with_git_repo(&mut conn);
+
+	let profile =
+		service::profile::create(&mut conn, &project.id, "cleanup-fail")
+			.unwrap();
+
+	let missing_project_folder = dir.with_extension("missing-project-folder");
+	repo::project::update(
+		&mut conn,
+		&project.id,
+		None,
+		Some(missing_project_folder.to_string_lossy().to_string()),
+	)
+	.unwrap();
+
+	let result = service::profile::delete(&mut conn, &profile.id);
+	assert!(result.is_err(), "expected error when cleanup fails");
+
+	// Critical: the profile row must still exist so user can see it / retry delete later.
+	let list = service::project::list(&mut conn).unwrap();
+	let pwp = list.iter().find(|p| p.id == project.id).unwrap();
+	let row_still_present = pwp.profiles.iter().any(|p| p.id == profile.id);
+	assert!(
+		row_still_present,
+		"profile row must remain in DB after cleanup failure (for retryability)"
+	);
+
+	repo::project::update(
+		&mut conn,
+		&project.id,
+		None,
+		Some(dir.to_string_lossy().to_string()),
+	)
+	.unwrap();
+	service::profile::delete(&mut conn, &profile.id).unwrap();
+
+	cleanup(&dir);
+}
+
+#[test]
+fn delete_profile_succeeds_when_git_resources_already_missing() {
+	let mut conn = setup_db();
+	let (project, _default, dir) = create_project_with_git_repo(&mut conn);
+
+	let profile =
+		service::profile::create(&mut conn, &project.id, "already-clean")
+			.unwrap();
+
+	command_without_windows_console("git")
+		.args(["worktree", "remove", &profile.worktree_path, "--force"])
+		.current_dir(&dir)
+		.output()
+		.unwrap();
+	command_without_windows_console("git")
+		.args(["branch", "-D", &profile.branch_name])
+		.current_dir(&dir)
+		.output()
+		.unwrap();
+
+	service::profile::delete(&mut conn, &profile.id).unwrap();
+
+	assert!(repo::profile::find_by_id(&mut conn, &profile.id).is_err());
+
+	cleanup(&dir);
+}
+
+#[test]
+fn delete_profile_removes_live_renamed_branch() {
+	let mut conn = setup_db();
+	let (project, _default, dir) = create_project_with_git_repo(&mut conn);
+
+	let profile =
+		service::profile::create(&mut conn, &project.id, "rename-me").unwrap();
+
+	command_without_windows_console("git")
+		.args(["branch", "-m", "renamed-outside"])
+		.current_dir(&profile.worktree_path)
+		.output()
+		.unwrap();
+
+	let branch_list = command_without_windows_console("git")
+		.args(["branch", "--list", "renamed-outside"])
+		.current_dir(&dir)
+		.output()
+		.unwrap();
+	assert!(String::from_utf8_lossy(&branch_list.stdout)
+		.contains("renamed-outside"));
+
+	service::profile::delete(&mut conn, &profile.id).unwrap();
+
+	let branch_list = command_without_windows_console("git")
+		.args(["branch", "--list", "renamed-outside"])
+		.current_dir(&dir)
+		.output()
+		.unwrap();
+	assert!(!String::from_utf8_lossy(&branch_list.stdout)
+		.contains("renamed-outside"));
+	assert!(repo::profile::find_by_id(&mut conn, &profile.id).is_err());
+
+	cleanup(&dir);
 }
 
 // ============================================================


### PR DESCRIPTION
# Plan 002: Make profile deletion cleanup transactional and retryable

> **Executor instructions**: Follow this plan step by step. Run every verification command. Update `plans/README.md` when done.
>
> **Drift check (run first)**: `git diff --stat 3ee5b79..HEAD -- src-tauri/crates/repo/src/profile.rs src-tauri/crates/service/src/profile.rs src-tauri/src/handler/profile.rs src-tauri/crates/infra/src/git.rs src/features/profiles/DeleteProfileDialog.tsx src-tauri/tests/integration_project.rs`

## Status

- **Priority**: P1
- **Effort**: M
- **Risk**: MED
- **Depends on**: `plans/001-stop-profile-branch-deletion.md`
- **Category**: bug
- **Planned at**: commit `3ee5b79`, 2026-06-13

## Why this matters

Profile deletion is destructive: it removes a Git worktree and branch. Today the DB row can be deleted before worktree/branch cleanup, and cleanup errors are only logged. A failure leaves orphaned user files/branches with no visible app record for retry or recovery.

## Current state

Relevant files:
- `src-tauri/crates/repo/src/profile.rs` — `delete` deletes DB record and returns the deleted profile + project folder.
- `src-tauri/src/handler/profile.rs` — IPC deletion duplicates service logic.
- `src-tauri/crates/service/src/profile.rs` — service deletion path, also duplicated.
- `src-tauri/crates/infra/src/git.rs` — `worktree_remove` and `branch_delete` return `()` and log failures.
- `src/features/profiles/DeleteProfileDialog.tsx` — already runs `useProfileDeleteCheck` before delete.

Current excerpts:
- `src-tauri/crates/repo/src/profile.rs:84` deletes the row before returning.
- `src-tauri/src/handler/profile.rs:38-52` runs teardown/worktree cleanup after DB delete.
- `src-tauri/crates/infra/src/git.rs:748` and `:766` return `()` and suppress cleanup failures.

Repo conventions:
- Handlers should be thin and delegate to service; `src-tauri/AGENTS.md` documents handler → service → repo/infra layering.
- Git helpers return `Result<_, AppError>` elsewhere.

## Commands you will need

| Purpose | Command | Expected on success |
|---|---|---|
| Focused Rust tests | `cargo test --manifest-path src-tauri/Cargo.toml delete_profile` | exit 0 |
| Full Rust | `cargo test --manifest-path src-tauri/Cargo.toml` | exit 0 |
| Frontend | `bun run test -- DeleteProfileDialog` | exit 0 if touched; otherwise optional |
| Lint/typecheck | `bun run lint:check && ./node_modules/.bin/tsc --noEmit` | exit 0 |

## Scope

**In scope**:
- `src-tauri/crates/repo/src/profile.rs`
- `src-tauri/crates/service/src/profile.rs`
- `src-tauri/src/handler/profile.rs`
- `src-tauri/crates/infra/src/git.rs`
- focused tests in `src-tauri/tests/` and crate tests
- optional UI copy/tests if error behavior changes visibly

**Out of scope**:
- Project deletion cleanup for all profiles; create a follow-up if needed.
- Force-delete UX beyond returning a clear error.

## Git workflow

Branch `advisor/002-profile-delete-cleanup-lifecycle`; commit `fix(profile): preserve delete records until cleanup succeeds`.

## Steps

### Step 1: Make Git cleanup helpers return errors

Change `infra::git::worktree_remove` and `infra::git::branch_delete` to return `Result<(), AppError>`. Preserve current logging if useful, but failed commands must propagate an `AppError::GitError` or `AppError::IoError`.

**Verify**: `cargo test --manifest-path src-tauri/Cargo.toml git::` or full Rust tests compile. Expected: compile errors point to deletion callers until Step 2.

### Step 2: Move profile deletion orchestration into the service

Create/adjust service API so `handler::profile::delete_profile` only clones DB state and calls `service::profile::delete_with_db` or equivalent.

Deletion order should be:
1. Read profile + project folder under DB lock without deleting row.
2. Reject default profile as today.
3. Run teardown script.
4. Run `git worktree remove` and `git branch -D` with errors propagated.
5. Delete the profile row only after cleanup succeeds.

If teardown currently intentionally does not block deletion, preserve that only if documented in tests; otherwise return errors if script execution is changed to `Result`.

**Verify**: `cargo test --manifest-path src-tauri/Cargo.toml delete_non_default_succeeds delete_default_profile_returns_error` → pass.

### Step 3: Add failure regression coverage

Add a test seam if necessary so a cleanup failure can be simulated without relying on platform-specific Git behavior. Assert that when cleanup fails, the profile row remains present and the caller receives an error.

If adding a seam is too invasive, use a temp repo/worktree setup that makes branch deletion fail deterministically while the profile row remains.

**Verify**: focused regression test exits 0.

### Step 4: Full validation

Run full Rust, frontend lint/typecheck, and existing frontend tests if any UI touched.

**Verify**: all commands exit 0.

## Test plan

- Existing default-profile deletion rejection remains.
- Existing successful non-default deletion remains.
- New failed-cleanup test proves DB row remains retryable.

## Done criteria

- [x] `handler::profile::delete_profile` delegates rather than duplicating lifecycle logic.
- [x] Cleanup failures return errors.
- [x] Profile DB row is deleted only after cleanup succeeds.
- [x] Full Rust tests pass.

## STOP conditions

- Teardown script semantics are ambiguous and changing them would be product-visible.
- Reliable cleanup-failure testing requires large test framework changes; report with a proposed seam.

## Maintenance notes

After this lands, project deletion should be re-audited: cascading project delete may still bypass per-profile worktree cleanup.