### PR TITLE
test(e2e): cover desktop mutation smoke flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,13 @@ on:
       - "v*"
 
 jobs:
+  smoke:
+    name: Linux Smoke Gate
+    uses: ./.github/workflows/tauri-smoke.yml
+
   publish:
     name: Publish (${{ matrix.name }})
+    needs: smoke
     runs-on: ${{ matrix.platform }}
     permissions:
       contents: write

--- a/.github/workflows/tauri-smoke.yml
+++ b/.github/workflows/tauri-smoke.yml
@@ -1,6 +1,7 @@
 name: Tauri Smoke
 
 on:
+  workflow_call:
   push:
     branches:
       - dev

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -7,12 +7,16 @@ It uses Tauri's WebDriver support via `tauri-driver` plus Selenium to verify tha
 - the desktop shell launches
 - the main layout renders
 - the frontend is not blank
+- a real desktop mutation path works: create a temp git project fixture through Tauri IPC, rename it through the sidebar UI, and verify the persisted project state
+
+The suite runs the app with isolated temporary `HOME`/XDG data directories so smoke data does not touch the user's normal app database.
 
 ## Run
 
 ```bash
 bun --cwd e2e-tests install
-bun run test:tauri-smoke
+cargo install tauri-driver --locked
+xvfb-run -a bun run test:tauri-smoke
 ```
 
 ## CI Notes
@@ -21,3 +25,4 @@ bun run test:tauri-smoke
 - On Linux CI, run the suite under a virtual display such as `xvfb-run`.
 - The suite skips on macOS because Tauri does not provide a desktop WebDriver client there.
 - If your runner needs an explicit native WebDriver binary, set `TAURI_SMOKE_NATIVE_DRIVER=/path/to/driver`.
+- Release publishing is gated by the reusable `.github/workflows/tauri-smoke.yml` workflow.

--- a/e2e-tests/test/smoke.test.mjs
+++ b/e2e-tests/test/smoke.test.mjs
@@ -7,7 +7,7 @@ import { fileURLToPath } from "node:url";
 
 import { expect } from "chai";
 import { after, afterEach, before, describe, it } from "mocha";
-import { Builder, By, Capabilities } from "selenium-webdriver";
+import { Builder, By, Capabilities, Key } from "selenium-webdriver";
 
 const testDir = fileURLToPath(new URL(".", import.meta.url));
 const e2eRoot = path.resolve(testDir, "..");
@@ -31,6 +31,8 @@ const appBinary = path.join(
 let driver;
 let tauriDriver;
 let tauriDriverClosed = false;
+let runtimeRoot;
+let fixtureDir;
 
 describe("tauri smoke", () => {
 	before(async function () {
@@ -45,6 +47,12 @@ describe("tauri smoke", () => {
 		this.timeout(15 * 60 * 1000);
 
 		await fsp.mkdir(artifactsDir, { recursive: true });
+		runtimeRoot = await fsp.mkdtemp(
+			path.join(os.tmpdir(), "2code-smoke-"),
+		);
+		await prepareRuntimeDirs();
+		fixtureDir = await createGitFixture();
+
 		assertExecutableExists(
 			tauriDriverBinary,
 			"Install it first with `cargo install tauri-driver`.",
@@ -68,6 +76,7 @@ describe("tauri smoke", () => {
 			.withCapabilities(capabilities)
 			.build();
 
+		await driver.manage().setTimeouts({ script: 60_000 });
 		await waitForPageReady();
 	});
 
@@ -114,6 +123,47 @@ describe("tauri smoke", () => {
 			/No projects yet|暂无项目|Create your first project|从侧边栏创建|Projects|项目|Settings|设置/,
 		);
 	});
+
+	it("renames a project through the desktop UI and persists the mutation", async function () {
+		this.timeout(90_000);
+
+		const initialName = "Smoke Project Before";
+		const renamedName = "Smoke Project After";
+		const project = await invokeTauri("create_project_from_folder", {
+			name: initialName,
+			folder: fixtureDir,
+		});
+
+		expect(project).to.include({
+			name: initialName,
+			folder: fixtureDir,
+		});
+
+		await reloadApp();
+		const projectItem = await waitForProjectItem(project.id);
+		await waitForBodyText((text) => text.includes(initialName));
+
+		await driver.actions({ async: true }).contextClick(projectItem).perform();
+		const renameItem = await waitForElement(
+			"[data-testid='project-menu-rename']",
+		);
+		await renameItem.click();
+
+		const renameInput = await waitForElement("[data-rename-input]");
+		await renameInput.clear();
+		await renameInput.sendKeys(renamedName, Key.ENTER);
+
+		await waitForBodyText(
+			(text) => text.includes(renamedName) && !text.includes(initialName),
+		);
+
+		const projects = await invokeTauri("list_projects");
+		const persisted = projects.find((item) => item.id === project.id);
+		expect(persisted).to.include({
+			id: project.id,
+			name: renamedName,
+		});
+	});
 });
 
 function buildAppForSmoke() {
@@ -127,6 +177,14 @@ function startTauriDriver() {
 	}
 
 	tauriDriver = spawn(tauriDriverBinary, args, {
+		env: {
+			...process.env,
+			HOME: path.join(runtimeRoot, "home"),
+			XDG_CACHE_HOME: path.join(runtimeRoot, "cache"),
+			XDG_CONFIG_HOME: path.join(runtimeRoot, "config"),
+			XDG_DATA_HOME: path.join(runtimeRoot, "data"),
+			TMPDIR: path.join(runtimeRoot, "tmp"),
+		},
 		stdio: ["ignore", "pipe", "pipe"],
 	});
 
@@ -240,6 +298,53 @@ async function waitForBodyText(predicate, timeoutMs = 60_000) {
 	throw lastError ?? new Error("Timed out waiting for non-empty body text.");
 }
 
+async function reloadApp() {
+	await driver.navigate().refresh();
+	await waitForPageReady();
+}
+
+async function waitForProjectItem(projectId, timeoutMs = 60_000) {
+	return waitForElement(
+		`[data-testid='project-sidebar-item'][data-project-id='${cssString(projectId)}']`,
+		timeoutMs,
+	);
+}
+
+async function invokeTauri(command, args = {}) {
+	const result = await driver.executeAsyncScript(
+		`
+		const command = arguments[0];
+		const args = arguments[1] ?? {};
+		const done = arguments[arguments.length - 1];
+		const invoke =
+			window.__TAURI_INTERNALS__?.invoke
+			?? window.__TAURI__?.core?.invoke;
+
+		if (typeof invoke !== "function") {
+			done({ ok: false, error: "Tauri invoke API not found" });
+			return;
+		}
+
+		Promise.resolve(invoke(command, args))
+			.then((value) => done({ ok: true, value }))
+			.catch((error) => {
+				done({
+					ok: false,
+					error: error?.message ?? String(error),
+				});
+			});
+		`,
+		command,
+		args,
+	);
+
+	if (!result?.ok) {
+		throw new Error(`Tauri command failed: ${command}: ${result?.error}`);
+	}
+
+	return result.value;
+}
+
 function isTransientNavigationError(error) {
 	const name = error?.name ?? "";
 	const message = error?.message ?? "";
@@ -248,14 +353,47 @@ function isTransientNavigationError(error) {
 		|| /unload event|stale element/i.test(message);
 }
 
-function runOrThrow(command, args) {
+async function prepareRuntimeDirs() {
+	await Promise.all(
+		["home", "cache", "config", "data", "tmp"].map((name) =>
+			fsp.mkdir(path.join(runtimeRoot, name), { recursive: true }),
+		),
+	);
+}
+
+async function createGitFixture() {
+	const fixture = path.join(runtimeRoot, "fixture-repo");
+	await fsp.mkdir(fixture, { recursive: true });
+	await fsp.writeFile(
+		path.join(fixture, "README.md"),
+		"# 2code smoke fixture\n",
+		"utf8",
+	);
+
+	runOrThrow("git", ["init", "."], { cwd: fixture });
+	runOrThrow("git", ["config", "user.email", "smoke@example.invalid"], {
+		cwd: fixture,
+	});
+	runOrThrow("git", ["config", "user.name", "2code Smoke"], {
+		cwd: fixture,
+	});
+	runOrThrow("git", ["add", "README.md"], { cwd: fixture });
+	runOrThrow("git", ["commit", "-m", "initial smoke fixture"], {
+		cwd: fixture,
+	});
+
+	return fixture;
+}
+
+function runOrThrow(command, args, options = {}) {
 	const result = spawnSync(command, args, {
-		cwd: repoRoot,
+		cwd: options.cwd ?? repoRoot,
 		stdio: "inherit",
 		shell: process.platform === "win32",
 		env: {
 			...process.env,
 			CI: process.env.CI ?? "1",
+			...options.env,
 		},
 	});
 
@@ -274,6 +412,10 @@ function sanitize(value) {
 	return value.toLowerCase().replace(/[^a-z0-9]+/g, "-");
 }
 
+function cssString(value) {
+	return String(value).replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+}
+
 function sleep(ms) {
 	return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -290,5 +432,10 @@ async function closeResources() {
 		tauriDriverClosed = true;
 		tauriDriver.kill();
 		tauriDriver = undefined;
+	}
+
+	if (runtimeRoot) {
+		await fsp.rm(runtimeRoot, { recursive: true, force: true });
+		runtimeRoot = undefined;
 	}
 }


### PR DESCRIPTION
# Plan 014: Add desktop mutation smoke coverage and release gate

> **Executor instructions**: Follow steps. Update `plans/README.md` when done.
>
> **Drift check (run first)**: `git diff --stat 3ee5b79..HEAD -- e2e-tests .github/workflows/tauri-smoke.yml .github/workflows/release.yml src-tauri/tauri.conf.json package.json`

## Status

- **Priority**: P2
- **Effort**: M
- **Risk**: MED
- **Depends on**: `plans/013-ci-website-node-tooling-checks.md`
- **Category**: tests
- **Planned at**: commit `3ee5b79`, 2026-06-13

## Why this matters

Current desktop smoke coverage mostly verifies that the app window renders. Many highest-risk flows are IPC mutations: create project/profile, interact with terminal/session state, and observe Git/file refresh. Release CI should gate on at least one real Tauri-driver mutation path so generated bindings, backend commands, DB migrations, and UI wiring are tested together.

## Current state

Resolved in this checkout:
- `e2e-tests/test/smoke.test.mjs` now runs the app with isolated temporary HOME/XDG directories, creates a temporary git fixture, creates a project through Tauri IPC, renames it through the sidebar UI, and verifies persisted project state via Tauri IPC.
- The smoke workflow is reusable via `workflow_call`, and `.github/workflows/release.yml` gates publishing on that Linux smoke workflow.
- `e2e-tests/README.md` documents the mutation coverage, isolated runtime data, local Linux command, and release gate.
- Local macOS verification loads the Mocha suite and skips both tests because Tauri desktop WebDriver is unsupported on macOS; Linux execution is enforced by CI/release workflows.

Relevant files:
- `e2e-tests/test/smoke.test.mjs` — Mocha/Selenium/Tauri driver smoke tests.
- `e2e-tests/README.md` — local e2e instructions.
- `.github/workflows/tauri-smoke.yml` — smoke workflow using virtual display/Tauri driver.
- `.github/workflows/release.yml` — release workflow.

Current excerpt:
- `smoke.test.mjs` has basic render assertions around app shell; it does not create/delete project/profile or exercise terminal/Git mutations.

## Commands you will need

| Purpose | Command | Expected on success |
|---|---|---|
| E2E install/check | `cd e2e-tests && bun install --frozen-lockfile && bun test` | exit 0 in supported environment |
| Smoke workflow parity | command documented in `e2e-tests/README.md` | exit 0 |
| App checks | `bun run lint:check && ./node_modules/.bin/tsc --noEmit && cargo test --manifest-path src-tauri/Cargo.toml` | exit 0 |

## Scope

**In scope**:
- One or two reliable Tauri-driver smoke tests for mutation flows.
- CI/release workflow gating on the smoke workflow/job.
- E2E docs update for any required environment variables/temp dirs.

**Out of scope**:
- Full visual regression suite.
- Testing every feature path.

## Git workflow

Branch `advisor/014-desktop-mutation-smoke`; commit `test(e2e): cover desktop mutation smoke flow`.

## Steps

### Step 1: Choose the smallest reliable mutation flow

Prefer this flow:
1. Launch app with isolated temp app data/config if supported.
2. Create or import a temp Git project fixture.
3. Verify the project appears in sidebar/list.
4. Create a profile/worktree or open default profile.
5. Verify terminal/project UI reflects the mutation.
6. Clean up via UI or isolated temp directory teardown.

If profile creation is flaky in CI, use project create/delete plus a simple file-tree operation instead.

**Verify**: local e2e command passes repeatedly twice.

### Step 2: Add selectors/test hooks only where necessary

If UI lacks stable selectors, add minimal `data-testid`/accessible labels in source components. Prefer accessible roles/names over implementation-specific CSS selectors.

**Verify**: app frontend tests/typecheck pass if source changed.

### Step 3: Wire smoke into release gating

Ensure `.github/workflows/release.yml` requires the smoke workflow/job before packaging/publishing, or documents that release is blocked by required GitHub checks. If using `workflow_run`, make the dependency explicit and maintainable.

**Verify**: workflow syntax is valid; local equivalent commands pass.

### Step 4: Update docs

Update `e2e-tests/README.md` with exact local commands and any required system services (`xvfb`, Tauri driver, WebKit driver).

**Verify**: commands in docs match actual package scripts.

## Test plan

- New e2e smoke test covering at least one real mutation through UI + IPC + DB/backend.
- Existing render smoke remains.
- App unit/Rust checks still pass.

## Done criteria

- [x] E2E smoke covers a mutation, not only shell render.
- [x] Release process is gated by smoke or required checks are documented/enforced.
- [x] E2E docs are current.
- [x] App checks pass.

## STOP conditions

- Tauri driver is too flaky to run the mutation flow twice locally.
- The flow requires secrets or user-specific paths.
- CI platform lacks required GUI dependencies and cannot install them in reasonable time.

## Maintenance notes

Keep smoke tests short and deterministic. Add broader exploratory coverage separately; this plan is for release confidence, not exhaustive QA.