### PR TITLE
perf(db): index profile and pty lookup columns

### DIFF
--- a/src-tauri/migrations/2026-06-13-124905-0000_add_profile_session_indexes/down.sql
+++ b/src-tauri/migrations/2026-06-13-124905-0000_add_profile_session_indexes/down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_pty_sessions_profile_id;
+DROP INDEX IF EXISTS idx_profiles_project_id;

--- a/src-tauri/migrations/2026-06-13-124905-0000_add_profile_session_indexes/up.sql
+++ b/src-tauri/migrations/2026-06-13-124905-0000_add_profile_session_indexes/up.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS idx_profiles_project_id ON profiles (project_id);
+CREATE INDEX IF NOT EXISTS idx_pty_sessions_profile_id ON pty_sessions (profile_id);

--- a/src-tauri/tests/integration_migrations.rs
+++ b/src-tauri/tests/integration_migrations.rs
@@ -1,0 +1,145 @@
+use diesel::connection::SimpleConnection;
+use diesel::prelude::*;
+use diesel::sql_types::{Binary, Text};
+use diesel_migrations::MigrationHarness;
+use infra::db::MIGRATIONS;
+
+#[derive(QueryableByName)]
+struct OutputRow {
+	#[diesel(sql_type = Text)]
+	session_id: String,
+	#[diesel(sql_type = Binary)]
+	data: Vec<u8>,
+}
+
+#[derive(QueryableByName)]
+struct IndexRow {
+	#[diesel(sql_type = Text)]
+	name: String,
+}
+
+fn setup_pre_single_blob_migration_db() -> SqliteConnection {
+	let mut conn =
+		SqliteConnection::establish(":memory:").expect("in-memory db");
+	conn.batch_execute(
+		r#"
+		PRAGMA foreign_keys=ON;
+
+		CREATE TABLE projects (
+			id TEXT PRIMARY KEY NOT NULL,
+			name TEXT NOT NULL,
+			folder TEXT NOT NULL,
+			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+		);
+
+		CREATE TABLE profiles (
+			id TEXT PRIMARY KEY NOT NULL,
+			project_id TEXT NOT NULL REFERENCES projects (id) ON DELETE CASCADE,
+			branch_name TEXT NOT NULL,
+			worktree_path TEXT NOT NULL,
+			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+		);
+
+		CREATE TABLE pty_sessions (
+			id TEXT PRIMARY KEY NOT NULL,
+			project_id TEXT NOT NULL REFERENCES projects (id) ON DELETE CASCADE,
+			title TEXT NOT NULL DEFAULT '',
+			shell TEXT NOT NULL,
+			cwd TEXT NOT NULL,
+			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			closed_at TIMESTAMP
+		);
+
+		CREATE TABLE pty_output_chunks (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			session_id TEXT NOT NULL REFERENCES pty_sessions (id) ON DELETE CASCADE,
+			data BLOB NOT NULL
+		);
+		CREATE INDEX idx_pty_output_session ON pty_output_chunks (session_id);
+
+		INSERT INTO projects (id, name, folder)
+		VALUES ('project-1', 'Project 1', '/repo');
+
+		INSERT INTO pty_sessions (id, project_id, title, shell, cwd)
+		VALUES
+			('session-with-output', 'project-1', 'with output', '/bin/sh', '/repo'),
+			('session-empty', 'project-1', 'empty', '/bin/sh', '/repo');
+
+		INSERT INTO pty_output_chunks (session_id, data)
+		VALUES
+			('session-with-output', X'68656C6C6F'),
+			('session-with-output', X'20'),
+			('session-with-output', X'776F726C6400FF');
+		"#,
+	)
+	.expect("create old schema fixture");
+	conn
+}
+
+fn setup_db_with_migrations() -> SqliteConnection {
+	let mut conn =
+		SqliteConnection::establish(":memory:").expect("in-memory db");
+	diesel::sql_query("PRAGMA foreign_keys=ON;")
+		.execute(&mut conn)
+		.ok();
+	conn.run_pending_migrations(MIGRATIONS)
+		.expect("run migrations");
+	conn
+}
+
+fn run_pty_output_migration_sequence(conn: &mut SqliteConnection) {
+	conn.batch_execute(include_str!(
+		"../migrations/2026-02-13-000000_profile_first_refactor/up.sql"
+	))
+	.expect("run profile-first migration");
+	conn.batch_execute(include_str!(
+		"../migrations/2026-02-13-100000_add_pty_dimensions/up.sql"
+	))
+	.expect("run dimensions migration");
+	conn.batch_execute(include_str!(
+		"../migrations/2026-02-14-000000_single_blob_output/up.sql"
+	))
+	.expect("run single-blob migration");
+}
+
+#[test]
+fn migration_preserves_pty_output_chunks() {
+	let mut conn = setup_pre_single_blob_migration_db();
+
+	run_pty_output_migration_sequence(&mut conn);
+
+	let rows: Vec<OutputRow> = diesel::sql_query(
+		"SELECT session_id, data FROM pty_session_output ORDER BY session_id",
+	)
+	.load(&mut conn)
+	.expect("load migrated output rows");
+
+	assert_eq!(rows.len(), 2);
+	assert_eq!(rows[0].session_id, "session-empty");
+	assert_eq!(rows[0].data, Vec::<u8>::new());
+	assert_eq!(rows[1].session_id, "session-with-output");
+	assert_eq!(rows[1].data, b"hello world\0\xff".to_vec());
+}
+
+#[test]
+fn migrations_create_profile_and_session_lookup_indexes() {
+	let mut conn = setup_db_with_migrations();
+
+	let rows: Vec<IndexRow> = diesel::sql_query(
+		"SELECT name FROM sqlite_master \
+		 WHERE type = 'index' \
+		 AND name IN ('idx_profiles_project_id', 'idx_pty_sessions_profile_id') \
+		 ORDER BY name",
+	)
+	.load(&mut conn)
+	.expect("load index names");
+	let names: Vec<String> = rows.into_iter().map(|row| row.name).collect();
+
+	assert_eq!(
+		names,
+		vec![
+			"idx_profiles_project_id".to_string(),
+			"idx_pty_sessions_profile_id".to_string(),
+		],
+	);
+}


### PR DESCRIPTION
# Plan 011: Add DB indexes for profile/session lookup paths

> **Executor instructions**: Follow steps. Update `plans/README.md` when done.
>
> **Drift check (run first)**: `git diff --stat 3ee5b79..HEAD -- src-tauri/migrations src-tauri/crates/repo/src/profile.rs src-tauri/crates/repo/src/pty.rs src-tauri/src/schema.rs`

## Status

- **Priority**: P2
- **Effort**: S
- **Risk**: LOW
- **Depends on**: none
- **Category**: perf
- **Planned at**: commit `3ee5b79`, 2026-06-13

## Why this matters

Profile and PTY session tables are queried by foreign keys during startup restoration and project/profile loading. SQLite does not automatically index foreign-key columns. Adding indexes prevents scans as users accumulate profiles and terminal sessions.

## Current state

Relevant files:
- `src-tauri/migrations/` — Diesel migrations.
- `src-tauri/crates/repo/src/profile.rs` — queries profiles by `project_id`.
- `src-tauri/crates/repo/src/pty.rs` — queries sessions by profile/project context.
- `src-tauri/src/schema.rs` — Diesel generated; do not hand-edit.

Current facts:
- Migrations create `profiles.project_id` and `pty_sessions.profile_id` foreign-key-like lookup columns.
- No obvious indexes exist for those lookup columns.

## Commands you will need

| Purpose | Command | Expected on success |
|---|---|---|
| Create migration | `cd src-tauri && diesel migration generate add_profile_session_indexes` | exit 0; creates migration dir |
| Run tests | `cargo test --manifest-path src-tauri/Cargo.toml` | exit 0 |
| Regenerate schema if needed | `cd src-tauri && diesel migration run` or project-standard schema generation | exit 0 |

## Scope

**In scope**:
- New migration adding indexes with `IF NOT EXISTS`.
- Optional migration test/query plan assertion if project already has such tests.

**Out of scope**:
- Rewriting query shapes.
- Hand-editing `src-tauri/src/schema.rs` except via Diesel tooling if schema changes require it.

## Git workflow

Branch `advisor/011-db-indexes-profile-session-lookups`; commit `perf(db): index profile and pty lookup columns`.

## Steps

### Step 1: Add migration

Create a Diesel migration that adds:
- index on `profiles(project_id)`;
- index on `pty_sessions(profile_id)`;
- any existing frequent lookup column discovered in repo queries, but keep scope narrow.

Use stable names like `idx_profiles_project_id` and `idx_pty_sessions_profile_id`.

**Verify**: migration applies locally or tests run pending migrations successfully.

### Step 2: Validate tests and schema

Run full Rust tests. If schema generation changes `src-tauri/src/schema.rs`, regenerate via Diesel, do not edit manually.

**Verify**: `cargo test --manifest-path src-tauri/Cargo.toml` → pass.

## Test plan

- Existing DB setup tests that run all migrations must pass.
- If easy, add an assertion querying `sqlite_master` for index existence.

## Done criteria

- [x] Migration adds indexes for profile/session lookup columns.
- [x] Migrations are idempotent enough for normal Diesel usage.
- [x] Full Rust tests pass.

## STOP conditions

- Diesel CLI is unavailable and project has no documented migration creation alternative; create files manually only if existing migration naming conventions are clear.

## Maintenance notes

Future migrations adding foreign-key lookup columns should add indexes at the same time.