### PR TITLE
fix(markdown): milkdown 文本区使用终端字体

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -179,6 +179,8 @@ a,
 	min-height: 100%;
 	outline: none;
 	padding: 0;
+	/* Follow settings terminal font via --font-mono (synced in terminalSettingsStore). */
+	font-family: var(--font-mono);
 }
 
 .milkdown-wrapper .markdown-editor-placeholder {
@@ -279,7 +281,7 @@ a,
 }
 
 .milkdown-wrapper .ProseMirror code {
-	font-family: monospace;
+	font-family: var(--font-mono);
 	background: var(--muted);
 	padding: 0.1em 0.3em;
 	border-radius: 3px;
@@ -497,7 +499,7 @@ a,
 	overflow-x: auto;
 	background: transparent;
 	color: #abb2bf;
-	font-family: monospace;
+	font-family: var(--font-mono);
 	font-size: 13px;
 	line-height: 1.5;
 	white-space: pre-wrap;
@@ -526,7 +528,7 @@ a,
 
 .milkdown-wrapper .ProseMirror .milkdown-code-block .cm-scroller {
 	max-height: 420px;
-	font-family: monospace;
+	font-family: var(--font-mono);
 	font-size: 13px;
 	line-height: 1.55;
 }


### PR DESCRIPTION
## Summary
- Milkdown / ProseMirror 编辑区 `font-family` 改为 `var(--font-mono)`
- 内联 code、code-block placeholder、CodeMirror scroller 同步使用 `--font-mono`
- `--font-mono` 已由 `terminalSettingsStore` 与设置里的终端字体同步，改字体后编辑器会跟随

## Context
KIT-326：Markdown 编辑器 milkdown 文本区域使用设置中的终端字体。

## Test plan
- [ ] 打开 profile notes 或 markdown 文件编辑器
- [ ] 设置 → 终端字体 切换为非默认等宽字体（如 Fira Code）
- [ ] 确认 milkdown 正文与代码块字体已更新
- [ ] 确认工具栏 UI 字体不受影响