### PR TITLE
fix(notes): serialize profile autosaves

### DIFF
--- a/src/features/profiles/ProfileNotesEditor.test.tsx
+++ b/src/features/profiles/ProfileNotesEditor.test.tsx
@@ -1,0 +1,179 @@
+import {
+	QueryClient,
+	QueryClientProvider,
+} from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Profile, ProjectWithProfiles } from "@/generated";
+import { queryKeys } from "@/shared/lib/queryKeys";
+import ProfileNotesEditor from "./ProfileNotesEditor";
+
+const {
+	toasterCreateMock,
+	updateProfileNotesMock,
+} = vi.hoisted(() => ({
+	toasterCreateMock: vi.fn(),
+	updateProfileNotesMock: vi.fn(),
+}));
+
+vi.mock("@/features/markdown/MarkdownEditor", () => ({
+	default: ({
+		initialMarkdown,
+		onMarkdownChange,
+		saveStatus,
+	}: {
+		initialMarkdown: string;
+		onMarkdownChange: (markdown: string) => void;
+		saveStatus: string;
+	}) => (
+		<div>
+			<div data-testid="initial-markdown">{initialMarkdown}</div>
+			<div data-testid="save-status">{saveStatus}</div>
+			<button type="button" onClick={() => onMarkdownChange("A")}>
+				Save A
+			</button>
+			<button type="button" onClick={() => onMarkdownChange("B")}>
+				Save B
+			</button>
+		</div>
+	),
+}));
+
+vi.mock("@/generated", async () => {
+	const actual = await vi.importActual<typeof import("@/generated")>(
+		"@/generated",
+	);
+	return {
+		...actual,
+		updateProfileNotes: updateProfileNotesMock,
+	};
+});
+
+vi.mock("@/shared/providers/appToaster", () => ({
+	toaster: {
+		create: toasterCreateMock,
+	},
+}));
+
+function createDeferred<T>() {
+	let resolve!: (value: T) => void;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res;
+		reject = rej;
+	});
+	return { promise, reject, resolve };
+}
+
+function createProfile(notes: string): Profile {
+	return {
+		id: "profile-1",
+		project_id: "project-1",
+		branch_name: "main",
+		worktree_path: "/repo",
+		created_at: "2026-01-01 00:00:00",
+		is_default: true,
+		notes,
+	};
+}
+
+function createProject(profile: Profile): ProjectWithProfiles {
+	return {
+		id: "project-1",
+		name: "Project",
+		folder: "/repo",
+		created_at: "2026-01-01 00:00:00",
+		group_id: null,
+		sort_order: 0,
+		pinned_at: null,
+		pinned_order: null,
+		profiles: [profile],
+	};
+}
+
+function createWrapper(queryClient: QueryClient) {
+	return ({ children }: { children: ReactNode }) => (
+		<QueryClientProvider client={queryClient}>
+			{children}
+		</QueryClientProvider>
+	);
+}
+
+describe("profileNotesEditor", () => {
+	beforeEach(() => {
+		toasterCreateMock.mockReset();
+		updateProfileNotesMock.mockReset();
+	});
+
+	it("ignores stale autosave successes that resolve after newer saves", async () => {
+		const initialProfile = createProfile("");
+		const queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false } },
+		});
+		queryClient.setQueryData(queryKeys.projects.all, [
+			createProject(initialProfile),
+		]);
+		const firstSave = createDeferred<Profile>();
+		const secondSave = createDeferred<Profile>();
+		updateProfileNotesMock
+			.mockReturnValueOnce(firstSave.promise)
+			.mockReturnValueOnce(secondSave.promise);
+
+		render(<ProfileNotesEditor profile={initialProfile} />, {
+			wrapper: createWrapper(queryClient),
+		});
+
+		fireEvent.click(screen.getByRole("button", { name: "Save A" }));
+		fireEvent.click(screen.getByRole("button", { name: "Save B" }));
+
+		secondSave.resolve(createProfile("B"));
+		await waitFor(() => {
+			expect(screen.getByTestId("save-status")).toHaveTextContent("saved");
+		});
+		firstSave.resolve(createProfile("A"));
+
+		await waitFor(() => {
+			expect(
+				queryClient.getQueryData<ProjectWithProfiles[]>(queryKeys.projects.all)?.[0]
+					?.profiles[0]?.notes,
+			).toBe("B");
+		});
+
+		fireEvent.click(screen.getByRole("button", { name: "Save B" }));
+		expect(updateProfileNotesMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("ignores stale autosave errors after a newer save succeeds", async () => {
+		const initialProfile = createProfile("");
+		const queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false } },
+		});
+		queryClient.setQueryData(queryKeys.projects.all, [
+			createProject(initialProfile),
+		]);
+		const firstSave = createDeferred<Profile>();
+		const secondSave = createDeferred<Profile>();
+		updateProfileNotesMock
+			.mockReturnValueOnce(firstSave.promise)
+			.mockReturnValueOnce(secondSave.promise);
+
+		render(<ProfileNotesEditor profile={initialProfile} />, {
+			wrapper: createWrapper(queryClient),
+		});
+
+		fireEvent.click(screen.getByRole("button", { name: "Save A" }));
+		fireEvent.click(screen.getByRole("button", { name: "Save B" }));
+
+		secondSave.resolve(createProfile("B"));
+		await waitFor(() => {
+			expect(screen.getByTestId("save-status")).toHaveTextContent("saved");
+		});
+		firstSave.reject(new Error("stale failure"));
+
+		await waitFor(() => {
+			expect(toasterCreateMock).not.toHaveBeenCalled();
+		});
+		expect(screen.getByTestId("save-status")).toHaveTextContent("saved");
+	});
+});

--- a/src/features/profiles/ProfileNotesEditor.tsx
+++ b/src/features/profiles/ProfileNotesEditor.tsx
@@ -19,6 +19,7 @@ export default function ProfileNotesEditor({
 	const updateNotesRef = useRef(updateNotes);
 	const profileIdRef = useRef(profile.id);
 	const lastSavedMarkdownRef = useRef(profile.notes);
+	const latestSaveRevisionRef = useRef(0);
 	const saveStatusRef = useRef<MarkdownEditorSaveStatus>("idle");
 	const saveStatusTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -36,6 +37,7 @@ export default function ProfileNotesEditor({
 		if (profileIdRef.current === profile.id) return;
 		profileIdRef.current = profile.id;
 		lastSavedMarkdownRef.current = profile.notes;
+		latestSaveRevisionRef.current = 0;
 		saveStatusRef.current = "idle";
 		if (saveStatusTimerRef.current) {
 			clearTimeout(saveStatusTimerRef.current);
@@ -53,11 +55,14 @@ export default function ProfileNotesEditor({
 		(markdown: string) => {
 			if (markdown === lastSavedMarkdownRef.current) return;
 
+			const saveRevision = latestSaveRevisionRef.current + 1;
+			latestSaveRevisionRef.current = saveRevision;
 			setSaveStatusIfChanged("saving");
 			updateNotesRef.current.mutate(
 				{ id: profileIdRef.current, notes: markdown },
 				{
 					onSuccess: (updatedProfile) => {
+						if (saveRevision !== latestSaveRevisionRef.current) return;
 						lastSavedMarkdownRef.current = updatedProfile.notes;
 						setSaveStatusIfChanged("saved");
 						if (saveStatusTimerRef.current) {
@@ -69,6 +74,7 @@ export default function ProfileNotesEditor({
 						}, 1600);
 					},
 					onError: () => {
+						if (saveRevision !== latestSaveRevisionRef.current) return;
 						setSaveStatusIfChanged("failed");
 						toaster.create({
 							title: m.notesSaveFailedTitle(),

--- a/src/features/profiles/hooks.ts
+++ b/src/features/profiles/hooks.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useRef } from "react";
 import { useTerminalStore } from "@/features/terminal/store";
 import {
 	createProfile,
@@ -110,10 +111,22 @@ export function useProfileDeleteCheck(profileId: string, enabled: boolean) {
 
 export function useUpdateProfileNotes() {
 	const queryClient = useQueryClient();
+	const latestRevisionByProfileIdRef = useRef(new Map<string, number>());
 	return useMutation({
 		mutationFn: ({ id, notes }: { id: string; notes: string }) =>
 			updateProfileNotes({ id, notes }),
-		onSuccess: (profile) => {
+		onMutate: ({ id }) => {
+			const revision = (latestRevisionByProfileIdRef.current.get(id) ?? 0) + 1;
+			latestRevisionByProfileIdRef.current.set(id, revision);
+			return { revision };
+		},
+		onSuccess: (profile, { id }, context) => {
+			if (
+				!context ||
+				latestRevisionByProfileIdRef.current.get(id) !== context.revision
+			) {
+				return;
+			}
 			queryClient.setQueryData<ProjectWithProfiles[]>(
 				queryKeys.projects.all,
 				(projects) =>


### PR DESCRIPTION
# Plan 010: Serialize profile-note autosaves

> **Executor instructions**: Follow steps. Update `plans/README.md` when done.
>
> **Drift check (run first)**: `git diff --stat 3ee5b79..HEAD -- src/features/markdown/MarkdownEditor.tsx src/features/profiles/ProfileNotesEditor.tsx src/features/profiles/hooks.ts src/features/profiles/*.test.tsx`

## Status

- **Priority**: P2
- **Effort**: M
- **Risk**: MED
- **Depends on**: none
- **Category**: bug
- **Planned at**: commit `3ee5b79`, 2026-06-13

## Why this matters

Profile notes autosave can issue overlapping mutations. If an older slower response resolves after a newer faster response, it can overwrite cache/UI state with stale text while showing a saved status. Notes should save in order or ignore stale completions.

## Current state

Relevant files:
- `src/features/markdown/MarkdownEditor.tsx` — autosave debounce/status behavior.
- `src/features/profiles/ProfileNotesEditor.tsx` — wires editor to `useUpdateProfileNotes`.
- `src/features/profiles/hooks.ts` — mutation updates project/profile cache on success.

Current excerpts:
- `ProfileNotesEditor.tsx` calls mutate/save from `MarkdownEditor` autosave.
- `hooks.ts` `onSuccess` unconditionally writes returned profile into cached project list.

## Commands you will need

| Purpose | Command | Expected on success |
|---|---|---|
| Focused tests | `bun run test -- ProfileNotesEditor MarkdownEditor` | exit 0 |
| Full frontend | `bun run test && ./node_modules/.bin/tsc --noEmit && bun run lint:check` | exit 0 |

## Scope

**In scope**:
- Profile notes autosave ordering/stale response handling.
- Tests for out-of-order save completion.

**Out of scope**:
- Full collaborative editing or merge conflict UI.
- Notes backend schema changes.

## Git workflow

Branch `advisor/010-serialize-profile-note-autosaves`; commit `fix(notes): serialize profile autosaves`.

## Steps

### Step 1: Add a failing out-of-order test

Test that two saves `A` then `B` resolving in reverse order leave the cache/editor showing `B`. Mock `updateProfileNotes` so promises resolve manually.

**Verify**: focused test fails on current code because stale success can win.

### Step 2: Implement ordered saves or stale-response guard

Choose one simple strategy:
- serialize saves through a queue so save N+1 starts after N finishes; or
- assign monotonically increasing client revision numbers and ignore `onSuccess` for responses older than the latest submitted revision.

Prefer queueing if it preserves backend order without extra API changes. Keep visible saving/saved/error status accurate.

**Verify**: focused tests pass.

### Step 3: Full frontend validation

Run full frontend suite/typecheck/lint.

**Verify**: all commands exit 0.

## Test plan

- Out-of-order resolution does not stale-write cache.
- Failed save still reports error and later retry works.
- Existing MarkdownEditor autosave tests pass.

## Done criteria

- [x] Latest note text wins regardless of network/IPC response order.
- [x] Autosave status remains accurate.
- [x] Full frontend checks pass.

## STOP conditions

- Fix requires changing generated IPC/backend response shape.
- Existing editor abstraction cannot expose enough state without broad refactor.

## Maintenance notes

Reviewers should manually type quickly into notes and verify no saved indicator appears for stale content.