### PR TITLE
KIT-203: omit project template ids from config

### DIFF
--- a/src-tauri/crates/infra/src/config.rs
+++ b/src-tauri/crates/infra/src/config.rs
@@ -18,12 +18,17 @@ pub fn load_project_config(
 		}
 		Err(e) => return Err(AppError::IoError(e)),
 	};
-	serde_json::from_str(&content).map_err(|e| {
-		AppError::IoError(std::io::Error::new(
-			std::io::ErrorKind::InvalidData,
-			format!("Failed to parse 2code.json: {e}"),
-		))
-	})
+	let mut config: ProjectConfig =
+		serde_json::from_str(&content).map_err(|e| {
+			AppError::IoError(std::io::Error::new(
+				std::io::ErrorKind::InvalidData,
+				format!("Failed to parse 2code.json: {e}"),
+			))
+		})?;
+	for (index, template) in config.terminal_templates.iter_mut().enumerate() {
+		template.id = format!("project-template-{index}");
+	}
+	Ok(config)
 }
 
 pub fn write_project_config(
@@ -31,7 +36,11 @@ pub fn write_project_config(
 	config: &ProjectConfig,
 ) -> Result<(), AppError> {
 	let config_path = Path::new(project_folder).join("2code.json");
-	let content = serde_json::to_string_pretty(config).map_err(|e| {
+	let mut file_config = config.clone();
+	for template in &mut file_config.terminal_templates {
+		template.id.clear();
+	}
+	let content = serde_json::to_string_pretty(&file_config).map_err(|e| {
 		AppError::IoError(std::io::Error::new(
 			std::io::ErrorKind::InvalidData,
 			format!("Failed to serialize 2code.json: {e}"),
@@ -225,8 +234,16 @@ mod tests {
 
 		write_project_config(dir.path().to_str().unwrap(), &config).unwrap();
 
+		let saved: serde_json::Value = serde_json::from_str(
+			&fs::read_to_string(dir.path().join("2code.json")).unwrap(),
+		)
+		.unwrap();
+		assert!(saved["terminal_templates"][0].get("id").is_none());
+
 		let loaded = load_project_config(dir.path().to_str().unwrap()).unwrap();
-		assert_eq!(loaded, config);
+		let mut expected = config;
+		expected.terminal_templates[0].id = "project-template-0".to_string();
+		assert_eq!(loaded, expected);
 	}
 
 	#[test]

--- a/src-tauri/crates/model/src/project.rs
+++ b/src-tauri/crates/model/src/project.rs
@@ -19,6 +19,7 @@ pub struct ProjectConfig {
 
 #[derive(Debug, Deserialize, Serialize, Default, PartialEq, Clone)]
 pub struct ProjectTerminalTemplate {
+	#[serde(default, skip_serializing_if = "String::is_empty")]
 	pub id: String,
 	pub name: String,
 	pub cwd: String,


### PR DESCRIPTION
## Summary

- omit runtime-only terminal template IDs from saved `2code.json` files
- recreate deterministic in-memory IDs when loading project templates so editing remains stable
- keep existing configs with IDs readable; the redundant field disappears on the next save

## Root cause

The project template model is shared by IPC and file persistence, so its UI-only identifier was serialized into project configuration files.

## Validation

- `cargo test --workspace` (405 passed, 1 ignored)
- `cargo fmt --all -- --check`

Closes KIT-203
