### PR TITLE
fix(settings): retry cached ipc after failure

### DIFF
--- a/src/shared/lib/cachedPromise.test.ts
+++ b/src/shared/lib/cachedPromise.test.ts
@@ -23,13 +23,21 @@ describe("createCachedPromise", () => {
 		await expect(getter()).resolves.toBe(42);
 	});
 
-	it("caches a rejected promise (does not retry)", async () => {
-		const error = new Error("fail");
-		const getter = createCachedPromise(() => Promise.reject(error));
+	it("shares pending failures but retries after rejection", async () => {
+		const factory = vi.fn()
+			.mockRejectedValueOnce(new Error("fail"))
+			.mockResolvedValueOnce("recovered");
+		const getter = createCachedPromise(factory);
+
 		const p1 = getter();
 		const p2 = getter();
+
 		expect(p1).toBe(p2);
 		await expect(p1).rejects.toThrow("fail");
+		expect(factory).toHaveBeenCalledTimes(1);
+
+		await expect(getter()).resolves.toBe("recovered");
+		expect(factory).toHaveBeenCalledTimes(2);
 	});
 
 	it("works with async factory functions", async () => {

--- a/src/shared/lib/cachedPromise.ts
+++ b/src/shared/lib/cachedPromise.ts
@@ -1,7 +1,13 @@
 export function createCachedPromise<T>(fn: () => Promise<T>) {
 	let promise: Promise<T> | null = null;
 	return () => {
-		if (!promise) promise = fn();
+		if (!promise) {
+			const nextPromise = fn().catch((error) => {
+				if (promise === nextPromise) promise = null;
+				throw error;
+			});
+			promise = nextPromise;
+		}
 		return promise;
 	};
 }


### PR DESCRIPTION
# Plan 009: Make cached settings IPC retryable

> **Executor instructions**: Run every verification command. Update `plans/README.md` when done.
>
> **Drift check (run first)**: `git diff --stat 3ee5b79..HEAD -- src/shared/lib/cachedPromise.ts src/features/settings src/features/terminal src/shared/lib/*.test.ts`

## Status

- **Priority**: P2
- **Effort**: S
- **Risk**: LOW
- **Depends on**: none
- **Category**: bug
- **Planned at**: commit `3ee5b79`, 2026-06-13

## Why this matters

Some settings providers cache IPC promises at module scope. If the first call fails due to transient Tauri startup timing or OS failure, the rejected promise can be reused forever until app restart. Cache successes, not permanent transient failures.

## Current state

Relevant files:
- `src/shared/lib/cachedPromise.ts` — generic cache helper.
- `src/features/settings/ShellPicker.tsx` and nearby settings components — use cached IPC helpers for shell/font/sound-like data.

Current excerpt:
- `cachedPromise.ts` memoizes a promise and does not clear it on rejection.

## Commands you will need

| Purpose | Command | Expected on success |
|---|---|---|
| Focused test | `bun run test -- cachedPromise` | exit 0 |
| Full frontend | `bun run test && ./node_modules/.bin/tsc --noEmit && bun run lint:check` | exit 0 |

## Scope

**In scope**:
- `cachedPromise` behavior and tests.
- Call sites only if typings change.

**Out of scope**:
- Adding retry UI/toasts for every settings panel.

## Git workflow

Branch `advisor/009-retryable-cached-settings-ipc`; commit `fix(settings): retry cached ipc after failure`.

## Steps

### Step 1: Add tests for rejection reset

Create/update `src/shared/lib/cachedPromise.test.ts` with cases:
- concurrent callers share one pending promise;
- fulfilled result is cached;
- rejected promise clears cache so next call invokes factory again.

**Verify**: `bun run test -- cachedPromise` → fails before implementation for rejection reset.

### Step 2: Clear cache on rejection

Update `cachedPromise` so rejected promises reset the stored promise/value. Preserve sharing of concurrent pending calls.

**Verify**: focused test passes.

### Step 3: Full frontend validation

Run full frontend checks.

**Verify**: all commands exit 0.

## Done criteria

- [x] Rejected cached calls are retryable.
- [x] Concurrent dedupe and success caching remain.
- [x] Full frontend checks pass.

## STOP conditions

- A caller relies on permanent rejection caching for control flow; report the caller and rationale.

## Maintenance notes

Reviewers should ensure errors still surface to users; this only changes retry behavior.