### PR TITLE
perf(profiles): pause hidden file tree queries

### DIFF
--- a/src/features/projects/CommandPalette.test.tsx
+++ b/src/features/projects/CommandPalette.test.tsx
@@ -136,7 +136,7 @@ describe("commandPalette", () => {
 		await waitFor(() => {
 			expect(
 				useFileViewerTabsStore.getState().profiles["profile-1"]?.activeFilePath,
-			).toBe("/repo/src/main.ts");
+			).toBe("src/main.ts");
 		});
 		expect(
 			screen.queryByRole("combobox", {

--- a/src/features/projects/CommandPalette.tsx
+++ b/src/features/projects/CommandPalette.tsx
@@ -180,7 +180,7 @@ export default function CommandPalette({
 
 	const commitSelection = useCallback(
 		(result: FileSearchResult) => {
-			openFile(profileId, result.path);
+			openFile(profileId, result.relative_path);
 			closePalette();
 		},
 		[closePalette, openFile, profileId],

--- a/src/features/projects/FileTreePanel.test.tsx
+++ b/src/features/projects/FileTreePanel.test.tsx
@@ -254,13 +254,17 @@ function createFileTreeGitStatusResult(
 	} as FileTreeGitStatusResult;
 }
 
-function renderPanel(onOpenFile = vi.fn()) {
+function renderPanel(
+	onOpenFile = vi.fn(),
+	options: { isOpen?: boolean; isActive?: boolean } = {},
+) {
 	render(
 		<ChakraProvider value={appSystem}>
 			<FileTreePanel
 				profileId={profileId}
 				rootPath={rootPath}
-				isOpen
+				isOpen={options.isOpen ?? true}
+				isActive={options.isActive ?? true}
 				onOpenFile={onOpenFile}
 			/>
 		</ChakraProvider>,
@@ -368,6 +372,17 @@ describe("fileTreePanel", () => {
 		await waitFor(() => {
 			expect(resetPathsMock).toHaveBeenCalledWith(treePaths);
 		});
+	});
+
+	it("disables tree and git status queries while inactive", () => {
+		renderPanel(vi.fn(), { isActive: false });
+
+		expect(useFileTreeChildPaths).toHaveBeenCalledWith(
+			profileId,
+			null,
+			false,
+		);
+		expect(useFileTreeGitStatus).toHaveBeenCalledWith(profileId, false);
 	});
 
 	it("loads direct children when a directory is expanded", async () => {
@@ -520,7 +535,7 @@ describe("fileTreePanel", () => {
 
 		fireEvent.click(screen.getByText("index.ts"));
 
-		expect(onOpenFile).toHaveBeenCalledWith("/root/src/index.ts");
+		expect(onOpenFile).toHaveBeenCalledWith("src/index.ts");
 	});
 
 	it("opens status-only ignored file rows from tree click events", () => {
@@ -534,7 +549,7 @@ describe("fileTreePanel", () => {
 
 		fireEvent.click(screen.getByText("ignored.log"));
 
-		expect(onOpenFile).toHaveBeenCalledWith("/root/ignored.log");
+		expect(onOpenFile).toHaveBeenCalledWith("ignored.log");
 	});
 
 	it("does not open status-only deleted file rows", () => {
@@ -560,7 +575,7 @@ describe("fileTreePanel", () => {
 			]);
 		});
 
-		expect(onOpenFile).toHaveBeenCalledWith("/root/src/index.ts");
+		expect(onOpenFile).toHaveBeenCalledWith("src/index.ts");
 	});
 
 	it("does not open files while mouse selection is waiting for click", () => {
@@ -577,7 +592,7 @@ describe("fileTreePanel", () => {
 
 		fireEvent.click(screen.getByText("index.ts"));
 
-		expect(onOpenFile).toHaveBeenCalledWith("/root/src/index.ts");
+		expect(onOpenFile).toHaveBeenCalledWith("src/index.ts");
 	});
 
 	it("does not open files while extending multi-selection", () => {
@@ -673,8 +688,7 @@ describe("fileTreePanel", () => {
 
 		await waitFor(() => {
 			expect(revealMutateAsyncMock).toHaveBeenCalledWith({
-				profileId: "profile-1",
-				path: "",
+				path: null,
 			});
 		});
 	});
@@ -824,7 +838,6 @@ describe("fileTreePanel", () => {
 
 		await waitFor(() => {
 			expect(revealMutateAsyncMock).toHaveBeenCalledWith({
-				profileId: "profile-1",
 				path: "src/index.ts",
 			});
 		});
@@ -840,7 +853,6 @@ describe("fileTreePanel", () => {
 
 		await waitFor(() => {
 			expect(openDefaultAppMutateAsyncMock).toHaveBeenCalledWith({
-				profileId: "profile-1",
 				path: "src/index.ts",
 			});
 		});

--- a/src/features/projects/FileTreePanel.tsx
+++ b/src/features/projects/FileTreePanel.tsx
@@ -93,6 +93,7 @@ interface FileTreePanelProps {
 	profileId: string;
 	rootPath: string;
 	isOpen: boolean;
+	isActive?: boolean;
 	onOpenFile?: (filePath: string) => void;
 }
 
@@ -517,6 +518,7 @@ export default function FileTreePanel({
 	profileId,
 	rootPath,
 	isOpen,
+	isActive = true,
 	onOpenFile,
 }: FileTreePanelProps) {
 	const [openFilePath, setOpenFilePath] = useState<string | null>(null);
@@ -574,15 +576,18 @@ export default function FileTreePanel({
 		data: rootChildPaths,
 		error: treePathsError,
 		isError: isTreePathsError,
-	} = useFileTreeChildPaths(profileId, null, isOpen);
-	const { data: gitStatusEntries } = useFileTreeGitStatus(profileId, isOpen);
+	} = useFileTreeChildPaths(profileId, null, isOpen && isActive);
+	const { data: gitStatusEntries } = useFileTreeGitStatus(
+		profileId,
+		isOpen && isActive,
+	);
 	const loadFileTreeChildPaths = useLoadFileTreeChildPaths(profileId);
 	const createFileTreePath = useCreateFileTreePath(profileId);
 	const renameFileTreePath = useRenameFileTreePath(profileId);
 	const moveFileTreePaths = useMoveFileTreePaths(profileId);
 	const deleteFileTreePaths = useDeleteFileTreePaths(profileId);
-	const openPathInDefaultApp = useOpenPathInDefaultApp();
-	const revealPathInFileManager = useRevealPathInFileManager();
+	const openPathInDefaultApp = useOpenPathInDefaultApp(profileId);
+	const revealPathInFileManager = useRevealPathInFileManager(profileId);
 	const loadedDirectoryChildPaths =
 		loadedChildPathsState.rootPath === rootPath &&
 		loadedChildPathsState.rootChildPaths === rootChildPaths
@@ -650,11 +655,10 @@ export default function FileTreePanel({
 	}, [rootPath, rootChildPaths]);
 
 	const openRelativeFile = useCallback((relativePath: string) => {
-		const filePath = toAbsolutePath(rootPathRef.current, relativePath);
 		if (onOpenFileRef.current) {
-			onOpenFileRef.current(filePath);
+			onOpenFileRef.current(relativePath);
 		} else {
-			setOpenFilePath(filePath);
+			setOpenFilePath(relativePath);
 		}
 	}, []);
 
@@ -1058,7 +1062,6 @@ export default function FileTreePanel({
 		async (relativePath: string) => {
 			try {
 				await revealPathInFileManager.mutateAsync({
-					profileId,
 					path: relativePath,
 				});
 			} catch (error) {
@@ -1070,13 +1073,12 @@ export default function FileTreePanel({
 				});
 			}
 		},
-		[profileId, revealPathInFileManager],
+		[revealPathInFileManager],
 	);
 	const handleRevealRoot = useCallback(async () => {
 		try {
 			await revealPathInFileManager.mutateAsync({
-				profileId,
-				path: "",
+				path: null,
 			});
 		} catch (error) {
 			toaster.create({
@@ -1086,12 +1088,11 @@ export default function FileTreePanel({
 				closable: true,
 			});
 		}
-	}, [profileId, revealPathInFileManager]);
+	}, [revealPathInFileManager]);
 	const handleOpenPathInDefaultApp = useCallback(
 		async (relativePath: string) => {
 			try {
 				await openPathInDefaultApp.mutateAsync({
-					profileId,
 					path: relativePath,
 				});
 			} catch (error) {
@@ -1103,7 +1104,7 @@ export default function FileTreePanel({
 				});
 			}
 		},
-		[profileId, openPathInDefaultApp],
+		[openPathInDefaultApp],
 	);
 
 	return (
@@ -1278,6 +1279,7 @@ export default function FileTreePanel({
 			{openFilePath && (
 				<FileViewerDialog
 					profileId={profileId}
+					rootPath={rootPath}
 					filePath={openFilePath}
 					onClose={() => setOpenFilePath(null)}
 				/>

--- a/src/features/projects/FileViewerDialog.tsx
+++ b/src/features/projects/FileViewerDialog.tsx
@@ -13,16 +13,19 @@ import { useTerminalThemeId } from "@/features/terminal/hooks";
 import { detectLanguage } from "@/shared/lib/languageDetection";
 import { getPrismTheme } from "./prismThemes";
 import { useFileContent } from "./hooks";
+import { toProfileRelativePath } from "./pathUtils";
 
 interface FileViewerDialogProps {
-	profileId: string;
 	filePath: string;
+	profileId: string;
+	rootPath: string;
 	onClose: () => void;
 }
 
 export default function FileViewerDialog({
-	profileId,
 	filePath,
+	profileId,
+	rootPath,
 	onClose,
 }: FileViewerDialogProps) {
 	const themeId = useTerminalThemeId();
@@ -35,7 +38,7 @@ export default function FileViewerDialog({
 		error,
 		isError,
 		isLoading,
-	} = useFileContent(profileId, filePath);
+	} = useFileContent(profileId, toProfileRelativePath(rootPath, filePath));
 
 	const filename = filePath.split("/").pop() ?? "";
 	const language = detectLanguage(filename);

--- a/src/features/projects/FileViewerPane.test.tsx
+++ b/src/features/projects/FileViewerPane.test.tsx
@@ -100,6 +100,7 @@ vi.mock("@/features/terminal/hooks", () => ({
 }));
 
 const filePath = "/repo/src/index.ts";
+const rootPath = "/repo";
 const profileId = "profile-1";
 const fileContent = [
 	"function alpha() {}",
@@ -123,10 +124,15 @@ function createVisibleRectList(): DOMRectList {
 	} as unknown as DOMRectList;
 }
 
-function renderPane(path = filePath) {
+function renderPane(path = filePath, isActive = true) {
 	return render(
 		<ChakraProvider value={appSystem}>
-			<FileViewerPane filePath={path} profileId={profileId} />
+			<FileViewerPane
+				filePath={path}
+				profileId={profileId}
+				rootPath={rootPath}
+				isActive={isActive}
+			/>
 		</ChakraProvider>,
 	);
 }
@@ -183,6 +189,21 @@ describe("fileViewerPane", () => {
 		expect(screen.queryByRole("button")).not.toBeInTheDocument();
 	});
 
+	it("disables file content and preview queries while inactive", () => {
+		renderPane("/repo/assets/logo.png", false);
+
+		expect(useFileContent).toHaveBeenCalledWith(
+			profileId,
+			"assets/logo.png",
+			false,
+		);
+		expect(useFilePreview).toHaveBeenCalledWith(
+			profileId,
+			"assets/logo.png",
+			false,
+		);
+	});
+
 	it("renders the file load error before content is available", () => {
 		vi.mocked(useFileContent).mockReturnValue({
 			data: undefined,
@@ -218,7 +239,7 @@ describe("fileViewerPane", () => {
 		});
 
 		expect(saveMutateMock).toHaveBeenCalledWith(
-			{ path: filePath, content: nextContent },
+			{ path: "src/index.ts", content: nextContent },
 			expect.objectContaining({ onSuccess: expect.any(Function) }),
 		);
 		expect(useFileViewerDirtyStore.getState().profiles[profileId]).toBeUndefined();
@@ -279,7 +300,7 @@ describe("fileViewerPane", () => {
 		});
 
 		expect(saveMutateMock).toHaveBeenCalledWith(
-			{ path: markdownPath, content: nextContent },
+			{ path: "README.md", content: nextContent },
 			expect.objectContaining({ onSuccess: expect.any(Function) }),
 		);
 		expect(useFileViewerDirtyStore.getState().profiles[profileId]).toBeUndefined();
@@ -289,12 +310,14 @@ describe("fileViewerPane", () => {
 		const markdownPath = "/repo/README.md";
 		const markdownContent = "# Readme";
 		const markdownDraft = `${markdownContent}\n\nUpdated.`;
-		vi.mocked(useFileContent).mockImplementation((_profileId: string, p: string) => ({
-			data: p === markdownPath ? markdownContent : fileContent,
-			isLoading: false,
-			isError: false,
-			error: null,
-		} as FileContentResult));
+		vi.mocked(useFileContent).mockImplementation(
+			(_profileId: string, path: string) => ({
+				data: path === "README.md" ? markdownContent : fileContent,
+				isLoading: false,
+				isError: false,
+				error: null,
+			}) as FileContentResult,
+		);
 
 		const { rerender } = renderPane(markdownPath);
 
@@ -303,7 +326,11 @@ describe("fileViewerPane", () => {
 
 		rerender(
 			<ChakraProvider value={appSystem}>
-				<FileViewerPane filePath={filePath} profileId={profileId} />
+				<FileViewerPane
+					filePath={filePath}
+					profileId={profileId}
+					rootPath={rootPath}
+				/>
 			</ChakraProvider>,
 		);
 
@@ -317,12 +344,14 @@ describe("fileViewerPane", () => {
 		const markdownPath = "/repo/README.md";
 		const markdownContent = "# Readme";
 		const markdownDraft = `${markdownContent}\n\nUpdated.`;
-		vi.mocked(useFileContent).mockImplementation((_profileId: string, p: string) => ({
-			data: p === markdownPath ? markdownContent : fileContent,
-			isLoading: false,
-			isError: false,
-			error: null,
-		} as FileContentResult));
+		vi.mocked(useFileContent).mockImplementation(
+			(_profileId: string, path: string) => ({
+				data: path === "README.md" ? markdownContent : fileContent,
+				isLoading: false,
+				isError: false,
+				error: null,
+			}) as FileContentResult,
+		);
 
 		const { rerender } = renderPane(markdownPath);
 
@@ -331,7 +360,11 @@ describe("fileViewerPane", () => {
 
 		rerender(
 			<ChakraProvider value={appSystem}>
-				<FileViewerPane filePath={filePath} profileId={profileId} />
+				<FileViewerPane
+					filePath={filePath}
+					profileId={profileId}
+					rootPath={rootPath}
+				/>
 			</ChakraProvider>,
 		);
 
@@ -345,7 +378,11 @@ describe("fileViewerPane", () => {
 
 		rerender(
 			<ChakraProvider value={appSystem}>
-				<FileViewerPane filePath={markdownPath} profileId={profileId} />
+				<FileViewerPane
+					filePath={markdownPath}
+					profileId={profileId}
+					rootPath={rootPath}
+				/>
 			</ChakraProvider>,
 		);
 
@@ -359,12 +396,14 @@ describe("fileViewerPane", () => {
 		const markdownPath = "/repo/README.md";
 		const markdownContent = "# Readme";
 		const codeDraft = `${fileContent}\nconsole.log(beta);`;
-		vi.mocked(useFileContent).mockImplementation((_profileId: string, p: string) => ({
-			data: p === markdownPath ? markdownContent : fileContent,
-			isLoading: false,
-			isError: false,
-			error: null,
-		} as FileContentResult));
+		vi.mocked(useFileContent).mockImplementation(
+			(_profileId: string, path: string) => ({
+				data: path === "README.md" ? markdownContent : fileContent,
+				isLoading: false,
+				isError: false,
+				error: null,
+			}) as FileContentResult,
+		);
 
 		const { rerender } = renderPane(filePath);
 
@@ -373,7 +412,11 @@ describe("fileViewerPane", () => {
 
 		rerender(
 			<ChakraProvider value={appSystem}>
-				<FileViewerPane filePath={markdownPath} profileId={profileId} />
+				<FileViewerPane
+					filePath={markdownPath}
+					profileId={profileId}
+					rootPath={rootPath}
+				/>
 			</ChakraProvider>,
 		);
 
@@ -402,8 +445,16 @@ describe("fileViewerPane", () => {
 		const image = await screen.findByRole("img", { name: "logo.png" });
 		expect(image).toHaveAttribute("src", expect.stringContaining(imagePath));
 		expect(screen.queryByLabelText("Monaco Editor")).not.toBeInTheDocument();
-		expect(useFileContent).toHaveBeenCalledWith("profile-1", imagePath, false);
-		expect(useFilePreview).toHaveBeenCalledWith("profile-1", imagePath, true);
+		expect(useFileContent).toHaveBeenCalledWith(
+			profileId,
+			"assets/logo.png",
+			false,
+		);
+		expect(useFilePreview).toHaveBeenCalledWith(
+			profileId,
+			"assets/logo.png",
+			true,
+		);
 	});
 
 	it("renders Office previews as converted PDFs", async () => {
@@ -453,6 +504,10 @@ describe("fileViewerPane", () => {
 		expect(screen.getByText("archive.zip")).toBeInTheDocument();
 		expect(screen.getByText("src/index.ts")).toBeInTheDocument();
 		expect(screen.queryByLabelText("Monaco Editor")).not.toBeInTheDocument();
-		expect(useFileContent).toHaveBeenCalledWith("profile-1", archivePath, false);
+		expect(useFileContent).toHaveBeenCalledWith(
+			profileId,
+			"archive.zip",
+			false,
+		);
 	});
 });

--- a/src/features/projects/FileViewerPane.tsx
+++ b/src/features/projects/FileViewerPane.tsx
@@ -18,6 +18,7 @@ import MarkdownEditor from "@/features/markdown/MarkdownEditor";
 import ArchivePreviewTree from "@/features/projects/ArchivePreviewTree";
 import { isPreviewableBinaryFile } from "@/features/projects/filePreview";
 import { useFileViewerDirtyStore } from "@/features/projects/fileViewerTabsStore";
+import { toProfileRelativePath } from "@/features/projects/pathUtils";
 import { useTerminalSettingsStore } from "@/features/settings/stores/terminalSettingsStore";
 import { useTerminalThemeId } from "@/features/terminal/hooks";
 import type { FilePreview } from "@/generated";
@@ -27,6 +28,8 @@ import { useFileContent, useFilePreview, useSaveFileContent } from "./hooks";
 interface FileViewerPaneProps {
 	filePath: string;
 	profileId: string;
+	rootPath: string;
+	isActive?: boolean;
 }
 
 const DRAFT_SYNC_DELAY_MS = 400;
@@ -170,6 +173,8 @@ function FilePreviewPane({
 export default function FileViewerPane({
 	filePath,
 	profileId,
+	rootPath,
+	isActive = true,
 }: FileViewerPaneProps) {
 	const themeId = useTerminalThemeId();
 	const fontFamily = useTerminalSettingsStore((s) => s.fontFamily);
@@ -194,6 +199,10 @@ export default function FileViewerPane({
 		(state) => state.setFileSavedValue,
 	);
 	const setFileDirty = useFileViewerDirtyStore((state) => state.setFileDirty);
+	const scopedFilePath = useMemo(
+		() => toProfileRelativePath(rootPath, filePath),
+		[rootPath, filePath],
+	);
 
 	const fileMeta = useMemo(
 		() => {
@@ -212,8 +221,16 @@ export default function FileViewerPane({
 		error,
 		isError,
 		isLoading,
-	} = useFileContent(profileId, filePath, !fileMeta.previewableBinaryFile);
-	const previewQuery = useFilePreview(profileId, filePath, fileMeta.previewableBinaryFile);
+	} = useFileContent(
+		profileId,
+		scopedFilePath,
+		isActive && !fileMeta.previewableBinaryFile,
+	);
+	const previewQuery = useFilePreview(
+		profileId,
+		scopedFilePath,
+		isActive && fileMeta.previewableBinaryFile,
+	);
 	const {
 		isPending: isSaving,
 		mutate: saveFileContent,
@@ -344,12 +361,12 @@ export default function FileViewerPane({
 
 		flushPendingDraft();
 		saveFileContent(
-			{ path: filePath, content: contentToSave },
+			{ path: scopedFilePath, content: contentToSave },
 			{
 				onSuccess: (_result, variables) => {
-					setFileDraft(profileId, variables.path, variables.content);
-					setFileSavedValue(profileId, variables.path, variables.content);
-					setFileDirty(profileId, variables.path, false);
+					setFileDraft(profileId, filePath, variables.content);
+					setFileSavedValue(profileId, filePath, variables.content);
+					setFileDirty(profileId, filePath, false);
 				},
 			},
 		);
@@ -362,6 +379,7 @@ export default function FileViewerPane({
 		lastSavedValue,
 		profileId,
 		saveFileContent,
+		scopedFilePath,
 		setFileDraft,
 		setFileDirty,
 		setFileSavedValue,

--- a/src/features/projects/ProfileLayout.tsx
+++ b/src/features/projects/ProfileLayout.tsx
@@ -53,6 +53,7 @@ export default function ProfileLayout({
 					profileId={profile.id}
 					rootPath={profile.worktree_path}
 					isOpen={fileTreeOpen}
+					isActive={isActive}
 					onOpenFile={handleOpenFile}
 				/>
 				<Box

--- a/src/features/projects/ProjectDetailPage.tsx
+++ b/src/features/projects/ProjectDetailPage.tsx
@@ -149,6 +149,7 @@ export default function ProjectDetailPage() {
 						profileId={profile.id}
 						cwd={profile.worktree_path}
 						profile={profile}
+						isActive
 						emptyFallback={emptyTerminalState}
 					/>
 				</ProfileLayout>

--- a/src/features/projects/pathUtils.ts
+++ b/src/features/projects/pathUtils.ts
@@ -1,0 +1,33 @@
+const WINDOWS_ABSOLUTE_PATH_RE = /^[a-z]:[\\/]/i;
+const TRAILING_PATH_SEPARATOR_RE = /[\\/]+$/;
+
+function normalizePathSeparators(path: string) {
+	return path.replace(/\\/g, "/");
+}
+
+function isAbsolutePath(path: string) {
+	return path.startsWith("/") || WINDOWS_ABSOLUTE_PATH_RE.test(path);
+}
+
+export function toProfileRelativePath(rootPath: string, filePath: string) {
+	const normalizedFilePath = normalizePathSeparators(filePath);
+	if (!isAbsolutePath(normalizedFilePath)) {
+		return normalizedFilePath.replace(/^\.\//, "");
+	}
+
+	const normalizedRootPath = normalizePathSeparators(rootPath).replace(
+		TRAILING_PATH_SEPARATOR_RE,
+		"",
+	);
+
+	if (normalizedFilePath === normalizedRootPath) {
+		return "";
+	}
+
+	const rootPrefix = `${normalizedRootPath}/`;
+	if (normalizedFilePath.startsWith(rootPrefix)) {
+		return normalizedFilePath.slice(rootPrefix.length);
+	}
+
+	return normalizedFilePath;
+}

--- a/src/features/terminal/TerminalLayer.test.tsx
+++ b/src/features/terminal/TerminalLayer.test.tsx
@@ -1,0 +1,143 @@
+import {
+	QueryClient,
+	QueryClientProvider,
+} from "@tanstack/react-query";
+import { act, render, waitFor } from "@testing-library/react";
+import { Suspense, type ReactNode } from "react";
+import { MemoryRouter } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useFileViewerTabsStore } from "@/features/projects/fileViewerTabsStore";
+import { useTerminalStore } from "./store";
+import TerminalLayer from "./TerminalLayer";
+
+const {
+	closeTerminalTabMock,
+	createTerminalTabMock,
+	listProjectsMock,
+	profileLayoutProps,
+} = vi.hoisted(() => ({
+	closeTerminalTabMock: vi.fn(),
+	createTerminalTabMock: vi.fn(),
+	listProjectsMock: vi.fn(),
+	profileLayoutProps: [] as { profileId: string; isActive: boolean }[],
+}));
+
+vi.mock("@/generated", () => ({
+	listProjects: listProjectsMock,
+}));
+
+vi.mock("./state", () => ({
+	restorationPromise: Promise.resolve(),
+}));
+
+vi.mock("./hooks", () => ({
+	useCloseTerminalTab: () => ({ mutate: closeTerminalTabMock }),
+	useCreateTerminalTab: () => ({ mutate: createTerminalTabMock }),
+}));
+
+vi.mock("@/features/projects/ProfileLayout", () => ({
+	default: ({
+		children,
+		isActive,
+		profile,
+	}: {
+		children: ReactNode;
+		isActive: boolean;
+		profile: { id: string };
+	}) => {
+		profileLayoutProps.push({ profileId: profile.id, isActive });
+		return <div data-testid={`profile-layout-${profile.id}`}>{children}</div>;
+	},
+}));
+
+vi.mock("./TerminalTabs", () => ({
+	default: ({ isActive, profileId }: { isActive: boolean; profileId: string }) => (
+		<div data-active={isActive ? "true" : "false"} data-testid={`tabs-${profileId}`} />
+	),
+}));
+
+vi.mock("./TerminalFileLinkPickerDialog", () => ({
+	TerminalFileLinkPickerDialog: () => null,
+}));
+
+function createWrapper(route: string) {
+	const queryClient = new QueryClient({
+		defaultOptions: {
+			queries: { retry: false },
+		},
+	});
+
+	return ({ children }: { children: ReactNode }) => (
+		<QueryClientProvider client={queryClient}>
+			<MemoryRouter initialEntries={[route]}>
+				<Suspense fallback={null}>{children}</Suspense>
+			</MemoryRouter>
+		</QueryClientProvider>
+	);
+}
+
+describe("terminalLayer", () => {
+	beforeEach(() => {
+		closeTerminalTabMock.mockReset();
+		createTerminalTabMock.mockReset();
+		profileLayoutProps.length = 0;
+		listProjectsMock.mockResolvedValue([
+			{
+				id: "project-1",
+				name: "Project",
+				folder: "/repo",
+				created_at: "2026-01-01 00:00:00",
+				group_id: null,
+				sort_order: 0,
+				pinned_at: null,
+				pinned_order: null,
+				profiles: [
+					{
+						id: "profile-1",
+						project_id: "project-1",
+						branch_name: "main",
+						worktree_path: "/repo",
+						created_at: "2026-01-01 00:00:00",
+						is_default: true,
+						notes: "",
+					},
+					{
+						id: "profile-2",
+						project_id: "project-1",
+						branch_name: "feature",
+						worktree_path: "/repo-feature",
+						created_at: "2026-01-01 00:00:00",
+						is_default: false,
+						notes: "",
+					},
+				],
+			},
+		]);
+		useTerminalStore.setState({
+			profiles: {},
+			agentStatuses: {},
+			sessionProfileIds: {},
+		});
+		useFileViewerTabsStore.setState({ profiles: {} });
+	});
+
+	it("marks only the routed profile layout active while keeping other layouts mounted", async () => {
+		useTerminalStore.getState().addTab("profile-1", "session-1", "Terminal 1");
+		useTerminalStore.getState().addTab("profile-2", "session-2", "Terminal 2");
+
+		await act(async () => {
+			render(<TerminalLayer />, {
+				wrapper: createWrapper("/projects/project-1/profiles/profile-2"),
+			});
+		});
+
+		await waitFor(() => {
+			expect(profileLayoutProps).toEqual(
+				expect.arrayContaining([
+					{ profileId: "profile-1", isActive: false },
+					{ profileId: "profile-2", isActive: true },
+				]),
+			);
+		});
+	});
+});

--- a/src/features/terminal/TerminalLayer.tsx
+++ b/src/features/terminal/TerminalLayer.tsx
@@ -106,6 +106,7 @@ export default function TerminalLayer() {
 								profileId={profileId}
 								cwd={profile.worktree_path}
 								profile={profile}
+								isActive={profileId === activeProfileId}
 							/>
 						</ProfileLayout>
 					</div>

--- a/src/features/terminal/TerminalTabs.test.tsx
+++ b/src/features/terminal/TerminalTabs.test.tsx
@@ -104,12 +104,13 @@ function createFileTreeDrop(paths: string[]) {
 	return dataTransfer;
 }
 
-function renderTerminalTabs() {
+function renderTerminalTabs(options: { isActive?: boolean } = {}) {
 	render(
 		<TerminalTabs
 			projectId="project-1"
 			profileId={profileId}
 			cwd="/root"
+			isActive={options.isActive ?? true}
 		/>,
 		{ wrapper: createWrapper() },
 	);
@@ -163,6 +164,18 @@ describe("terminalTabs file tree drops", () => {
 		expect(screen.getByTestId("terminal-session-2")).toHaveAttribute(
 			"data-active",
 			"true",
+		);
+	});
+
+	it("keeps terminal instances mounted but inactive when the profile is hidden", () => {
+		useTerminalStore.getState().addTab(profileId, "session-1", "Terminal 1");
+		useTerminalStore.getState().setActiveTab(profileId, "session-1");
+
+		renderTerminalTabs({ isActive: false });
+
+		expect(screen.getByTestId("terminal-session-1")).toHaveAttribute(
+			"data-active",
+			"false",
 		);
 	});
 });

--- a/src/features/terminal/TerminalTabs.tsx
+++ b/src/features/terminal/TerminalTabs.tsx
@@ -114,6 +114,7 @@ interface TerminalTabsProps {
 	profileId: string;
 	cwd: string;
 	profile?: import("@/generated").Profile;
+	isActive?: boolean;
 	emptyFallback?: ReactNode;
 }
 
@@ -122,6 +123,7 @@ export default function TerminalTabs({
 	profileId,
 	cwd,
 	profile,
+	isActive = true,
 	emptyFallback,
 }: TerminalTabsProps) {
 	const { tabs, activeTabId } = useTerminalStore(
@@ -464,7 +466,12 @@ export default function TerminalTabs({
 							<InlineError error={error} height="32" onRetry={onRetry} />
 						)}
 					>
-						<FileViewerPane filePath={activeFilePath} profileId={profileId} />
+						<FileViewerPane
+							filePath={activeFilePath}
+							profileId={profileId}
+							rootPath={profile?.worktree_path ?? ""}
+							isActive={isActive}
+						/>
 					</AsyncBoundary>
 				</Box>
 			)}
@@ -507,7 +514,12 @@ export default function TerminalTabs({
 						<Terminal
 							profileId={profileId}
 							sessionId={tab.id}
-							isActive={tab.id === activeTabId && !fileTabActive && !notesActive}
+							isActive={
+								isActive &&
+								tab.id === activeTabId &&
+								!fileTabActive &&
+								!notesActive
+							}
 						/>
 					</Box>
 				))}

--- a/src/layout/sidebar/ProjectMenuItem.tsx
+++ b/src/layout/sidebar/ProjectMenuItem.tsx
@@ -97,7 +97,11 @@ export function ProjectMenuItem({
 						_hover={{ bg: "bg.subtle" }}
 						_active={{ bg: "bg.muted" }}
 					>
-						<NavLink to={defaultProfileUrl}>
+						<NavLink
+							data-project-id={project.id}
+							data-testid="project-sidebar-item"
+							to={defaultProfileUrl}
+						>
 							{hasOnlyDefaultProfile && isDefaultActive && (
 								<SidebarActiveIndicator insetInlineStart="0" />
 							)}
@@ -196,6 +200,7 @@ export function ProjectMenuItem({
 								{m.projectSettings()}
 							</Menu.Item>
 							<Menu.Item
+								data-testid="project-menu-rename"
 								value="rename"
 								onClick={renameDialog.onOpen}
 							>

--- a/src/shared/components/FileTreeFileIcon.test.tsx
+++ b/src/shared/components/FileTreeFileIcon.test.tsx
@@ -22,6 +22,9 @@ describe("fileTreeFileIcon", () => {
 		expect(icon).toHaveAttribute("data-icon-name", "file-tree-icon-file");
 		expect(icon).toHaveAttribute("data-icon-token", "react");
 		expect(icon).toHaveAttribute("viewBox", "0 0 16 16");
+		expect(icon.getAttribute("style")).toContain(
+			"color: var(--trees-file-icon-color-react, var(--trees-file-icon-color, currentColor));",
+		);
 		expect(icon.querySelector("path")).not.toBeNull();
 	});
 

--- a/src/shared/components/FileTreeFileIcon.tsx
+++ b/src/shared/components/FileTreeFileIcon.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable react/dom-no-dangerously-set-innerhtml -- Renders static SVG symbol markup from @pierre/trees. */
-import { getBuiltInFileIconColor } from "@pierre/trees";
 import type { CSSProperties, SVGProps } from "react";
 import { memo } from "react";
 import {
@@ -26,7 +25,7 @@ const FileTreeFileIcon = memo(({
 	const symbol = getFileTreeIconSymbol(icon.name);
 	const color = icon.token == null
 		? undefined
-		: getBuiltInFileIconColor(icon.token);
+		: `var(--trees-file-icon-color-${icon.token}, var(--trees-file-icon-color, currentColor))`;
 	const iconStyle = {
 		color,
 		display: "block",


### PR DESCRIPTION
# Plan 007: Gate hidden file-tree work for inactive profiles

> **Executor instructions**: Run every verification command. Update `plans/README.md` when done.
>
> **Drift check (run first)**: `git diff --stat 3ee5b79..HEAD -- src/features/terminal/TerminalLayer.tsx src/features/projects/ProfileLayout.tsx src/features/projects/FileTreePanel.tsx src/features/projects/hooks.ts src/features/terminal/store.ts`

## Status

- **Priority**: P2
- **Effort**: M
- **Risk**: MED
- **Depends on**: `plans/004-watch-worktrees-and-file-cache-invalidation.md`
- **Category**: perf
- **Planned at**: commit `3ee5b79`, 2026-06-13

## Why this matters

Terminal panes stay mounted to preserve xterm state. That is correct, but each hidden profile layout can also keep file-tree queries and Git status polling alive. On projects with several profiles, idle hidden profiles can continue doing filesystem and Git work every refresh interval.

## Current state

Relevant files:
- `src/features/terminal/TerminalLayer.tsx` — renders profile layouts for multiple terminal tabs and hides inactive ones.
- `src/features/projects/ProfileLayout.tsx` — mounts project/file tree/profile UI.
- `src/features/projects/FileTreePanel.tsx` and `src/features/projects/hooks.ts` — file tree queries.
- `src/shared/lib/queryRefresh.ts` — refresh intervals used by Git/status hooks.

Current excerpts:
- `TerminalLayer.tsx` keeps terminals mounted using CSS visibility/display patterns; do not unmount terminals.
- `ProfileLayout.tsx` passes enough context to know whether a profile is active/visible.
- File tree hooks use TanStack Query and can accept `enabled` options.

## Commands you will need

| Purpose | Command | Expected on success |
|---|---|---|
| Focused frontend tests | `bun run test -- TerminalLayer FileTreePanel` | exit 0 |
| Typecheck | `./node_modules/.bin/tsc --noEmit` | exit 0 |
| Full frontend | `bun run test` | exit 0 |
| Lint | `bun run lint:check` | exit 0 |

## Scope

**In scope**:
- Add visibility/active flags to profile/file tree hooks.
- Disable background file-tree queries and polling for hidden profile layouts.
- Preserve mounted terminal instances.

**Out of scope**:
- Unmounting terminals or changing terminal persistence.
- Eliminating all Git polling; plan 008 handles polling strategy.

## Git workflow

Branch `advisor/007-gate-hidden-file-tree-work`; commit `perf(profiles): pause hidden file tree queries`.

## Steps

### Step 1: Thread active/visible state into profile layouts

In `TerminalLayer`, compute whether each rendered profile layout corresponds to the active tab/profile. Pass `isActive` or `isVisible` to `ProfileLayout` and then to file tree/viewer components as needed.

**Verify**: `./node_modules/.bin/tsc --noEmit` → compile errors only until Step 2 if prop plumbing incomplete.

### Step 2: Gate file tree and expensive hooks

Update project hooks to accept `enabled?: boolean` and pass it to TanStack Query. For hidden profiles, disable:
- file-tree child loading;
- file preview/content queries for inactive panels if mounted only for background profiles;
- Git/status polling triggered by that hidden layout unless terminal output itself needs it.

Do not disable state needed to preserve terminal sessions.

**Verify**: `bun run test -- FileTreePanel` → pass after updating tests/mocks.

### Step 3: Add regression tests

Add/adjust tests so rendering multiple profile layouts results in only the active profile's file-tree query being enabled. Mock generated IPC calls and assert hidden profile calls are not made on mount.

**Verify**: `bun run test -- TerminalLayer FileTreePanel` → pass.

### Step 4: Full validation

Run frontend test, typecheck, lint.

**Verify**: all commands exit 0.

## Test plan

- Active profile still loads file tree.
- Hidden profile does not call file-tree IPC on mount.
- Switching active profile enables the newly active profile.

## Done criteria

- [x] Hidden profiles do not keep file-tree queries/polling active.
- [x] Terminals remain mounted and preserve state.
- [x] Frontend tests/typecheck/lint pass.

## STOP conditions

- The active profile cannot be determined without redesigning terminal store identity.
- Disabling a hidden query breaks terminal restoration or tab switching.

## Maintenance notes

Reviewers should use React Profiler/network logs to confirm hidden work drops without introducing remount flicker.