### PR TITLE
fix(watcher): refresh worktrees and open file caches

### DIFF
--- a/src-tauri/crates/model/src/watcher.rs
+++ b/src-tauri/crates/model/src/watcher.rs
@@ -3,4 +3,7 @@ use serde::Serialize;
 #[derive(Serialize, Clone, Debug)]
 pub struct WatchEvent {
 	pub project_id: String,
+	pub profile_id: Option<String>,
+	pub root_path: String,
+	pub path: Option<String>,
 }

--- a/src-tauri/crates/service/src/watcher.rs
+++ b/src-tauri/crates/service/src/watcher.rs
@@ -1,4 +1,5 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
 use std::sync::atomic::Ordering;
 use std::sync::mpsc;
 use std::time::{Duration, Instant};
@@ -7,6 +8,7 @@ use notify::{recommended_watcher, Event, EventKind, RecursiveMode, Watcher};
 
 use infra::db::DbPool;
 use infra::watcher::WatcherShutdownFlag;
+use model::project::ProjectWithProfiles;
 use model::watcher::WatchEvent;
 
 use crate::WatchEventSender;
@@ -14,10 +16,19 @@ use crate::WatchEventSender;
 const DB_POLL_INTERVAL: Duration = Duration::from_secs(3);
 const RECV_TIMEOUT: Duration = Duration::from_millis(100);
 const DEBOUNCE_DURATION: Duration = Duration::from_millis(500);
+const MAX_DEBOUNCE_KEYS: usize = 1024;
 
 struct ProjectWatcher {
 	// The watcher must be kept alive — dropping it stops watching.
 	_watcher: Box<dyn Watcher + Send>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct WatchTarget {
+	key: String,
+	project_id: String,
+	profile_id: Option<String>,
+	root_path: String,
 }
 
 pub fn start(
@@ -35,7 +46,7 @@ fn run_coordinator(
 	db: DbPool,
 	shutdown: WatcherShutdownFlag,
 ) {
-	let (tx, rx) = mpsc::channel::<String>();
+	let (tx, rx) = mpsc::channel::<WatchEvent>();
 
 	let mut watchers: HashMap<String, ProjectWatcher> = HashMap::new();
 	let mut last_poll = Instant::now() - DB_POLL_INTERVAL;
@@ -54,21 +65,24 @@ fn run_coordinator(
 
 		// Receive filesystem events with timeout
 		match rx.recv_timeout(RECV_TIMEOUT) {
-			Ok(project_id) => {
+			Ok(event) => {
 				let now = Instant::now();
+				prune_debounce_cache(&mut last_event, now);
+				let event_key = watch_event_debounce_key(&event);
 				let should_send = last_event
-					.get(&project_id)
+					.get(&event_key)
 					.map(|t| now.duration_since(*t) >= DEBOUNCE_DURATION)
 					.unwrap_or(true);
 
 				if should_send {
-					last_event.insert(project_id.clone(), now);
+					last_event.insert(event_key, now);
 					tracing::trace!(
 						target: "watcher",
-						%project_id,
+						project_id = %event.project_id,
+						profile_id = ?event.profile_id,
+						path = ?event.path,
 						"file changed"
 					);
-					let event = WatchEvent { project_id };
 					if !sender.send(event) {
 						// Channel closed — frontend dropped it
 						break;
@@ -83,11 +97,11 @@ fn run_coordinator(
 
 fn reconcile_watchers(
 	db: &DbPool,
-	tx: &mpsc::Sender<String>,
+	tx: &mpsc::Sender<WatchEvent>,
 	watchers: &mut HashMap<String, ProjectWatcher>,
 ) {
-	let projects = match db.lock() {
-		Ok(mut conn) => match repo::project::list_all(&mut conn) {
+	let targets = match db.lock() {
+		Ok(mut conn) => match repo::project::list_all_with_profiles(&mut conn) {
 			Ok(p) => p,
 			Err(e) => {
 				tracing::warn!("Watcher: failed to list projects: {e}");
@@ -96,22 +110,23 @@ fn reconcile_watchers(
 		},
 		Err(_) => return,
 	};
+	let targets = watcher_targets(&targets);
 
-	let current_ids: std::collections::HashSet<String> =
-		projects.iter().map(|p| p.id.clone()).collect();
+	let current_keys: HashSet<String> =
+		targets.iter().map(|target| target.key.clone()).collect();
 
-	// Remove watchers for deleted projects
-	watchers.retain(|id, _| current_ids.contains(id));
+	// Remove watchers for deleted projects/profiles
+	watchers.retain(|key, _| current_keys.contains(key));
 
-	// Add watchers for new projects
-	for project in projects {
-		if watchers.contains_key(&project.id) {
+	// Add watchers for new roots
+	for target in targets {
+		if watchers.contains_key(&target.key) {
 			continue;
 		}
 
-		let folder = project.folder.clone();
-		let project_id = project.id.clone();
+		let root_path = target.root_path.clone();
 		let tx_clone = tx.clone();
+		let target_for_event = target.clone();
 
 		let watcher = recommended_watcher(move |res: Result<Event, _>| {
 			if let Ok(event) = res {
@@ -122,12 +137,10 @@ fn reconcile_watchers(
 						| EventKind::Remove(_)
 				);
 				if dominated {
-					let has_project_file = event.paths.iter().any(|path| {
-						// Skip .git internal files to reduce noise
-						!path.components().any(|c| c.as_os_str() == ".git")
-					});
-					if has_project_file {
-						let _ = tx_clone.send(project_id.clone());
+					if let Some(event) =
+						watch_event_for_notify_event(&target_for_event, &event)
+					{
+						let _ = tx_clone.send(event);
 					}
 				}
 			}
@@ -135,16 +148,16 @@ fn reconcile_watchers(
 
 		match watcher {
 			Ok(mut w) => {
-				let path = std::path::Path::new(&folder);
+				let path = Path::new(&root_path);
 				if path.exists() {
 					if let Err(e) = w.watch(path, RecursiveMode::Recursive) {
 						tracing::warn!(
-							"Watcher: failed to watch {folder}: {e}"
+							"Watcher: failed to watch {root_path}: {e}"
 						);
 						continue;
 					}
 					watchers.insert(
-						project.id.clone(),
+						target.key,
 						ProjectWatcher {
 							_watcher: Box::new(w),
 						},
@@ -153,9 +166,274 @@ fn reconcile_watchers(
 			}
 			Err(e) => {
 				tracing::warn!(
-					"Watcher: failed to create watcher for {folder}: {e}"
+					"Watcher: failed to create watcher for {root_path}: {e}"
 				);
 			}
 		}
+	}
+}
+
+fn watcher_targets(projects: &[ProjectWithProfiles]) -> Vec<WatchTarget> {
+	let mut targets = Vec::new();
+
+	for project in projects {
+		let mut has_project_root_profile = false;
+
+		for profile in &project.profiles {
+			if profile.worktree_path == project.folder {
+				has_project_root_profile = true;
+			}
+
+			targets.push(WatchTarget {
+				key: format!("profile:{}:{}", profile.id, profile.worktree_path),
+				project_id: project.id.clone(),
+				profile_id: Some(profile.id.clone()),
+				root_path: profile.worktree_path.clone(),
+			});
+		}
+
+		if !has_project_root_profile {
+			targets.push(WatchTarget {
+				key: format!("project:{}:{}", project.id, project.folder),
+				project_id: project.id.clone(),
+				profile_id: None,
+				root_path: project.folder.clone(),
+			});
+		}
+	}
+
+	targets.sort_by(|left, right| left.key.cmp(&right.key));
+	targets
+}
+
+fn prune_debounce_cache(
+	last_event: &mut HashMap<String, Instant>,
+	now: Instant,
+) {
+	last_event
+		.retain(|_, timestamp| now.duration_since(*timestamp) < DEBOUNCE_DURATION);
+
+	if last_event.len() <= MAX_DEBOUNCE_KEYS {
+		return;
+	}
+
+	let mut entries = last_event
+		.iter()
+		.map(|(key, timestamp)| (key.clone(), *timestamp))
+		.collect::<Vec<_>>();
+	entries.sort_by_key(|(_, timestamp)| *timestamp);
+
+	let remove_count = last_event.len().saturating_sub(MAX_DEBOUNCE_KEYS);
+	for (key, _) in entries.into_iter().take(remove_count) {
+		last_event.remove(&key);
+	}
+}
+
+fn watch_event_debounce_key(event: &WatchEvent) -> String {
+	format!(
+		"{}:{}:{}",
+		event.project_id,
+		event.profile_id.as_deref().unwrap_or(""),
+		event.path.as_deref().unwrap_or("")
+	)
+}
+
+fn watch_event_for_notify_event(
+	target: &WatchTarget,
+	event: &Event,
+) -> Option<WatchEvent> {
+	let paths = event
+		.paths
+		.iter()
+		.filter(|path| !path.components().any(|c| c.as_os_str() == ".git"))
+		.collect::<Vec<_>>();
+	if paths.is_empty() {
+		return None;
+	}
+
+	let root = Path::new(&target.root_path);
+	let relative_paths = paths
+		.iter()
+		.filter_map(|path| relative_event_path(root, path))
+		.collect::<Vec<_>>();
+	let path = if relative_paths.len() == 1 {
+		relative_paths.into_iter().next()
+	} else {
+		None
+	};
+
+	Some(WatchEvent {
+		project_id: target.project_id.clone(),
+		profile_id: target.profile_id.clone(),
+		root_path: target.root_path.clone(),
+		path,
+	})
+}
+
+fn relative_event_path(root: &Path, path: &Path) -> Option<String> {
+	let relative = path.strip_prefix(root).ok()?;
+	let normalized = normalize_relative_path(relative);
+	if normalized.is_empty() {
+		None
+	} else {
+		Some(normalized)
+	}
+}
+
+fn normalize_relative_path(path: &Path) -> String {
+	let mut normalized = String::new();
+	for component in path.components() {
+		let std::path::Component::Normal(value) = component else {
+			continue;
+		};
+		if !normalized.is_empty() {
+			normalized.push('/');
+		}
+		normalized.push_str(&value.to_string_lossy());
+	}
+	normalized
+}
+
+#[cfg(test)]
+mod tests {
+	use model::profile::Profile;
+
+	use super::*;
+
+	fn profile(
+		id: &str,
+		project_id: &str,
+		worktree_path: &str,
+		is_default: bool,
+	) -> Profile {
+		Profile {
+			id: id.to_string(),
+			project_id: project_id.to_string(),
+			branch_name: if is_default { "main" } else { "feature" }.to_string(),
+			worktree_path: worktree_path.to_string(),
+			created_at: "2026-01-01T00:00:00Z".to_string(),
+			is_default,
+			notes: String::new(),
+		}
+	}
+
+	fn project_with_profiles(
+		id: &str,
+		folder: &str,
+		profiles: Vec<Profile>,
+	) -> ProjectWithProfiles {
+		ProjectWithProfiles {
+			id: id.to_string(),
+			name: id.to_string(),
+			folder: folder.to_string(),
+			created_at: "2026-01-01T00:00:00Z".to_string(),
+			group_id: None,
+			sort_order: 1000,
+			pinned_at: None,
+			pinned_order: None,
+			profiles,
+		}
+	}
+
+	#[test]
+	fn watcher_targets_include_profile_worktrees_and_dedupe_default_root() {
+		let projects = vec![project_with_profiles(
+			"project-1",
+			"/repo",
+			vec![
+				profile("default-1", "project-1", "/repo", true),
+				profile("profile-1", "project-1", "/workspace/profile-1", false),
+			],
+		)];
+
+		let targets = watcher_targets(&projects);
+
+		assert_eq!(targets.len(), 2);
+		assert!(targets.iter().any(|target| {
+			target.root_path == "/repo"
+				&& target.project_id == "project-1"
+				&& target.profile_id.as_deref() == Some("default-1")
+		}));
+		assert!(targets.iter().any(|target| {
+			target.root_path == "/workspace/profile-1"
+				&& target.project_id == "project-1"
+				&& target.profile_id.as_deref() == Some("profile-1")
+		}));
+	}
+
+	#[test]
+	fn watcher_targets_keep_project_root_without_profiles() {
+		let projects = vec![project_with_profiles("project-1", "/repo", vec![])];
+
+		let targets = watcher_targets(&projects);
+
+		assert_eq!(targets.len(), 1);
+		assert_eq!(targets[0].root_path, "/repo");
+		assert_eq!(targets[0].profile_id, None);
+	}
+
+	#[test]
+	fn watcher_targets_preserve_duplicate_project_folders() {
+		let projects = vec![
+			project_with_profiles(
+				"project-1",
+				"/repo",
+				vec![profile("default-1", "project-1", "/repo", true)],
+			),
+			project_with_profiles(
+				"project-2",
+				"/repo",
+				vec![profile("default-2", "project-2", "/repo", true)],
+			),
+		];
+
+		let targets = watcher_targets(&projects);
+
+		assert_eq!(targets.len(), 2);
+		assert!(targets.iter().any(|target| {
+			target.root_path == "/repo"
+				&& target.project_id == "project-1"
+				&& target.profile_id.as_deref() == Some("default-1")
+		}));
+		assert!(targets.iter().any(|target| {
+			target.root_path == "/repo"
+				&& target.project_id == "project-2"
+				&& target.profile_id.as_deref() == Some("default-2")
+		}));
+	}
+
+	#[test]
+	fn prune_debounce_cache_removes_expired_entries_and_bounds_size() {
+		let now = Instant::now();
+		let expired = now - DEBOUNCE_DURATION - Duration::from_millis(1);
+		let fresh = now - Duration::from_millis(1);
+		let mut last_event = HashMap::from([("expired".to_string(), expired)]);
+
+		for index in 0..(MAX_DEBOUNCE_KEYS + 10) {
+			last_event.insert(
+				format!("fresh-{index}"),
+				fresh + Duration::from_nanos(index as u64),
+			);
+		}
+
+		prune_debounce_cache(&mut last_event, now);
+
+		assert!(!last_event.contains_key("expired"));
+		assert_eq!(last_event.len(), MAX_DEBOUNCE_KEYS);
+		for index in 0..10 {
+			assert!(!last_event.contains_key(&format!("fresh-{index}")));
+		}
+	}
+
+	#[test]
+	fn relative_event_path_is_root_relative() {
+		let root = Path::new("/repo");
+
+		assert_eq!(
+			relative_event_path(root, Path::new("/repo/src/main.rs")),
+			Some("src/main.rs".to_string()),
+		);
+		assert_eq!(relative_event_path(root, Path::new("/repo")), None);
+		assert_eq!(relative_event_path(root, Path::new("/other/main.rs")), None);
 	}
 }

--- a/src/features/projects/hooks.test.tsx
+++ b/src/features/projects/hooks.test.tsx
@@ -11,9 +11,11 @@ import type {
 	ProjectWithProfiles,
 } from "@/generated";
 import { queryKeys, queryNamespaces } from "@/shared/lib/queryKeys";
+import { GIT_LIGHT_REFRESH_INTERVAL_MS } from "@/shared/lib/queryRefresh";
 import {
 	useDeleteFileTreePaths,
 	useDeleteProject,
+	useFileTreeGitStatus,
 	useFileSearch,
 	useUpdateProjectSidebarLayout,
 } from "./hooks";
@@ -21,11 +23,13 @@ import {
 const {
 	deleteFileTreePathsMock,
 	deleteProjectMock,
+	getFileTreeGitStatusMock,
 	searchFileMock,
 	updateProjectSidebarLayoutMock,
 } = vi.hoisted(() => ({
 	deleteFileTreePathsMock: vi.fn(),
 	deleteProjectMock: vi.fn(),
+	getFileTreeGitStatusMock: vi.fn(),
 	searchFileMock: vi.fn(),
 	updateProjectSidebarLayoutMock: vi.fn(),
 }));
@@ -38,6 +42,7 @@ vi.mock("@/generated", async () => {
 		...actual,
 		deleteFileTreePaths: deleteFileTreePathsMock,
 		deleteProject: deleteProjectMock,
+		getFileTreeGitStatus: getFileTreeGitStatusMock,
 		searchFile: searchFileMock,
 		updateProjectSidebarLayout: updateProjectSidebarLayoutMock,
 	};
@@ -71,6 +76,15 @@ function createWrapperWithClient(queryClient: QueryClient) {
 			{children}
 		</QueryClientProvider>
 	);
+}
+
+function getRuntimeQueryOptions(
+	queryClient: QueryClient,
+	queryKey: readonly unknown[],
+) {
+	return queryClient.getQueryCache().find({ queryKey })?.options as
+		| Record<string, unknown>
+		| undefined;
 }
 
 describe("useDeleteProject", () => {
@@ -159,7 +173,10 @@ describe("useDeleteFileTreePaths", () => {
 			queryKey: queryKeys.fs.tree("profile-1"),
 		});
 		expect(invalidateQueriesSpy).toHaveBeenCalledWith({
-			queryKey: [queryNamespaces["fs-file"]],
+			queryKey: [queryNamespaces["fs-file"], "profile-1"],
+		});
+		expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+			queryKey: [queryNamespaces["fs-file-preview"], "profile-1"],
 		});
 		expect(invalidateQueriesSpy).toHaveBeenCalledWith({
 			queryKey: [queryNamespaces["fs-search"], "profile-1"],
@@ -174,6 +191,33 @@ describe("useDeleteFileTreePaths", () => {
 			queryKey: queryKeys.git.diffStats("profile-1"),
 		});
 		invalidateQueriesSpy.mockRestore();
+	});
+});
+
+describe("useFileTreeGitStatus", () => {
+	beforeEach(() => {
+		getFileTreeGitStatusMock.mockReset();
+	});
+
+	it("uses a fast fallback refresh for visible file-tree status", async () => {
+		const queryClient = createQueryClient();
+		getFileTreeGitStatusMock.mockResolvedValue([]);
+
+		const { result } = renderHook(
+			() => useFileTreeGitStatus("profile-1", true),
+			{ wrapper: createWrapperWithClient(queryClient) },
+		);
+
+		await waitFor(() => {
+			expect(result.current.data).toEqual([]);
+		});
+
+		const options = getRuntimeQueryOptions(
+			queryClient,
+			queryKeys.git.status("profile-1"),
+		);
+		expect(options?.refetchInterval).toBe(GIT_LIGHT_REFRESH_INTERVAL_MS);
+		expect(options?.staleTime).toBe(10_000);
 	});
 });
 

--- a/src/features/projects/hooks.ts
+++ b/src/features/projects/hooks.ts
@@ -408,7 +408,10 @@ export function useDeleteFileTreePaths(profileId: string) {
 					queryKey: queryKeys.fs.tree(profileId),
 				}),
 				queryClient.invalidateQueries({
-					queryKey: [queryNamespaces["fs-file"]],
+					queryKey: [queryNamespaces["fs-file"], profileId],
+				}),
+				queryClient.invalidateQueries({
+					queryKey: [queryNamespaces["fs-file-preview"], profileId],
 				}),
 				queryClient.invalidateQueries({
 					queryKey: [queryNamespaces["fs-search"], profileId],
@@ -464,21 +467,25 @@ export function useCreateFileTreePath(profileId: string) {
 	});
 }
 
-export function useRevealPathInFileManager() {
+export function useRevealPathInFileManager(profileId: string) {
 	return useMutation({
-		mutationFn: ({ profileId, path }: { profileId: string; path: string }) =>
+		mutationFn: ({ path }: { path: string | null }) =>
 			revealPathInFileManager({ profileId, path }),
 	});
 }
 
-export function useOpenPathInDefaultApp() {
+export function useOpenPathInDefaultApp(profileId: string) {
 	return useMutation({
-		mutationFn: ({ profileId, path }: { profileId: string; path: string }) =>
+		mutationFn: ({ path }: { path: string }) =>
 			openPathInDefaultApp({ profileId, path }),
 	});
 }
 
-export function useFileContent(profileId: string, path: string, enabled = true) {
+export function useFileContent(
+	profileId: string,
+	path: string,
+	enabled = true,
+) {
 	return useQuery({
 		queryKey: queryKeys.fs.file(profileId, path),
 		queryFn: () => readFileContent({ profileId, path }),
@@ -487,7 +494,11 @@ export function useFileContent(profileId: string, path: string, enabled = true) 
 	});
 }
 
-export function useFilePreview(profileId: string, path: string, enabled = true) {
+export function useFilePreview(
+	profileId: string,
+	path: string,
+	enabled = true,
+) {
 	return useQuery({
 		queryKey: queryKeys.fs.filePreview(profileId, path),
 		queryFn: () => getFilePreview({ profileId, path }),

--- a/src/features/watcher/fileWatcher.test.ts
+++ b/src/features/watcher/fileWatcher.test.ts
@@ -1,8 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { getQueryDataMock, invalidateQueriesMock, watchProjectsMock } = vi.hoisted(() => ({
+const {
+	getQueryCacheMock,
+	getQueryDataMock,
+	invalidateQueriesMock,
+	queryCacheFindAllMock,
+	watchProjectsMock,
+} = vi.hoisted(() => ({
+	getQueryCacheMock: vi.fn(),
 	getQueryDataMock: vi.fn(),
 	invalidateQueriesMock: vi.fn(),
+	queryCacheFindAllMock: vi.fn(),
 	watchProjectsMock: vi.fn(),
 }));
 
@@ -12,6 +20,7 @@ vi.mock("@/generated", () => ({
 
 vi.mock("@/shared/lib/queryClient", () => ({
 	queryClient: {
+		getQueryCache: getQueryCacheMock,
 		getQueryData: getQueryDataMock,
 		invalidateQueries: invalidateQueriesMock,
 	},
@@ -21,7 +30,14 @@ async function loadWatcher() {
 	await import("./fileWatcher");
 	const [{ onEvent }] = watchProjectsMock.mock.calls.map((args) => args[0]);
 	return onEvent as {
-		onmessage: ((event: { project_id: string }) => void) | null;
+		onmessage: ((
+			event: {
+				project_id: string;
+				profile_id?: string | null;
+				root_path: string;
+				path?: string | null;
+			},
+		) => void) | null;
 	};
 }
 
@@ -29,6 +45,12 @@ describe("fileWatcher", () => {
 	beforeEach(() => {
 		vi.resetModules();
 		vi.useFakeTimers();
+		queryCacheFindAllMock.mockReset();
+		queryCacheFindAllMock.mockReturnValue([]);
+		getQueryCacheMock.mockReset();
+		getQueryCacheMock.mockReturnValue({
+			findAll: queryCacheFindAllMock,
+		});
 		getQueryDataMock.mockReset();
 		invalidateQueriesMock.mockClear();
 		watchProjectsMock.mockClear();
@@ -48,8 +70,8 @@ describe("fileWatcher", () => {
 	it("debounces bursts of file events into a single invalidation batch", async () => {
 		const channel = await loadWatcher();
 
-		channel.onmessage?.({ project_id: "project-1" });
-		channel.onmessage?.({ project_id: "project-1" });
+		channel.onmessage?.({ project_id: "project-1", root_path: "/repo" });
+		channel.onmessage?.({ project_id: "project-1", root_path: "/repo" });
 		vi.advanceTimersByTime(999);
 		expect(invalidateQueriesMock).not.toHaveBeenCalled();
 
@@ -97,23 +119,146 @@ describe("fileWatcher", () => {
 					exact: false,
 				},
 			],
+			[
+				{
+					queryKey: ["fs-file"],
+					exact: false,
+				},
+			],
+			[
+				{
+					queryKey: ["fs-file-preview"],
+					exact: false,
+				},
+			],
 		]);
 	});
 
 	it("resets the debounce timer when another event arrives before the flush", async () => {
 		const channel = await loadWatcher();
 
-		channel.onmessage?.({ project_id: "project-1" });
+		channel.onmessage?.({ project_id: "project-1", root_path: "/repo" });
 		vi.advanceTimersByTime(500);
-		channel.onmessage?.({ project_id: "project-1" });
+		channel.onmessage?.({ project_id: "project-1", root_path: "/repo" });
 		vi.advanceTimersByTime(999);
 		expect(invalidateQueriesMock).not.toHaveBeenCalled();
 
 		vi.advanceTimersByTime(1);
-		expect(invalidateQueriesMock).toHaveBeenCalledTimes(7);
+		expect(invalidateQueriesMock).toHaveBeenCalledTimes(9);
 	});
 
-	it("invalidates only the changed project's profile and tree queries when projects are cached", async () => {
+	it("invalidates precise profile file and preview queries when event includes a path", async () => {
+		const channel = await loadWatcher();
+
+		channel.onmessage?.({
+			project_id: "project-1",
+			profile_id: "profile-1",
+			root_path: "/repo",
+			path: "src/index.ts",
+		});
+		vi.advanceTimersByTime(1000);
+
+		expect(invalidateQueriesMock.mock.calls).toEqual([
+			[{ queryKey: ["git-diff", "profile-1"] }],
+			[{ queryKey: ["git-diff-stats", "profile-1"] }],
+			[{ queryKey: ["git-status", "profile-1"] }],
+			[{ queryKey: ["git-log", "profile-1"] }],
+			[{ queryKey: ["git-ahead-count", "profile-1"] }],
+			[
+				{
+					queryKey: ["fs-tree", "profile-1"],
+					exact: false,
+				},
+			],
+			[{ queryKey: ["git-branch", "/repo"] }],
+			[{ queryKey: ["fs-file", "profile-1", "src/index.ts"] }],
+			[{ queryKey: ["fs-file-preview", "profile-1", "src/index.ts"] }],
+		]);
+	});
+
+	it("invalidates cached descendant file queries for directory events", async () => {
+		queryCacheFindAllMock.mockImplementation(({ queryKey }) => {
+			if (queryKey[0] === "fs-file") {
+				return [
+					{ queryKey: ["fs-file", "profile-1", "src/index.ts"] },
+					{ queryKey: ["fs-file", "profile-1", "src"] },
+					{ queryKey: ["fs-file", "profile-1", "src-other/index.ts"] },
+				];
+			}
+
+			return [
+				{
+					queryKey: [
+						"fs-file-preview",
+						"profile-1",
+						"src/components/Button.tsx",
+					],
+				},
+			];
+		});
+		const channel = await loadWatcher();
+
+		channel.onmessage?.({
+			project_id: "project-1",
+			profile_id: "profile-1",
+			root_path: "/repo",
+			path: "src",
+		});
+		vi.advanceTimersByTime(1000);
+
+		expect(queryCacheFindAllMock).toHaveBeenCalledWith({
+			queryKey: ["fs-file", "profile-1"],
+		});
+		expect(queryCacheFindAllMock).toHaveBeenCalledWith({
+			queryKey: ["fs-file-preview", "profile-1"],
+		});
+		expect(invalidateQueriesMock).toHaveBeenCalledWith({
+			queryKey: ["fs-file", "profile-1", "src"],
+		});
+		expect(invalidateQueriesMock).toHaveBeenCalledWith({
+			queryKey: ["fs-file", "profile-1", "src/index.ts"],
+		});
+		expect(invalidateQueriesMock).toHaveBeenCalledWith({
+			queryKey: [
+				"fs-file-preview",
+				"profile-1",
+				"src/components/Button.tsx",
+			],
+		});
+		expect(invalidateQueriesMock).not.toHaveBeenCalledWith({
+			queryKey: ["fs-file", "profile-1", "src-other/index.ts"],
+		});
+		expect(
+			invalidateQueriesMock.mock.calls.filter(
+				([call]) =>
+					JSON.stringify(call.queryKey)
+					=== JSON.stringify(["fs-file", "profile-1", "src"]),
+			),
+		).toHaveLength(1);
+	});
+
+	it("invalidates profile file namespaces when event has no precise path", async () => {
+		const channel = await loadWatcher();
+
+		channel.onmessage?.({
+			project_id: "project-1",
+			profile_id: "profile-1",
+			root_path: "/repo",
+			path: null,
+		});
+		vi.advanceTimersByTime(1000);
+
+		expect(invalidateQueriesMock).toHaveBeenCalledWith({
+			queryKey: ["fs-file", "profile-1"],
+			exact: false,
+		});
+		expect(invalidateQueriesMock).toHaveBeenCalledWith({
+			queryKey: ["fs-file-preview", "profile-1"],
+			exact: false,
+		});
+	});
+
+	it("invalidates changed project profiles when project-only events are cached", async () => {
 		getQueryDataMock.mockReturnValue([
 			{
 				id: "project-1",
@@ -138,7 +283,7 @@ describe("fileWatcher", () => {
 		]);
 		const channel = await loadWatcher();
 
-		channel.onmessage?.({ project_id: "project-1" });
+		channel.onmessage?.({ project_id: "project-1", root_path: "/repo" });
 		vi.advanceTimersByTime(1000);
 
 		expect(invalidateQueriesMock.mock.calls).toEqual([
@@ -147,10 +292,22 @@ describe("fileWatcher", () => {
 			[{ queryKey: ["git-status", "profile-1"] }],
 			[{ queryKey: ["git-log", "profile-1"] }],
 			[{ queryKey: ["git-ahead-count", "profile-1"] }],
+			[
+				{
+					queryKey: ["fs-tree", "profile-1"],
+					exact: false,
+				},
+			],
 			[{ queryKey: ["git-branch", "/repo"] }],
 			[
 				{
-					queryKey: ["fs-tree", "/repo"],
+					queryKey: ["fs-file", "profile-1"],
+					exact: false,
+				},
+			],
+			[
+				{
+					queryKey: ["fs-file-preview", "profile-1"],
 					exact: false,
 				},
 			],

--- a/src/features/watcher/fileWatcher.ts
+++ b/src/features/watcher/fileWatcher.ts
@@ -7,7 +7,7 @@ import { queryKeys, queryNamespaces } from "@/shared/lib/queryKeys";
 const channel = new Channel<WatchEvent>();
 const INVALIDATION_DEBOUNCE_MS = 1000;
 let invalidateTimer: number | null = null;
-const pendingProjectIds = new Set<string>();
+const pendingEvents: WatchEvent[] = [];
 
 function invalidateAllProjectQueries() {
 	queryClient.invalidateQueries({
@@ -38,34 +38,93 @@ function invalidateAllProjectQueries() {
 		queryKey: [queryNamespaces["fs-tree"]],
 		exact: false,
 	});
+	queryClient.invalidateQueries({
+		queryKey: [queryNamespaces["fs-file"]],
+		exact: false,
+	});
+	queryClient.invalidateQueries({
+		queryKey: [queryNamespaces["fs-file-preview"]],
+		exact: false,
+	});
 }
 
-function invalidateChangedProjects(projectIds: ReadonlySet<string>) {
+function addFileInvalidation(
+	fileInvalidations: Map<string, Set<string | null>>,
+	profileId: string,
+	path: string | null | undefined,
+) {
+	const paths = fileInvalidations.get(profileId) ?? new Set<string | null>();
+	const normalizedPath = path == null ? null : normalizeFilePath(path);
+	paths.add(normalizedPath || null);
+	fileInvalidations.set(profileId, paths);
+}
+
+function normalizeFilePath(path: string) {
+	return path.replaceAll("\\", "/").replace(/^\/+/, "").replace(/\/+$/, "");
+}
+
+function isSameOrDescendantPath(candidatePath: string, changedPath: string) {
+	const normalizedCandidate = normalizeFilePath(candidatePath);
+	const normalizedChanged = normalizeFilePath(changedPath);
+	return (
+		normalizedCandidate === normalizedChanged
+		|| normalizedCandidate.startsWith(`${normalizedChanged}/`)
+	);
+}
+
+function invalidateMatchingCachedFileQueries(
+	namespace: string,
+	profileId: string,
+	changedPath: string,
+) {
+	const queries = queryClient.getQueryCache().findAll({
+		queryKey: [namespace, profileId],
+	});
+
+	for (const query of queries) {
+		const queryKey = query.queryKey;
+		const cachedPath = queryKey[2];
+		if (
+			typeof cachedPath !== "string"
+			|| normalizeFilePath(cachedPath) === changedPath
+			|| !isSameOrDescendantPath(cachedPath, changedPath)
+		) {
+			continue;
+		}
+
+		queryClient.invalidateQueries({ queryKey });
+	}
+}
+
+function invalidateChangedEvents(events: readonly WatchEvent[]) {
 	const projects = queryClient.getQueryData<ProjectWithProfiles[]>(
 		queryKeys.projects.all,
 	);
-	if (!projects) {
-		invalidateAllProjectQueries();
-		return;
-	}
-
-	const projectById = new Map(projects.map((project) => [project.id, project]));
+	const projectById = projects
+		? new Map(projects.map((project) => [project.id, project]))
+		: null;
 	const profileIds = new Set<string>();
 	const branchFolders = new Set<string>();
-	const fileTreeRoots = new Set<string>();
+	const fileInvalidations = new Map<string, Set<string | null>>();
 
-	for (const projectId of projectIds) {
-		const project = projectById.get(projectId);
+	for (const event of events) {
+		if (event.profile_id) {
+			profileIds.add(event.profile_id);
+			branchFolders.add(event.root_path);
+			addFileInvalidation(fileInvalidations, event.profile_id, event.path);
+			continue;
+		}
+
+		const project = projectById?.get(event.project_id);
 		if (!project) {
 			invalidateAllProjectQueries();
 			return;
 		}
 
-		fileTreeRoots.add(project.folder);
 		for (const profile of project.profiles) {
 			profileIds.add(profile.id);
 			branchFolders.add(profile.worktree_path);
-			fileTreeRoots.add(profile.worktree_path);
+			addFileInvalidation(fileInvalidations, profile.id, null);
 		}
 	}
 
@@ -81,22 +140,54 @@ function invalidateChangedProjects(projectIds: ReadonlySet<string>) {
 		queryClient.invalidateQueries({
 			queryKey: queryKeys.git.aheadCount(profileId),
 		});
+		queryClient.invalidateQueries({
+			queryKey: queryKeys.fs.tree(profileId),
+			exact: false,
+		});
 	}
 
 	for (const folder of branchFolders) {
 		queryClient.invalidateQueries({ queryKey: queryKeys.git.branch(folder) });
 	}
 
-	for (const root of fileTreeRoots) {
-		queryClient.invalidateQueries({
-			queryKey: [queryNamespaces["fs-tree"], root],
-			exact: false,
-		});
+	for (const [profileId, paths] of fileInvalidations) {
+		if (paths.has(null)) {
+			queryClient.invalidateQueries({
+				queryKey: [queryNamespaces["fs-file"], profileId],
+				exact: false,
+			});
+			queryClient.invalidateQueries({
+				queryKey: [queryNamespaces["fs-file-preview"], profileId],
+				exact: false,
+			});
+			continue;
+		}
+
+		for (const path of paths) {
+			if (path == null) continue;
+			const normalizedPath = normalizeFilePath(path);
+			queryClient.invalidateQueries({
+				queryKey: queryKeys.fs.file(profileId, normalizedPath),
+			});
+			queryClient.invalidateQueries({
+				queryKey: queryKeys.fs.filePreview(profileId, normalizedPath),
+			});
+			invalidateMatchingCachedFileQueries(
+				queryNamespaces["fs-file"],
+				profileId,
+				normalizedPath,
+			);
+			invalidateMatchingCachedFileQueries(
+				queryNamespaces["fs-file-preview"],
+				profileId,
+				normalizedPath,
+			);
+		}
 	}
 }
 
 channel.onmessage = (event) => {
-	pendingProjectIds.add(event.project_id);
+	pendingEvents.push(event);
 	// File watcher events arrive in bursts during builds/codegen.
 	// Coalesce them so we don't repeatedly re-run full git commands.
 	if (invalidateTimer !== null) {
@@ -105,10 +196,9 @@ channel.onmessage = (event) => {
 
 	invalidateTimer = window.setTimeout(() => {
 		invalidateTimer = null;
-		const projectIds = new Set(pendingProjectIds);
-		pendingProjectIds.clear();
+		const events = pendingEvents.splice(0);
 
-		invalidateChangedProjects(projectIds);
+		invalidateChangedEvents(events);
 	}, INVALIDATION_DEBOUNCE_MS);
 };
 

--- a/src/shared/lib/queryKeys.test.ts
+++ b/src/shared/lib/queryKeys.test.ts
@@ -169,7 +169,7 @@ describe("queryKeys", () => {
 			]);
 		});
 
-		it("treeChildren() includes the profileId and parent path", () => {
+		it("treeChildren() includes the profile and parent path", () => {
 			expect(queryKeys.fs.treeChildren("profile-1", "src/")).toEqual([
 				"fs-tree",
 				"profile-1",
@@ -177,7 +177,7 @@ describe("queryKeys", () => {
 			]);
 		});
 
-		it("file() includes the profileId and file path", () => {
+		it("file() includes the profile and file path", () => {
 			expect(queryKeys.fs.file("profile-1", "README.md")).toEqual([
 				"fs-file",
 				"profile-1",
@@ -185,7 +185,7 @@ describe("queryKeys", () => {
 			]);
 		});
 
-		it("filePreview() includes the profileId and file path", () => {
+		it("filePreview() includes the profile and file path", () => {
 			expect(queryKeys.fs.filePreview("profile-1", "spec.docx")).toEqual([
 				"fs-file-preview",
 				"profile-1",

--- a/src/shared/lib/queryKeys.ts
+++ b/src/shared/lib/queryKeys.ts
@@ -75,8 +75,10 @@ export const queryKeys = {
 			["profile-notes", profileId] as const,
 	},
 	fs: {
-		file: (profileId: string, path: string) => ["fs-file", profileId, path] as const,
-		filePreview: (profileId: string, path: string) => ["fs-file-preview", profileId, path] as const,
+		file: (profileId: string, path: string) =>
+			["fs-file", profileId, path] as const,
+		filePreview: (profileId: string, path: string) =>
+			["fs-file-preview", profileId, path] as const,
 		search: (profileId: string, query: string) =>
 			["fs-search", profileId, query] as const,
 		tree: (profileId: string) => ["fs-tree", profileId] as const,


### PR DESCRIPTION
# Plan 004: Watch profile worktrees and invalidate open file caches

> **Executor instructions**: Follow steps in order. Update `plans/README.md` when done.
>
> **Drift check (run first)**: `git diff --stat 3ee5b79..HEAD -- src-tauri/crates/service/src/watcher.rs src-tauri/src/handler/watcher.rs src-tauri/crates/model/src/watcher.rs src/features/watcher/fileWatcher.ts src/features/projects/hooks.ts src/shared/lib/queryKeys.ts`

## Status

- **Priority**: P1
- **Effort**: M
- **Risk**: MED
- **Depends on**: `plans/003-profile-scoped-file-ipc.md`
- **Category**: bug
- **Planned at**: commit `3ee5b79`, 2026-06-13

## Why this matters

Non-default profiles live under `~/.2code/workspace/{profile_id}`. The watcher currently watches only project root folders, so active worktree profiles can miss file/git refreshes. The frontend also invalidates tree/git caches but not open file content/preview caches, allowing external edits to become stale and later overwritten.

## Current state

Relevant files:
- `src-tauri/crates/service/src/watcher.rs` — reconciles native watchers from `repo::project::list_all` and watches `project.folder` recursively.
- `src/features/watcher/fileWatcher.ts` — receives `WatchEvent { project_id }`, invalidates git and `fs-tree` keys.
- `src/features/projects/hooks.ts` — `useFileContent` caches `queryKeys.fs.file(path)` and `useFilePreview` caches `queryKeys.fs.filePreview(path)` without polling.

Current excerpts:
- `src-tauri/crates/service/src/watcher.rs:89` loads projects only.
- `src-tauri/crates/service/src/watcher.rs:140` calls `w.watch(path, RecursiveMode::Recursive)` for project folders.
- `src/features/watcher/fileWatcher.ts:72-93` invalidates git/status/tree but not `fs-file` or `fs-file-preview`.

## Commands you will need

| Purpose | Command | Expected on success |
|---|---|---|
| Rust watcher tests | `cargo test --manifest-path src-tauri/Cargo.toml watcher` | exit 0 |
| Frontend watcher tests | `bun run test -- fileWatcher` | exit 0 |
| Typegen if event shape changes | `bun run typegen` | exit 0 |
| Full fast checks | `bun run lint:check && ./node_modules/.bin/tsc --noEmit && cargo test --manifest-path src-tauri/Cargo.toml` | exit 0 |

## Scope

**In scope**:
- Native watcher registration for project roots and profile worktree roots.
- Watch event payload additions needed for precise invalidation.
- Frontend invalidation for open file content/previews.

**Out of scope**:
- Replacing all git polling; plan 008 handles that.
- Full conflict-resolution UI for dirty editors; add a conservative invalidation first.

## Git workflow

Branch `advisor/004-watch-worktrees-file-cache`; commit `fix(watcher): refresh worktrees and open file caches`.

## Steps

### Step 1: Extend watcher model to identify root/profile/path

Update `model::watcher::WatchEvent` to include enough information for frontend invalidation. Recommended fields:
- `project_id`
- `profile_id: Option<String>`
- `root_path` or profile-scoped root identity
- `path: Option<String>` relative to watched root when available

Run typegen if serialized types change.

**Verify**: `cargo test --manifest-path src-tauri/Cargo.toml watcher` → compile/pass.

### Step 2: Reconcile watchers for all profile roots

Change `service::watcher` reconciliation to load projects with profiles or query profiles directly. Key watchers by watched root path, not only project id, to avoid duplicate watchers for default profile == project folder.

For each native event, emit the owning project/profile and relative changed path when it can be stripped from root.

**Verify**: Add tests for watcher target reconciliation with a project default profile and a non-default worktree. `cargo test --manifest-path src-tauri/Cargo.toml watcher` → pass.

### Step 3: Invalidate file content and previews

Update `src/features/watcher/fileWatcher.ts`:
- If a changed relative path is available, invalidate `queryKeys.fs.file(profileId, relativePath)` and `queryKeys.fs.filePreview(profileId, relativePath)` from plan 003's key shape.
- If path is unavailable, invalidate `fs-file` and `fs-file-preview` namespaces for affected profile/root.
- Keep existing git/tree invalidations, but avoid global fallback where possible.

**Verify**: `bun run test -- fileWatcher` → add tests for worktree event and file cache invalidation.

### Step 4: Full validation

Run typegen if needed, then fast checks.

**Verify**: all commands exit 0.

## Test plan

- Rust unit tests around watcher target derivation/deduping.
- Frontend tests for file and preview invalidation.
- Existing debounce tests still pass.

## Done criteria

- [x] Non-default profile worktree roots are watched.
- [x] Watch events can invalidate open file content and previews.
- [x] Existing project-root invalidation still works.
- [x] Full checks pass.

## STOP conditions

- Native watcher testing becomes flaky on the current platform; extract pure reconciliation logic and test that instead.
- Plan 003 has not landed and cache key shape is still absolute-path based; adapt minimally but report the mismatch.

## Maintenance notes

This creates the event foundation for plan 008. Reviewers should check that large build bursts remain debounced.