### PR TITLE
fix(git): store binary previews in app cache

### DIFF
--- a/src-tauri/crates/infra/src/git.rs
+++ b/src-tauri/crates/infra/src/git.rs
@@ -389,22 +389,29 @@ pub fn read_worktree_file(
 
 pub fn read_head_file(
 	folder: &str,
+	cache_root: &Path,
 	path: &str,
 ) -> Result<Option<String>, AppError> {
 	let path = validate_repo_relative_path(path, "Preview file path")?;
-	let cache_path = preview_cache_path(folder, "head", None, &path);
-	read_git_blob_to_cache(folder, &format!("HEAD:{path}"), &cache_path, false)
+	let spec = format!("HEAD:{path}");
+	let Some(blob_oid) = get_git_blob_oid(folder, &spec)? else {
+		return Ok(None);
+	};
+	let cache_path =
+		preview_cache_path(cache_root, folder, "head", Some(&blob_oid), &path);
+	read_git_blob_to_cache(folder, &spec, &cache_path, true)
 }
 
 pub fn read_commit_file(
 	folder: &str,
+	cache_root: &Path,
 	commit_hash: &str,
 	path: &str,
 ) -> Result<Option<String>, AppError> {
 	validate_commit_hash(commit_hash)?;
 	let path = validate_repo_relative_path(path, "Preview file path")?;
 	let cache_path =
-		preview_cache_path(folder, "commit", Some(commit_hash), &path);
+		preview_cache_path(cache_root, folder, "commit", Some(commit_hash), &path);
 	read_git_blob_to_cache(
 		folder,
 		&format!("{commit_hash}:{path}"),
@@ -415,13 +422,19 @@ pub fn read_commit_file(
 
 pub fn read_parent_commit_file(
 	folder: &str,
+	cache_root: &Path,
 	commit_hash: &str,
 	path: &str,
 ) -> Result<Option<String>, AppError> {
 	validate_commit_hash(commit_hash)?;
 	let path = validate_repo_relative_path(path, "Preview file path")?;
-	let cache_path =
-		preview_cache_path(folder, "parent-commit", Some(commit_hash), &path);
+	let cache_path = preview_cache_path(
+		cache_root,
+		folder,
+		"parent-commit",
+		Some(commit_hash),
+		&path,
+	);
 	read_git_blob_to_cache(
 		folder,
 		&format!("{commit_hash}^:{path}"),
@@ -691,8 +704,8 @@ pub fn pull_request_status_for_branch(
 
 /// Try `git worktree add -b <branch> <path>` (new branch).
 /// If the branch already exists, return an error.
-/// If a ref namespace conflict blocks creation (e.g. `feat` exists, blocking `feat/auth`),
-/// return a clear GitError naming the conflicting branch; never delete user branches.
+/// If a ref conflict blocks creation (e.g. `feat` exists, blocking `feat/auth`),
+/// return an error without deleting user branches.
 pub fn worktree_add(
 	project_folder: &str,
 	branch_name: &str,
@@ -716,13 +729,11 @@ pub fn worktree_add(
 		)));
 	}
 
-	// Ref namespace conflict: e.g. 'refs/heads/feat' blocks 'refs/heads/feat/auth'.
-	// Never delete the conflicting branch (that would destroy unrelated user work).
-	// Return a specific error so callers (profile creation) can surface a clear message.
+	// Ref conflict: e.g. 'refs/heads/feat' blocks 'refs/heads/feat/auth'.
 	if stderr.contains("cannot lock ref") {
 		if let Some(conflicting) = extract_conflicting_ref(&stderr) {
 			return Err(AppError::GitError(format!(
-				"Branch namespace conflict: '{conflicting}' exists and blocks creation of '{branch_name}'"
+				"Cannot create branch '{branch_name}' because existing branch '{conflicting}' conflicts with that namespace"
 			)));
 		}
 	}
@@ -732,7 +743,10 @@ pub fn worktree_add(
 	)))
 }
 
-pub fn worktree_remove(project_folder: &str, worktree_path: &str) -> Result<(), AppError> {
+pub fn worktree_remove(
+	project_folder: &str,
+	worktree_path: &str,
+) -> Result<(), AppError> {
 	let output = command_without_windows_console("git")
 		.args(["worktree", "remove", worktree_path, "--force"])
 		.current_dir(project_folder)
@@ -750,11 +764,9 @@ pub fn worktree_remove(project_folder: &str, worktree_path: &str) -> Result<(), 
 			return Ok(());
 		}
 
-		tracing::warn!("git worktree remove failed: {stderr}");
-		return Err(AppError::GitError(command_error(
-			"git worktree remove failed",
-			&output,
-		)));
+		let message = command_error("git worktree remove failed", &output);
+		tracing::warn!("{message}");
+		return Err(AppError::GitError(message));
 	}
 
 	Ok(())
@@ -799,7 +811,10 @@ pub fn worktree_current_branch(worktree_path: &str) -> Result<Option<String>, Ap
 	Ok(Some(branch_name))
 }
 
-pub fn branch_delete(project_folder: &str, branch_name: &str) -> Result<(), AppError> {
+pub fn branch_delete(
+	project_folder: &str,
+	branch_name: &str,
+) -> Result<(), AppError> {
 	let output = command_without_windows_console("git")
 		.args(["branch", "-D", branch_name])
 		.current_dir(project_folder)
@@ -815,11 +830,9 @@ pub fn branch_delete(project_folder: &str, branch_name: &str) -> Result<(), AppE
 			return Ok(());
 		}
 
-		tracing::warn!("git branch delete failed: {stderr}");
-		return Err(AppError::GitError(command_error(
-			"git branch delete failed",
-			&output,
-		)));
+		let message = command_error("git branch delete failed", &output);
+		tracing::warn!("{message}");
+		return Err(AppError::GitError(message));
 	}
 
 	Ok(())
@@ -1350,6 +1363,31 @@ fn get_git_blob_size(
 	Err(AppError::GitError(stderr))
 }
 
+fn get_git_blob_oid(
+	folder: &str,
+	spec: &str,
+) -> Result<Option<String>, AppError> {
+	let output = command_without_windows_console("git")
+		.args(["rev-parse", "--verify", "--quiet", spec])
+		.current_dir(folder)
+		.output()?;
+
+	if output.status.success() {
+		let oid = String::from_utf8_lossy(&output.stdout).trim().to_string();
+		if oid.is_empty() {
+			return Ok(None);
+		}
+		return Ok(Some(oid));
+	}
+
+	let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+	if stderr.is_empty() || is_missing_blob_error(&stderr) {
+		return Ok(None);
+	}
+
+	Err(AppError::GitError(stderr))
+}
+
 fn is_missing_blob_error(stderr: &str) -> bool {
 	[
 		"does not exist in",
@@ -1363,6 +1401,7 @@ fn is_missing_blob_error(stderr: &str) -> bool {
 }
 
 fn preview_cache_path(
+	cache_root: &Path,
 	folder: &str,
 	source: &str,
 	commit_hash: Option<&str>,
@@ -1372,9 +1411,7 @@ fn preview_cache_path(
 	folder.hash(&mut hasher);
 	let repo_hash = hasher.finish();
 
-	let mut cache_path = std::env::temp_dir()
-		.join("2code")
-		.join("git-preview-cache")
+	let mut cache_path = cache_root
 		.join(format!("{repo_hash:016x}"))
 		.join(source);
 
@@ -1861,6 +1898,7 @@ mod tests {
 	#[test]
 	fn read_preview_files_from_worktree_and_head() {
 		let dir = create_temp_git_repo();
+		let cache_dir = tempfile::TempDir::new().unwrap();
 		let initial = vec![0_u8, 1, 2, 3];
 		let modified = vec![4_u8, 5, 6, 7];
 
@@ -1878,16 +1916,20 @@ mod tests {
 
 		std::fs::write(dir.join("image.bin"), &modified).unwrap();
 
-		let head_preview =
-			read_head_file(dir.to_string_lossy().as_ref(), "image.bin")
-				.unwrap()
-				.unwrap();
+		let head_preview = read_head_file(
+			dir.to_string_lossy().as_ref(),
+			cache_dir.path(),
+			"image.bin",
+		)
+		.unwrap()
+		.unwrap();
 		let worktree_preview =
 			read_worktree_file(dir.to_string_lossy().as_ref(), "image.bin")
 				.unwrap()
 				.unwrap();
 
 		assert_ne!(head_preview, dir.join("image.bin").to_string_lossy());
+		assert!(Path::new(&head_preview).starts_with(cache_dir.path()));
 		assert_eq!(std::fs::read(head_preview).unwrap(), initial);
 		assert_eq!(worktree_preview, dir.join("image.bin").to_string_lossy());
 		assert_eq!(std::fs::read(worktree_preview).unwrap(), modified);
@@ -1896,8 +1938,63 @@ mod tests {
 	}
 
 	#[test]
+	fn read_head_file_cache_key_changes_when_head_blob_changes() {
+		let dir = create_temp_git_repo();
+		let cache_dir = tempfile::TempDir::new().unwrap();
+		let initial = vec![0_u8, 1, 2, 3];
+		let updated_same_size = vec![4_u8, 5, 6, 7];
+
+		std::fs::write(dir.join("image.bin"), &initial).unwrap();
+		command_without_windows_console("git")
+			.args(["add", "image.bin"])
+			.current_dir(&dir)
+			.output()
+			.unwrap();
+		command_without_windows_console("git")
+			.args(["commit", "-m", "add image"])
+			.current_dir(&dir)
+			.output()
+			.unwrap();
+
+		let initial_preview = read_head_file(
+			dir.to_string_lossy().as_ref(),
+			cache_dir.path(),
+			"image.bin",
+		)
+		.unwrap()
+		.unwrap();
+
+		std::fs::write(dir.join("image.bin"), &updated_same_size).unwrap();
+		command_without_windows_console("git")
+			.args(["add", "image.bin"])
+			.current_dir(&dir)
+			.output()
+			.unwrap();
+		command_without_windows_console("git")
+			.args(["commit", "-m", "update image"])
+			.current_dir(&dir)
+			.output()
+			.unwrap();
+
+		let updated_preview = read_head_file(
+			dir.to_string_lossy().as_ref(),
+			cache_dir.path(),
+			"image.bin",
+		)
+		.unwrap()
+		.unwrap();
+
+		assert_ne!(initial_preview, updated_preview);
+		assert_eq!(std::fs::read(initial_preview).unwrap(), initial);
+		assert_eq!(std::fs::read(updated_preview).unwrap(), updated_same_size);
+
+		std::fs::remove_dir_all(dir).unwrap();
+	}
+
+	#[test]
 	fn read_preview_files_from_commit_and_parent_commit() {
 		let dir = create_temp_git_repo();
+		let cache_dir = tempfile::TempDir::new().unwrap();
 		let before = vec![1_u8, 2, 3, 4];
 		let after = vec![5_u8, 6, 7, 8];
 
@@ -1935,6 +2032,7 @@ mod tests {
 
 		let commit_preview = read_commit_file(
 			dir.to_string_lossy().as_ref(),
+			cache_dir.path(),
 			&commit_hash,
 			"image.bin",
 		)
@@ -1942,12 +2040,15 @@ mod tests {
 		.unwrap();
 		let parent_preview = read_parent_commit_file(
 			dir.to_string_lossy().as_ref(),
+			cache_dir.path(),
 			&commit_hash,
 			"image.bin",
 		)
 		.unwrap()
 		.unwrap();
 
+		assert!(Path::new(&commit_preview).starts_with(cache_dir.path()));
+		assert!(Path::new(&parent_preview).starts_with(cache_dir.path()));
 		assert_eq!(std::fs::read(commit_preview).unwrap(), after);
 		assert_eq!(std::fs::read(parent_preview).unwrap(), before);
 
@@ -1957,6 +2058,7 @@ mod tests {
 	#[test]
 	fn read_preview_files_reject_large_committed_blob() {
 		let dir = create_temp_git_repo();
+		let cache_dir = tempfile::TempDir::new().unwrap();
 		let oversized = vec![0_u8; MAX_BINARY_PREVIEW_BYTES + 1];
 
 		std::fs::write(dir.join("large.bin"), oversized).unwrap();
@@ -1971,8 +2073,12 @@ mod tests {
 			.output()
 			.unwrap();
 
-		let error = read_head_file(dir.to_string_lossy().as_ref(), "large.bin")
-			.unwrap_err();
+		let error = read_head_file(
+			dir.to_string_lossy().as_ref(),
+			cache_dir.path(),
+			"large.bin",
+		)
+		.unwrap_err();
 
 		assert!(
 			matches!(error, AppError::GitError(message) if message.contains("too large"))

--- a/src-tauri/crates/repo/src/profile.rs
+++ b/src-tauri/crates/repo/src/profile.rs
@@ -65,19 +65,9 @@ pub fn find_by_id(
 		.map_err(|_| AppError::NotFound(format!("Profile: {id}")))
 }
 
-/// Delete the profile row only (assumes caller validated not default etc).
-/// Used internally after successful cleanup in service layer.
-pub fn delete_row(conn: &mut SqliteConnection, id: &str) -> Result<(), AppError> {
-	diesel::delete(profiles::table.find(id))
-		.execute(conn)
-		.map_err(|e| AppError::DbError(e.to_string()))?;
-	Ok(())
-}
-
-/// Delete a profile record and return the profile + project folder.
+/// Return the profile and project folder needed to delete a profile.
 /// Default profiles cannot be deleted directly — they are removed via cascade when the project is deleted.
-/// Note: this eagerly deletes the row (for repo unit tests and any legacy direct use); prefer service orchestration for production delete.
-pub fn delete(
+pub fn get_delete_target(
 	conn: &mut SqliteConnection,
 	id: &str,
 ) -> Result<(Profile, String), AppError> {
@@ -91,9 +81,31 @@ pub fn delete(
 
 	let project_folder = get_project_folder(conn, &profile.project_id)?;
 
-	delete_row(conn, id)?;
-
 	Ok((profile, project_folder))
+}
+
+pub fn delete_record(
+	conn: &mut SqliteConnection,
+	id: &str,
+) -> Result<(), AppError> {
+	let deleted = diesel::delete(profiles::table.find(id))
+		.execute(conn)
+		.map_err(|e| AppError::DbError(e.to_string()))?;
+
+	if deleted == 0 {
+		return Err(AppError::NotFound(format!("Profile: {id}")));
+	}
+
+	Ok(())
+}
+
+pub fn delete(
+	conn: &mut SqliteConnection,
+	id: &str,
+) -> Result<(Profile, String), AppError> {
+	let target = get_delete_target(conn, id)?;
+	delete_record(conn, id)?;
+	Ok(target)
 }
 
 pub fn get_project_folder(

--- a/src-tauri/crates/service/src/profile.rs
+++ b/src-tauri/crates/service/src/profile.rs
@@ -268,48 +268,24 @@ pub fn create(
 	Ok(profile)
 }
 
-pub fn delete(conn: &mut SqliteConnection, id: &str) -> Result<(), AppError> {
-	let profile = repo::profile::find_by_id(conn, id)?;
-	if profile.is_default {
-		return Err(AppError::DbError(
-			"Cannot delete default profile".to_string(),
-		));
-	}
-	let project_folder = repo::profile::get_project_folder(conn, &profile.project_id)?;
-
-	cleanup_profile(&profile, &project_folder)?;
-
-	// Delete DB row only after successful cleanup
-	repo::profile::delete_row(conn, id)?;
-
-	Ok(())
-}
-
-/// DB-pool variant for Tauri handler (matches create_with_db pattern).
-/// Reads identity under lock (no delete), performs teardown + git cleanup (propagating errors),
-/// then deletes the profile row only on success.
 pub fn delete_with_db(db: &DbPool, id: &str) -> Result<(), AppError> {
 	let (profile, project_folder) = {
 		let conn = &mut *db.lock().map_err(|_| AppError::LockError)?;
-		let profile = repo::profile::find_by_id(conn, id)?;
-		if profile.is_default {
-			return Err(AppError::DbError(
-				"Cannot delete default profile".to_string(),
-			));
-		}
-		let project_folder = repo::profile::get_project_folder(conn, &profile.project_id)?;
-		(profile, project_folder)
+		repo::profile::get_delete_target(conn, id)?
 	};
 
 	cleanup_profile(&profile, &project_folder)?;
 
-	// Delete row under fresh lock, only after cleanup succeeded
-	{
-		let conn = &mut *db.lock().map_err(|_| AppError::LockError)?;
-		repo::profile::delete_row(conn, id)?;
-	}
+	let conn = &mut *db.lock().map_err(|_| AppError::LockError)?;
+	repo::profile::delete_record(conn, id)
+}
 
-	Ok(())
+pub fn delete(conn: &mut SqliteConnection, id: &str) -> Result<(), AppError> {
+	let (profile, project_folder) = repo::profile::get_delete_target(conn, id)?;
+
+	cleanup_profile(&profile, &project_folder)?;
+
+	repo::profile::delete_record(conn, id)
 }
 
 fn cleanup_profile(

--- a/src-tauri/crates/service/src/project.rs
+++ b/src-tauri/crates/service/src/project.rs
@@ -218,6 +218,7 @@ pub fn get_commit_diff(
 pub fn get_binary_preview(
 	conn: &mut SqliteConnection,
 	profile_id: &str,
+	cache_root: &Path,
 	path: &str,
 	source: &str,
 	commit_hash: Option<&str>,
@@ -227,7 +228,9 @@ pub fn get_binary_preview(
 		"working_tree" => {
 			infra::git::read_worktree_file(&profile.worktree_path, path)?
 		}
-		"head" => infra::git::read_head_file(&profile.worktree_path, path)?,
+		"head" => {
+			infra::git::read_head_file(&profile.worktree_path, cache_root, path)?
+		}
 		"commit" => {
 			let commit_hash = commit_hash.ok_or_else(|| {
 				AppError::GitError(
@@ -236,6 +239,7 @@ pub fn get_binary_preview(
 			})?;
 			infra::git::read_commit_file(
 				&profile.worktree_path,
+				cache_root,
 				commit_hash,
 				path,
 			)?
@@ -248,6 +252,7 @@ pub fn get_binary_preview(
 			})?;
 			infra::git::read_parent_commit_file(
 				&profile.worktree_path,
+				cache_root,
 				commit_hash,
 				path,
 			)?

--- a/src-tauri/src/handler/filesystem.rs
+++ b/src-tauri/src/handler/filesystem.rs
@@ -38,102 +38,6 @@ const ARCHIVE_PREVIEW_MAX_BYTES: u64 = 200 * 1024 * 1024;
 const ARCHIVE_PREVIEW_MAX_ENTRIES: usize = 10_000;
 static SOFFICE_COMMAND: OnceLock<Option<PathBuf>> = OnceLock::new();
 
-fn invalid_file_path(message: impl Into<String>) -> AppError {
-	AppError::IoError(std::io::Error::new(
-		std::io::ErrorKind::InvalidInput,
-		message.into(),
-	))
-}
-
-fn validate_profile_relative_path(
-	path: &str,
-	label: &str,
-	allow_root: bool,
-) -> Result<PathBuf, AppError> {
-	if path.is_empty() {
-		if allow_root {
-			return Ok(PathBuf::new());
-		}
-		return Err(invalid_file_path(format!("{label} cannot be empty")));
-	}
-	if path.contains('\0') {
-		return Err(invalid_file_path(format!(
-			"{label} contains invalid characters"
-		)));
-	}
-
-	let without_trailing_separator =
-		path.trim_end_matches(['/', '\\']).to_string();
-	if without_trailing_separator.is_empty() {
-		if allow_root {
-			return Ok(PathBuf::new());
-		}
-		return Err(invalid_file_path(format!("{label} cannot be root")));
-	}
-
-	let parsed = Path::new(&without_trailing_separator);
-	if parsed.is_absolute() {
-		return Err(invalid_file_path(format!(
-			"{label} must be relative: {path}"
-		)));
-	}
-
-	let mut relative_path = PathBuf::new();
-	for component in parsed.components() {
-		match component {
-			Component::CurDir => {}
-			Component::Normal(value) => {
-				if value == ".git" {
-					return Err(invalid_file_path(format!(
-						"{label} cannot target .git metadata"
-					)));
-				}
-				relative_path.push(value);
-			}
-			Component::ParentDir
-			| Component::RootDir
-			| Component::Prefix(_) => {
-				return Err(invalid_file_path(format!(
-					"{label} escapes worktree: {path}"
-				)));
-			}
-		}
-	}
-
-	if relative_path.as_os_str().is_empty() && !allow_root {
-		return Err(invalid_file_path(format!("{label} cannot be empty")));
-	}
-
-	Ok(relative_path)
-}
-
-fn resolve_existing_profile_path(
-	root: &Path,
-	path: &str,
-	label: &str,
-	allow_root: bool,
-) -> Result<PathBuf, AppError> {
-	let canonical_root = root.canonicalize().map_err(AppError::IoError)?;
-	let relative_path =
-		validate_profile_relative_path(path, label, allow_root)?;
-	let full_path = root.join(relative_path);
-	let canonical_path = full_path.canonicalize().map_err(|error| {
-		if error.kind() == std::io::ErrorKind::NotFound {
-			AppError::NotFound(format!("{label}: {path}"))
-		} else {
-			AppError::IoError(error)
-		}
-	})?;
-
-	if !canonical_path.starts_with(&canonical_root) {
-		return Err(invalid_file_path(format!(
-			"{label} escapes worktree: {path}"
-		)));
-	}
-
-	Ok(canonical_path)
-}
-
 fn previewable_image_mime_type(path: &Path) -> Option<&'static str> {
 	let extension = path.extension()?.to_string_lossy().to_lowercase();
 	match extension.as_str() {
@@ -492,29 +396,197 @@ fn convert_office_file_to_pdf(
 	})
 }
 
+fn profile_worktree_path(
+	db: &DbPool,
+	profile_id: &str,
+) -> Result<String, AppError> {
+	let conn = &mut *db.lock().map_err(|_| AppError::LockError)?;
+	Ok(repo::profile::find_by_id(conn, profile_id)?.worktree_path)
+}
+
+fn profile_worktree_root(
+	db: &DbPool,
+	profile_id: &str,
+) -> Result<PathBuf, AppError> {
+	Ok(PathBuf::from(profile_worktree_path(db, profile_id)?))
+}
+
+fn path_outside_workspace_error() -> AppError {
+	AppError::IoError(std::io::Error::new(
+		std::io::ErrorKind::InvalidInput,
+		"Path is outside the workspace",
+	))
+}
+
+fn invalid_file_path(message: impl Into<String>) -> AppError {
+	AppError::IoError(std::io::Error::new(
+		std::io::ErrorKind::InvalidInput,
+		message.into(),
+	))
+}
+
+fn validate_worktree_relative_path(
+	path: &str,
+	label: &str,
+) -> Result<PathBuf, AppError> {
+	if path.is_empty() {
+		return Err(invalid_file_path(format!("{label} cannot be empty")));
+	}
+	if path.contains('\0') {
+		return Err(invalid_file_path(format!(
+			"{label} contains invalid characters"
+		)));
+	}
+
+	let without_trailing_separator =
+		path.trim_end_matches(['/', '\\']).to_string();
+	if without_trailing_separator.is_empty() {
+		return Err(invalid_file_path(format!("{label} cannot be root")));
+	}
+
+	let parsed = Path::new(&without_trailing_separator);
+	if parsed.is_absolute() {
+		return Err(invalid_file_path(format!(
+			"{label} must be relative: {path}"
+		)));
+	}
+
+	let mut relative_path = PathBuf::new();
+	for component in parsed.components() {
+		match component {
+			Component::CurDir => {}
+			Component::Normal(value) => {
+				if value == ".git" {
+					return Err(invalid_file_path(format!(
+						"{label} cannot target .git metadata"
+					)));
+				}
+				relative_path.push(value);
+			}
+			Component::ParentDir
+			| Component::RootDir
+			| Component::Prefix(_) => {
+				return Err(invalid_file_path(format!(
+					"{label} escapes worktree: {path}"
+				)));
+			}
+		}
+	}
+
+	if relative_path.as_os_str().is_empty() {
+		return Err(invalid_file_path(format!("{label} cannot be empty")));
+	}
+
+	Ok(relative_path)
+}
+
+fn ensure_canonical_path_inside_worktree(
+	worktree_root: &Path,
+	path: &Path,
+) -> Result<PathBuf, AppError> {
+	let canonical_worktree =
+		worktree_root.canonicalize().map_err(AppError::IoError)?;
+	let canonical_path = path.canonicalize().map_err(|error| {
+		if error.kind() == std::io::ErrorKind::NotFound {
+			AppError::NotFound(format!("Path: {}", path.display()))
+		} else {
+			AppError::IoError(error)
+		}
+	})?;
+
+	if !canonical_path.starts_with(&canonical_worktree) {
+		return Err(path_outside_workspace_error());
+	}
+
+	Ok(canonical_path)
+}
+
+fn resolve_existing_worktree_path(
+	worktree_root: &Path,
+	path: &str,
+	label: &str,
+) -> Result<PathBuf, AppError> {
+	let relative_path = validate_worktree_relative_path(path, label)?;
+	ensure_canonical_path_inside_worktree(
+		worktree_root,
+		&worktree_root.join(relative_path),
+	)
+}
+
+fn resolve_existing_worktree_path_or_root(
+	worktree_root: &Path,
+	path: Option<&str>,
+) -> Result<PathBuf, AppError> {
+	let Some(path) = path else {
+		return worktree_root.canonicalize().map_err(AppError::IoError);
+	};
+	if path.is_empty() {
+		return worktree_root.canonicalize().map_err(AppError::IoError);
+	}
+
+	resolve_existing_worktree_path(worktree_root, path, "File tree path")
+}
+
+fn ensure_creatable_worktree_path(
+	worktree_root: &Path,
+	path: &str,
+	label: &str,
+) -> Result<(), AppError> {
+	let relative_path = validate_worktree_relative_path(path, label)?;
+	let candidate = worktree_root.join(&relative_path);
+	if candidate.exists() {
+		ensure_canonical_path_inside_worktree(worktree_root, &candidate)?;
+		return Ok(());
+	}
+
+	let canonical_worktree =
+		worktree_root.canonicalize().map_err(AppError::IoError)?;
+	let Some(parent) = Path::new(&relative_path).parent() else {
+		return Ok(());
+	};
+
+	let mut current = worktree_root.to_path_buf();
+	for component in parent.components() {
+		let std::path::Component::Normal(segment) = component else {
+			continue;
+		};
+		current.push(segment);
+		if current.exists() {
+			let canonical_current =
+				current.canonicalize().map_err(AppError::IoError)?;
+			if !canonical_current.starts_with(&canonical_worktree) {
+				return Err(path_outside_workspace_error());
+			}
+		}
+	}
+
+	Ok(())
+}
+
 #[tauri::command]
 pub async fn list_file_tree_paths(
-	path: String,
+	profile_id: String,
+	state: State<'_, DbPool>,
 ) -> Result<Vec<String>, AppError> {
+	let db = state.inner().clone();
 	super::run_blocking(move || {
-		infra::filesystem::list_file_tree_paths(Path::new(&path))
+		let worktree_root = profile_worktree_root(&db, &profile_id)?;
+		infra::filesystem::list_file_tree_paths(&worktree_root)
 	})
 	.await
 }
 
-// Profile-scoped versions (preferred). Renderer sends profileId (trusted lookup in Rust)
-// + relative path(s). Rust resolves worktree from DB and enforces boundary via infra validators.
 #[tauri::command]
 pub async fn list_file_tree_child_paths(
-	state: State<'_, DbPool>,
 	profile_id: String,
 	parent_path: Option<String>,
+	state: State<'_, DbPool>,
 ) -> Result<Vec<String>, AppError> {
 	let db = state.inner().clone();
 	super::run_blocking(move || {
-		service::filesystem::list_file_tree_child_paths(
-			&db,
-			&profile_id,
+		let worktree_root = profile_worktree_root(&db, &profile_id)?;
+		infra::filesystem::list_file_tree_child_paths(
+			&worktree_root,
 			parent_path.as_deref(),
 		)
 	})
@@ -523,16 +595,26 @@ pub async fn list_file_tree_child_paths(
 
 #[tauri::command]
 pub async fn rename_file_tree_path(
-	state: State<'_, DbPool>,
 	profile_id: String,
 	source_path: String,
 	destination_path: String,
+	state: State<'_, DbPool>,
 ) -> Result<(), AppError> {
 	let db = state.inner().clone();
 	super::run_blocking(move || {
-		service::filesystem::rename_file_tree_path(
-			&db,
-			&profile_id,
+		let worktree_root = profile_worktree_root(&db, &profile_id)?;
+		resolve_existing_worktree_path(
+			&worktree_root,
+			&source_path,
+			"Source path",
+		)?;
+		ensure_creatable_worktree_path(
+			&worktree_root,
+			&destination_path,
+			"Destination path",
+		)?;
+		infra::filesystem::rename_file_tree_path(
+			&worktree_root,
 			&source_path,
 			&destination_path,
 		)
@@ -542,16 +624,30 @@ pub async fn rename_file_tree_path(
 
 #[tauri::command]
 pub async fn move_file_tree_paths(
-	state: State<'_, DbPool>,
 	profile_id: String,
 	source_paths: Vec<String>,
 	target_dir_path: Option<String>,
+	state: State<'_, DbPool>,
 ) -> Result<(), AppError> {
 	let db = state.inner().clone();
 	super::run_blocking(move || {
-		service::filesystem::move_file_tree_paths(
-			&db,
-			&profile_id,
+		let worktree_root = profile_worktree_root(&db, &profile_id)?;
+		for source_path in &source_paths {
+			resolve_existing_worktree_path(
+				&worktree_root,
+				source_path,
+				"Source path",
+			)?;
+		}
+		if let Some(target_dir_path) = target_dir_path.as_deref() {
+			resolve_existing_worktree_path(
+				&worktree_root,
+				target_dir_path,
+				"Target directory",
+			)?;
+		}
+		infra::filesystem::move_file_tree_paths(
+			&worktree_root,
 			&source_paths,
 			target_dir_path.as_deref(),
 		)
@@ -561,32 +657,41 @@ pub async fn move_file_tree_paths(
 
 #[tauri::command]
 pub async fn delete_file_tree_paths(
-	state: State<'_, DbPool>,
 	profile_id: String,
 	paths: Vec<String>,
+	state: State<'_, DbPool>,
 ) -> Result<(), AppError> {
 	let db = state.inner().clone();
 	super::run_blocking(move || {
-		service::filesystem::delete_file_tree_paths(&db, &profile_id, &paths)
+		let worktree_root = profile_worktree_root(&db, &profile_id)?;
+		for path in &paths {
+			resolve_existing_worktree_path(
+				&worktree_root,
+				path,
+				"File tree path",
+			)?;
+		}
+		infra::filesystem::delete_file_tree_paths(&worktree_root, &paths)
 	})
 	.await
 }
 
 #[tauri::command]
 pub async fn create_file_tree_path(
-	state: State<'_, DbPool>,
 	profile_id: String,
 	path: String,
 	kind: String,
+	state: State<'_, DbPool>,
 ) -> Result<(), AppError> {
 	let db = state.inner().clone();
 	super::run_blocking(move || {
-		service::filesystem::create_file_tree_path(
-			&db,
-			&profile_id,
+		let worktree_root = profile_worktree_root(&db, &profile_id)?;
+		ensure_creatable_worktree_path(
+			&worktree_root,
 			&path,
-			&kind,
-		)
+			"File tree path",
+		)?;
+		infra::filesystem::create_file_tree_path(&worktree_root, &path, &kind)
 	})
 	.await
 }
@@ -701,48 +806,52 @@ fn open_path_in_default_app_impl(path: &Path) -> Result<(), AppError> {
 
 #[tauri::command]
 pub async fn reveal_path_in_file_manager(
-	state: State<'_, DbPool>,
 	profile_id: String,
-	path: String,
+	path: Option<String>,
+	state: State<'_, DbPool>,
 ) -> Result<(), AppError> {
 	let db = state.inner().clone();
 	super::run_blocking(move || {
-		let root =
-			service::filesystem::get_profile_worktree_path(&db, &profile_id)?;
-		let full = resolve_existing_profile_path(&root, &path, "Path", true)?;
-		reveal_path_in_file_manager_impl(&full)
+		let worktree_root = profile_worktree_root(&db, &profile_id)?;
+		let path = resolve_existing_worktree_path_or_root(
+			&worktree_root,
+			path.as_deref(),
+		)?;
+		reveal_path_in_file_manager_impl(&path)
 	})
 	.await
 }
 
 #[tauri::command]
 pub async fn open_path_in_default_app(
-	state: State<'_, DbPool>,
 	profile_id: String,
 	path: String,
+	state: State<'_, DbPool>,
 ) -> Result<(), AppError> {
 	let db = state.inner().clone();
 	super::run_blocking(move || {
-		let root =
-			service::filesystem::get_profile_worktree_path(&db, &profile_id)?;
-		let full = resolve_existing_profile_path(&root, &path, "Path", true)?;
-		open_path_in_default_app_impl(&full)
+		let worktree_root = profile_worktree_root(&db, &profile_id)?;
+		let path = resolve_existing_worktree_path(
+			&worktree_root,
+			&path,
+			"File tree path",
+		)?;
+		open_path_in_default_app_impl(&path)
 	})
 	.await
 }
 
 #[tauri::command]
 pub async fn read_file_content(
-	state: State<'_, DbPool>,
 	profile_id: String,
 	path: String,
+	state: State<'_, DbPool>,
 ) -> Result<String, AppError> {
 	let db = state.inner().clone();
 	super::run_blocking(move || {
-		let root =
-			service::filesystem::get_profile_worktree_path(&db, &profile_id)?;
+		let worktree_root = profile_worktree_root(&db, &profile_id)?;
 		let file_path =
-			resolve_existing_profile_path(&root, &path, "File path", false)?;
+			resolve_existing_worktree_path(&worktree_root, &path, "File path")?;
 		if !file_path.exists() {
 			return Err(AppError::NotFound(format!("File: {path}")));
 		}
@@ -777,17 +886,16 @@ pub async fn read_file_content(
 
 #[tauri::command]
 pub async fn write_file_content(
-	state: State<'_, DbPool>,
 	profile_id: String,
 	path: String,
 	content: String,
+	state: State<'_, DbPool>,
 ) -> Result<(), AppError> {
 	let db = state.inner().clone();
 	super::run_blocking(move || {
-		let root =
-			service::filesystem::get_profile_worktree_path(&db, &profile_id)?;
+		let worktree_root = profile_worktree_root(&db, &profile_id)?;
 		let file_path =
-			resolve_existing_profile_path(&root, &path, "File path", false)?;
+			resolve_existing_worktree_path(&worktree_root, &path, "File path")?;
 		if !file_path.exists() {
 			return Err(AppError::NotFound(format!("File: {path}")));
 		}
@@ -810,10 +918,10 @@ pub async fn write_file_content(
 
 #[tauri::command]
 pub async fn get_file_preview(
-	state: State<'_, DbPool>,
 	profile_id: String,
 	path: String,
 	app: AppHandle,
+	state: State<'_, DbPool>,
 ) -> Result<FilePreview, AppError> {
 	let db = state.inner().clone();
 	let cache_root = app
@@ -823,51 +931,58 @@ pub async fn get_file_preview(
 		.join("office-preview");
 
 	super::run_blocking(move || {
-		let root =
-			service::filesystem::get_profile_worktree_path(&db, &profile_id)?;
+		let worktree_root = profile_worktree_root(&db, &profile_id)?;
 		let file_path =
-			resolve_existing_profile_path(&root, &path, "File path", false)?;
+			resolve_existing_worktree_path(&worktree_root, &path, "File path")?;
 		let metadata = ensure_previewable_file(&file_path)?;
+		let canonical_path =
+			file_path.canonicalize().map_err(AppError::IoError)?;
 
-		if let Some(mime_type) = previewable_image_mime_type(&file_path) {
+		if let Some(mime_type) = previewable_image_mime_type(&canonical_path) {
 			return Ok(FilePreview {
 				kind: "image".to_string(),
-				file_path: file_path.to_string_lossy().into_owned(),
+				file_path: canonical_path.to_string_lossy().into_owned(),
 				mime_type: mime_type.to_string(),
 				source_path: None,
 				archive_entries: None,
 			});
 		}
 
-		if is_pdf_file(&file_path) {
+		if is_pdf_file(&canonical_path) {
 			return Ok(FilePreview {
 				kind: "pdf".to_string(),
-				file_path: file_path.to_string_lossy().into_owned(),
+				file_path: canonical_path.to_string_lossy().into_owned(),
 				mime_type: "application/pdf".to_string(),
 				source_path: None,
 				archive_entries: None,
 			});
 		}
 
-		if is_archive_file(&file_path) {
-			let archive_entries = list_archive_entries(&file_path, &metadata)?;
+		if is_archive_file(&canonical_path) {
+			let archive_entries =
+				list_archive_entries(&canonical_path, &metadata)?;
 			return Ok(FilePreview {
 				kind: "archive".to_string(),
-				file_path: file_path.to_string_lossy().into_owned(),
+				file_path: canonical_path.to_string_lossy().into_owned(),
 				mime_type: "application/x-archive".to_string(),
 				source_path: None,
 				archive_entries: Some(archive_entries),
 			});
 		}
 
-		if is_office_file(&file_path) {
-			let pdf_path =
-				convert_office_file_to_pdf(&file_path, &cache_root, &metadata)?;
+		if is_office_file(&canonical_path) {
+			let pdf_path = convert_office_file_to_pdf(
+				&canonical_path,
+				&cache_root,
+				&metadata,
+			)?;
 			return Ok(FilePreview {
 				kind: "office-pdf".to_string(),
 				file_path: pdf_path.to_string_lossy().into_owned(),
 				mime_type: "application/pdf".to_string(),
-				source_path: Some(file_path.to_string_lossy().into_owned()),
+				source_path: Some(
+					canonical_path.to_string_lossy().into_owned(),
+				),
 				archive_entries: None,
 			});
 		}
@@ -887,9 +1002,8 @@ pub async fn search_file(
 ) -> Result<Vec<FileSearchResult>, AppError> {
 	let db = state.inner().clone();
 	super::run_blocking(move || {
-		let worktree =
-			service::filesystem::get_profile_worktree_path(&db, &profile_id)?;
-		infra::filesystem::search_files(&worktree, &query)
+		let worktree_path = profile_worktree_path(&db, &profile_id)?;
+		infra::filesystem::search_files(Path::new(&worktree_path), &query)
 	})
 	.await
 }
@@ -901,9 +1015,8 @@ pub async fn get_file_tree_git_status(
 ) -> Result<Vec<FileTreeGitStatusEntry>, AppError> {
 	let db = state.inner().clone();
 	super::run_blocking(move || {
-		let worktree =
-			service::filesystem::get_profile_worktree_path(&db, &profile_id)?;
-		infra::git::status(&worktree.to_string_lossy())
+		let worktree_path = profile_worktree_path(&db, &profile_id)?;
+		infra::git::status(&worktree_path)
 	})
 	.await
 }
@@ -920,9 +1033,8 @@ pub async fn resolve_terminal_file_path(
 ) -> Result<ResolvedFilePath, AppError> {
 	let db = state.inner().clone();
 	super::run_blocking(move || {
-		let worktree =
-			service::filesystem::get_profile_worktree_path(&db, &profile_id)?;
-		resolve_file_path_in_worktree(&worktree, &file_path)
+		let worktree = profile_worktree_path(&db, &profile_id)?;
+		resolve_file_path_in_worktree(Path::new(&worktree), &file_path)
 	})
 	.await
 }
@@ -967,9 +1079,46 @@ fn resolve_file_path_in_worktree(
 
 #[cfg(test)]
 mod tests {
+	use std::sync::{Arc, Mutex};
+
+	use diesel::prelude::*;
+	use diesel_migrations::MigrationHarness;
+	use model::profile::NewProfile;
+	use model::project::NewProject;
 	use uuid::Uuid;
 
 	use super::*;
+
+	fn setup_db() -> DbPool {
+		let mut conn =
+			SqliteConnection::establish(":memory:").expect("in-memory db");
+		conn.run_pending_migrations(infra::db::MIGRATIONS)
+			.expect("run migrations");
+
+		diesel::insert_into(model::schema::projects::table)
+			.values(&NewProject {
+				id: "proj-1",
+				name: "Project",
+				folder: "/repo",
+				group_id: None,
+				sort_order: 1000,
+			})
+			.execute(&mut conn)
+			.expect("insert project");
+
+		diesel::insert_into(model::schema::profiles::table)
+			.values(&NewProfile {
+				id: "profile-1",
+				project_id: "proj-1",
+				branch_name: "main",
+				worktree_path: "/repo/worktree",
+				is_default: true,
+			})
+			.execute(&mut conn)
+			.expect("insert profile");
+
+		Arc::new(Mutex::new(conn))
+	}
 
 	fn temp_worktree() -> std::path::PathBuf {
 		let path = std::env::temp_dir()
@@ -979,27 +1128,93 @@ mod tests {
 	}
 
 	#[test]
-	fn validate_profile_relative_path_preserves_whitespace() {
-		let path = validate_profile_relative_path(
-			"  spaced name .txt  ",
-			"File path",
-			false,
-		)
-		.unwrap();
+	fn profile_worktree_path_reads_only_the_needed_field() {
+		let db = setup_db();
 
-		assert_eq!(path, PathBuf::from("  spaced name .txt  "));
+		let worktree = profile_worktree_path(&db, "profile-1").unwrap();
+
+		assert_eq!(worktree, "/repo/worktree");
 	}
 
 	#[test]
-	fn validate_profile_relative_path_allows_root_when_requested() {
-		let path = validate_profile_relative_path("", "Path", true).unwrap();
+	fn profile_worktree_path_returns_not_found_for_missing_profile() {
+		let db = setup_db();
 
-		assert!(path.as_os_str().is_empty());
+		let result = profile_worktree_path(&db, "missing-profile");
+
+		assert!(matches!(result, Err(AppError::NotFound(_))));
+	}
+
+	#[test]
+	fn resolve_existing_worktree_path_returns_canonical_path() {
+		let worktree = temp_worktree();
+		let file_path = worktree.join("src/main.rs");
+		std::fs::create_dir_all(file_path.parent().expect("parent"))
+			.expect("create parent");
+		std::fs::write(&file_path, "fn main() {}").expect("write file");
+
+		let result =
+			resolve_existing_worktree_path(&worktree, "src/main.rs", "File")
+				.unwrap();
+
+		assert_eq!(result, file_path.canonicalize().unwrap());
+		std::fs::remove_dir_all(worktree).expect("cleanup temp worktree");
+	}
+
+	#[test]
+	fn resolve_existing_worktree_path_preserves_whitespace() {
+		let worktree = temp_worktree();
+		let file_path = worktree.join("  spaced name .txt  ");
+		std::fs::write(&file_path, "content").expect("write file");
+
+		let result = resolve_existing_worktree_path(
+			&worktree,
+			"  spaced name .txt  ",
+			"File",
+		)
+		.unwrap();
+
+		assert_eq!(result, file_path.canonicalize().unwrap());
+		std::fs::remove_dir_all(worktree).expect("cleanup temp worktree");
+	}
+
+	#[test]
+	fn resolve_existing_worktree_path_or_root_accepts_empty_path() {
+		let worktree = temp_worktree();
+
+		let result =
+			resolve_existing_worktree_path_or_root(&worktree, Some(""))
+				.unwrap();
+
+		assert_eq!(result, worktree.canonicalize().unwrap());
+		std::fs::remove_dir_all(worktree).expect("cleanup temp worktree");
+	}
+
+	#[test]
+	fn resolve_existing_worktree_path_rejects_escape_inputs() {
+		let worktree = temp_worktree();
+		std::fs::write(worktree.join("main.rs"), "fn main() {}")
+			.expect("write file");
+
+		let parent_result =
+			resolve_existing_worktree_path(&worktree, "../main.rs", "File");
+		let absolute_result = resolve_existing_worktree_path(
+			&worktree,
+			worktree.join("main.rs").to_string_lossy().as_ref(),
+			"File",
+		);
+		let git_result =
+			resolve_existing_worktree_path(&worktree, ".git/config", "File");
+
+		assert!(matches!(parent_result, Err(AppError::IoError(_))));
+		assert!(matches!(absolute_result, Err(AppError::IoError(_))));
+		assert!(matches!(git_result, Err(AppError::IoError(_))));
+		std::fs::remove_dir_all(worktree).expect("cleanup temp worktree");
 	}
 
 	#[cfg(unix)]
 	#[test]
-	fn resolve_existing_profile_path_rejects_symlink_escape() {
+	fn resolve_existing_worktree_path_rejects_symlink_escape() {
 		let temp_dir = temp_worktree();
 		let worktree = temp_dir.join("worktree");
 		let outside = temp_dir.join("outside");
@@ -1010,11 +1225,31 @@ mod tests {
 		std::os::unix::fs::symlink(&outside, worktree.join("link"))
 			.expect("create symlink");
 
-		let result = resolve_existing_profile_path(
+		let result = resolve_existing_worktree_path(
 			&worktree,
 			"link/secret.txt",
-			"File path",
-			false,
+			"File",
+		);
+
+		assert!(matches!(result, Err(AppError::IoError(_))));
+		std::fs::remove_dir_all(temp_dir).expect("cleanup temp dir");
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn ensure_creatable_worktree_path_rejects_symlink_parent_escape() {
+		let temp_dir = temp_worktree();
+		let worktree = temp_dir.join("worktree");
+		let outside = temp_dir.join("outside");
+		std::fs::create_dir_all(&worktree).expect("create worktree");
+		std::fs::create_dir_all(&outside).expect("create outside");
+		std::os::unix::fs::symlink(&outside, worktree.join("link"))
+			.expect("create symlink");
+
+		let result = ensure_creatable_worktree_path(
+			&worktree,
+			"link/created.txt",
+			"File",
 		);
 
 		assert!(matches!(result, Err(AppError::IoError(_))));

--- a/src-tauri/src/handler/project.rs
+++ b/src-tauri/src/handler/project.rs
@@ -1,4 +1,4 @@
-use tauri::State;
+use tauri::{AppHandle, Manager, State};
 
 use infra::db::DbPool;
 use model::error::AppError;
@@ -127,16 +127,24 @@ pub async fn get_git_binary_preview(
 	path: String,
 	source: String,
 	commit_hash: Option<String>,
+	app: AppHandle,
 	state: State<'_, DbPool>,
 ) -> Result<Option<GitBinaryPreview>, AppError> {
 	let db = state.inner().clone();
+	let cache_root = app
+		.path()
+		.app_cache_dir()
+		.map_err(|err| AppError::IoError(std::io::Error::other(err)))?
+		.join("git-preview-cache");
 	super::run_blocking(move || {
 		let worktree_path = profile_worktree_path(&db, &profile_id)?;
 		let file_path = match source.as_str() {
 			"working_tree" => {
 				infra::git::read_worktree_file(&worktree_path, &path)?
 			}
-			"head" => infra::git::read_head_file(&worktree_path, &path)?,
+			"head" => {
+				infra::git::read_head_file(&worktree_path, &cache_root, &path)?
+			}
 			"commit" => {
 				let commit_hash = commit_hash.as_deref().ok_or_else(|| {
 					AppError::GitError(
@@ -145,6 +153,7 @@ pub async fn get_git_binary_preview(
 				})?;
 				infra::git::read_commit_file(
 					&worktree_path,
+					&cache_root,
 					commit_hash,
 					&path,
 				)?
@@ -158,6 +167,7 @@ pub async fn get_git_binary_preview(
 				})?;
 				infra::git::read_parent_commit_file(
 					&worktree_path,
+					&cache_root,
 					commit_hash,
 					&path,
 				)?

--- a/src-tauri/tests/integration_project.rs
+++ b/src-tauri/tests/integration_project.rs
@@ -1,12 +1,12 @@
 mod common;
 
 use diesel::prelude::*;
+use infra::no_window::command_without_windows_console;
 
 use common::{
 	add_commit, cleanup, create_project_with_git_repo, create_temp_git_repo,
 	setup_db,
 };
-use infra::no_window::command_without_windows_console;
 
 fn create_project_named(
 	conn: &mut SqliteConnection,
@@ -572,6 +572,63 @@ fn create_profile_preserves_namespace() {
 }
 
 #[test]
+fn profile_branch_namespace_conflict_does_not_delete_existing_branch() {
+	let mut conn = setup_db();
+	let (project, _default, dir) = create_project_with_git_repo(&mut conn);
+
+	let branch_output = command_without_windows_console("git")
+		.args(["branch", "feat"])
+		.current_dir(&dir)
+		.output()
+		.expect("create conflicting branch");
+	assert!(
+		branch_output.status.success(),
+		"failed to create branch: {}",
+		String::from_utf8_lossy(&branch_output.stderr)
+	);
+
+	let result = service::profile::create(&mut conn, &project.id, "feat/auth");
+	let created_profile_id =
+		result.as_ref().ok().map(|profile| profile.id.clone());
+
+	let branch_list = command_without_windows_console("git")
+		.args(["branch", "--list", "feat"])
+		.current_dir(&dir)
+		.output()
+		.expect("list conflicting branch");
+	let branch_survived =
+		String::from_utf8_lossy(&branch_list.stdout).contains("feat");
+
+	let profile_count: i64 = model::schema::profiles::table
+		.filter(model::schema::profiles::project_id.eq(&project.id))
+		.filter(model::schema::profiles::branch_name.eq("feat/auth"))
+		.count()
+		.get_result(&mut conn)
+		.expect("count profiles");
+
+	if let Some(profile_id) = created_profile_id {
+		let _ = service::profile::delete(&mut conn, &profile_id);
+	}
+	cleanup(&dir);
+
+	let error_message = match result {
+		Ok(_) => panic!("namespace conflict should fail profile creation"),
+		Err(error) => error.to_string(),
+	};
+	assert!(
+		error_message.to_lowercase().contains("conflict")
+			&& error_message.contains("feat")
+			&& error_message.contains("feat/auth"),
+		"expected namespace conflict error, got: {error_message}"
+	);
+	assert!(branch_survived, "existing branch must not be deleted");
+	assert_eq!(
+		profile_count, 0,
+		"profile row should not be inserted when worktree creation fails"
+	);
+}
+
+#[test]
 fn create_profile_duplicate_branch_returns_error() {
 	let mut conn = setup_db();
 	let (project, _default, dir) = create_project_with_git_repo(&mut conn);
@@ -598,58 +655,6 @@ fn create_profile_for_nonexistent_project_returns_error() {
 	let result =
 		service::profile::create(&mut conn, "nonexistent-project-id", "branch");
 	assert!(result.is_err());
-}
-
-#[test]
-fn profile_branch_namespace_conflict_does_not_delete_existing_branch() {
-	let mut conn = setup_db();
-	let (project, _default, dir) = create_project_with_git_repo(&mut conn);
-
-	// Create an existing "feat" branch that will namespace-conflict with "feat/auth"
-	command_without_windows_console("git")
-		.args(["branch", "feat"])
-		.current_dir(&dir)
-		.output()
-		.unwrap();
-
-	// Attempt to create profile with branch that conflicts: feat/auth blocked by feat
-	let result = service::profile::create(&mut conn, &project.id, "feat/auth");
-
-	let error = match result {
-		Ok(_) => panic!("expected error for namespace ref conflict"),
-		Err(error) => error,
-	};
-	let error_message = error.to_string();
-	assert!(
-		error_message.to_lowercase().contains("conflict")
-			&& error_message.contains("feat")
-			&& error_message.contains("feat/auth"),
-		"expected namespace conflict error, got: {error_message}"
-	);
-
-	// The 'feat' branch must still exist (core assertion: creation must not delete it)
-	let branch_list = command_without_windows_console("git")
-		.args(["branch", "--list", "feat"])
-		.current_dir(&dir)
-		.output()
-		.unwrap();
-	let branch_out = String::from_utf8_lossy(&branch_list.stdout);
-	assert!(
-		branch_out.contains("feat"),
-		"existing 'feat' branch must survive failed profile creation, got: {branch_out}"
-	);
-
-	// No profile row for the conflicting branch name should have been inserted
-	let list = service::project::list(&mut conn).unwrap();
-	let pwp = list.iter().find(|p| p.id == project.id).unwrap();
-	let has_conflict_profile =
-		pwp.profiles.iter().any(|p| p.branch_name == "feat/auth");
-	assert!(
-		!has_conflict_profile,
-		"no profile for 'feat/auth' should be inserted on conflict"
-	);
-
-	cleanup(&dir);
 }
 
 // ============================================================
@@ -751,14 +756,9 @@ fn delete_profile_keeps_row_when_cleanup_fails() {
 	let result = service::profile::delete(&mut conn, &profile.id);
 	assert!(result.is_err(), "expected error when cleanup fails");
 
-	// Critical: the profile row must still exist so user can see it / retry delete later.
-	let list = service::project::list(&mut conn).unwrap();
-	let pwp = list.iter().find(|p| p.id == project.id).unwrap();
-	let row_still_present = pwp.profiles.iter().any(|p| p.id == profile.id);
-	assert!(
-		row_still_present,
-		"profile row must remain in DB after cleanup failure (for retryability)"
-	);
+	let persisted = repo::profile::find_by_id(&mut conn, &profile.id)
+		.expect("profile row should remain retryable");
+	assert_eq!(persisted.id, profile.id);
 
 	repo::project::update(
 		&mut conn,
@@ -781,20 +781,34 @@ fn delete_profile_succeeds_when_git_resources_already_missing() {
 		service::profile::create(&mut conn, &project.id, "already-clean")
 			.unwrap();
 
-	command_without_windows_console("git")
+	let remove_worktree = command_without_windows_console("git")
 		.args(["worktree", "remove", &profile.worktree_path, "--force"])
 		.current_dir(&dir)
 		.output()
-		.unwrap();
-	command_without_windows_console("git")
+		.expect("remove worktree outside service");
+	assert!(
+		remove_worktree.status.success(),
+		"failed to remove worktree: {}",
+		String::from_utf8_lossy(&remove_worktree.stderr)
+	);
+
+	let delete_branch = command_without_windows_console("git")
 		.args(["branch", "-D", &profile.branch_name])
 		.current_dir(&dir)
 		.output()
-		.unwrap();
+		.expect("delete branch outside service");
+	assert!(
+		delete_branch.status.success(),
+		"failed to delete branch: {}",
+		String::from_utf8_lossy(&delete_branch.stderr)
+	);
 
 	service::profile::delete(&mut conn, &profile.id).unwrap();
 
-	assert!(repo::profile::find_by_id(&mut conn, &profile.id).is_err());
+	assert!(
+		repo::profile::find_by_id(&mut conn, &profile.id).is_err(),
+		"profile row should be deleted when cleanup is already complete"
+	);
 
 	cleanup(&dir);
 }


### PR DESCRIPTION
# Plan 005: Serve generated git previews from app cache scope

> **Executor instructions**: Follow steps. Update `plans/README.md` when done.
>
> **Drift check (run first)**: `git diff --stat 3ee5b79..HEAD -- src-tauri/crates/infra/src/git.rs src-tauri/src/handler/project.rs src/features/git/components/GitBinaryPreview.tsx src-tauri/tauri.conf.json`

## Status

- **Priority**: P1
- **Effort**: M
- **Risk**: MED
- **Depends on**: `plans/003-profile-scoped-file-ipc.md`
- **Category**: security
- **Planned at**: commit `3ee5b79`, 2026-06-13

## Why this matters

Tauri asset scope currently allows `$HOME/**` and `$APPCACHE/**`, but git binary previews are written under `std::env::temp_dir()`. That can make previews fail if temp is outside scope, or tempt future broadening of asset permissions. Generated preview artifacts should live under app cache and be the only cache area exposed.

## Current state

Relevant files:
- `src-tauri/crates/infra/src/git.rs` — `preview_cache_path` uses temp dir.
- `src-tauri/src/handler/project.rs` — `get_git_binary_preview` calls git preview helpers without an app cache root.
- `src/features/git/components/GitBinaryPreview.tsx` — uses `convertFileSrc(previewQuery.data.file_path)`.
- `src-tauri/tauri.conf.json` — asset scope includes `$HOME/**` and `$APPCACHE/**`; CSP is null.

Current excerpts:
- `src-tauri/crates/infra/src/git.rs:1331` uses `std::env::temp_dir().join("2code").join("git-preview-cache")`.
- `src-tauri/tauri.conf.json:8-13` scopes asset protocol and disables CSP.

## Commands you will need

| Purpose | Command | Expected on success |
|---|---|---|
| Rust tests | `cargo test --manifest-path src-tauri/Cargo.toml git_binary_preview` | exit 0 |
| Full Rust | `cargo test --manifest-path src-tauri/Cargo.toml` | exit 0 |
| Frontend | `bun run test -- GitBinaryPreview` | exit 0 if changed |
| Fast checks | `bun run lint:check && ./node_modules/.bin/tsc --noEmit` | exit 0 |

## Scope

**In scope**:
- Git binary preview cache root.
- Tauri handler path passing app cache root to backend.
- Optional tightening of asset scope after all preview call sites work.

**Out of scope**:
- Office/PDF previews already use `app_cache_dir()` in `handler/filesystem.rs`.
- Full CSP hardening unless trivial and verified.

## Git workflow

Branch `advisor/005-app-cache-git-previews`; commit `fix(git): store binary previews in app cache`.

## Steps

### Step 1: Change git preview helpers to accept a cache root

Update `read_head_file`, `read_commit_file`, `read_parent_commit_file`, and `preview_cache_path` so callers provide a cache root path. Keep cache organization by repo hash/source/commit/path.

**Verify**: Rust compiles; existing git preview tests updated to pass a temp cache root.

### Step 2: Pass app cache root from Tauri handler

In `handler::project::get_git_binary_preview`, accept/use `AppHandle` and resolve `app.path().app_cache_dir()?.join("git-preview-cache")`. Pass that to infra preview helpers.

**Verify**: `cargo test --manifest-path src-tauri/Cargo.toml git_binary_preview` → pass.

### Step 3: Reconsider asset scope

If no remaining preview path requires `$HOME/**`, remove or narrow `$HOME/**` from `src-tauri/tauri.conf.json`. If `$HOME/**` is still needed for direct image/PDF previews from user worktrees, document why and leave it; do not break user previews.

**Verify**: `bun run test -- FileViewerPane GitBinaryPreview` → pass.

### Step 4: Full validation

Run full Rust and frontend checks.

**Verify**: all commands exit 0.

## Test plan

- Rust tests assert preview paths start under provided cache root and contain expected bytes.
- Existing binary preview UI tests still pass.

## Done criteria

- [x] Git generated preview cache no longer uses OS temp dir by default.
- [x] Preview paths returned to frontend are inside app cache.
- [x] Asset scope is not broadened.
- [x] Full checks pass.

## STOP conditions

- Tauri asset protocol cannot serve app cache paths on a target platform without additional config.
- Removing `$HOME/**` breaks direct user-file previews; leave it and report.

## Maintenance notes

Reviewers should distinguish generated preview artifacts from user worktree files; they have different asset-scope needs.