### PR TITLE
chore(website): refresh AI SEO keywords

### DIFF
--- a/website/app/i18n/resources.ts
+++ b/website/app/i18n/resources.ts
@@ -15,7 +15,10 @@ export const resources = {
         keywords: [
           '2code',
           'terminal workstation',
+          'terminal multiplexer',
           'agentic IDE',
+          'harness',
+          'agent',
           'AI coding terminal',
           'vibe coding',
           'git worktree',
@@ -177,7 +180,10 @@ export const resources = {
         keywords: [
           '2code',
           '终端工作站',
+          'terminal multiplexer',
           'Agentic IDE',
+          'harness',
+          'agent',
           'AI 编程终端',
           'vibe coding',
           'git worktree',


### PR DESCRIPTION
## Summary

- add `terminal multiplexer`, `harness`, and `agent` to homepage SEO keywords
- keep the requested trend keywords aligned across English and Chinese metadata

## Verification

- `bun run lint`
- `bun run build`
- verified both generated locale homepages contain `agentic IDE`, `terminal multiplexer`, `harness`, and `agent`

Issue: KIT-466
