### PR TITLE
ci: check website and node tooling

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -27,8 +27,34 @@ jobs:
       - name: Run ESLint
         run: bun run lint:check
 
+      - name: Run node tooling typecheck
+        run: ./node_modules/.bin/tsc -p tsconfig.node.json --noEmit
+
       - name: Run Vitest
         run: bun run test
+
+  website:
+    name: Website
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install website dependencies
+        working-directory: website
+        run: bun install --frozen-lockfile
+
+      - name: Run website ESLint
+        working-directory: website
+        run: bun run lint
+
+      - name: Build website
+        working-directory: website
+        run: bun run build
 
   rust:
     name: Rust (${{ matrix.os }})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,8 @@
 import path from "node:path";
 import process from "node:process";
 import { paraglideVitePlugin } from "@inlang/paraglide-js";
-import react from "@vitejs/plugin-react";
+import babel from "@rolldown/plugin-babel";
+import react, { reactCompilerPreset } from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import { localFileIconsPlugin } from "./scripts/vite-plugin-local-file-icons";
 
@@ -11,10 +12,9 @@ const host = process.env.TAURI_DEV_HOST;
 export default defineConfig(async () => ({
   plugins: [
     localFileIconsPlugin(),
-    react({
-      babel: {
-        plugins: ["babel-plugin-react-compiler"],
-      },
+    react(),
+    babel({
+      presets: [reactCompilerPreset()],
     }),
     paraglideVitePlugin({
       project: "./project.inlang",

--- a/website/next.config.mjs
+++ b/website/next.config.mjs
@@ -1,6 +1,14 @@
+import { dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const websiteRoot = dirname(fileURLToPath(import.meta.url))
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'export',
+  turbopack: {
+    root: websiteRoot,
+  },
 }
 
 export default nextConfig


### PR DESCRIPTION
# Plan 013: Put website and node-tooling checks under CI

> **Executor instructions**: Follow steps. Update `plans/README.md` when done.
>
> **Drift check (run first)**: `git diff --stat 3ee5b79..HEAD -- .github/workflows/unit-tests.yml .github/workflows/tauri-smoke.yml .github/workflows/release.yml tsconfig.node.json vite.config.ts website/package.json website/next.config.mjs`

## Status

- **Priority**: P2
- **Effort**: S
- **Risk**: LOW
- **Depends on**: `plans/012-triage-high-dependency-advisories.md`
- **Category**: dx
- **Planned at**: commit `3ee5b79`, 2026-06-13

## Why this matters

The website builds locally but is not clearly covered by main CI. Node tooling typecheck also currently fails (`vite.config.ts` has a typed `babel` option mismatch under `tsconfig.node.json`) while normal app TS checks pass. CI should catch breakage in all shipped/supporting packages.

## Current state

Resolved in this checkout:
- `vite.config.ts` now uses the `@vitejs/plugin-react` v6 React Compiler preset via `@rolldown/plugin-babel`, so node tooling typecheck exits 0 while preserving React Compiler behavior.
- `.github/workflows/unit-tests.yml` runs node tooling typecheck in the frontend job and adds a dedicated website lint/build job.
- `website/next.config.mjs` pins `turbopack.root` to the website directory, so the multiple-lockfile root warning is gone.

Relevant files:
- `.github/workflows/unit-tests.yml` — main unit workflow.
- `tsconfig.node.json` — includes `vite.config.ts` and scripts.
- `vite.config.ts` — current node typecheck failure at `babel` option.
- `website/` — Next.js static export app.

Known command results at planning time:
- `cd website && bun run lint && bun run build` passes, with Next warning about multiple lockfiles/inferred root.
- `./node_modules/.bin/tsc -p tsconfig.node.json --noEmit` fails: `vite.config.ts(15,7): 'babel' does not exist in type 'Options'`.

## Commands you will need

| Purpose | Command | Expected on success |
|---|---|---|
| Node tooling typecheck | `./node_modules/.bin/tsc -p tsconfig.node.json --noEmit` | exit 0 |
| Website checks | `cd website && bun run lint && bun run build` | exit 0 |
| Full app checks | `bun run lint:check && ./node_modules/.bin/tsc --noEmit && bun run test` | exit 0 |

## Scope

**In scope**:
- Fix node tooling typecheck.
- Add website lint/build and node tooling typecheck to CI.
- Optionally fix Next root warning if low-risk.

**Out of scope**:
- Redesigning website deployment.
- Adding heavy Tauri package builds to unit workflow.

## Git workflow

Branch `advisor/013-ci-website-node-checks`; commit `ci: check website and node tooling`.

## Steps

### Step 1: Fix node tooling typecheck

Update `vite.config.ts` typing or plugin configuration so `tsc -p tsconfig.node.json --noEmit` exits 0. Preserve runtime behavior.

**Verify**: node tooling typecheck exits 0.

### Step 2: Add CI jobs/steps

In the appropriate workflow, add:
- root install/check step for node tooling typecheck;
- website install/lint/build step, using `working-directory: website`.

Keep job names explicit so failures are easy to read.

**Verify**: run equivalent local commands from the table.

### Step 3: Optional Next root warning cleanup

If the warning is due to multiple lockfiles and can be fixed with `outputFileTracingRoot` or package root config without behavior changes, apply it. Otherwise leave a comment in PR, not code.

**Verify**: website build still exits 0.

## Done criteria

- [x] Node tooling typecheck passes locally and is in CI.
- [x] Website lint/build passes locally and is in CI.
- [x] App checks still pass.

## STOP conditions

- The `vite.config.ts` typing fix would require downgrading/removing current plugin behavior.
- CI runtime would become too long without caching; report proposed split job.

## Maintenance notes

Reviewers should inspect workflow caching and working directories carefully.