### PR TITLE
feat(website): add P1 blog post on why 2code isn't a 100-agent factory

### DIFF
--- a/website/content/blog/en/why-im-not-building-an-agent-factory.md
+++ b/website/content/blog/en/why-im-not-building-an-agent-factory.md
@@ -1,0 +1,123 @@
+---
+title: Why I'm Not Building a 100-Agent Factory First
+description: Orca says Ship 100x. Superset's goal is 100 parallel agents per person by the end of 2026. The direction is right — but even they reliably run 5–7 today. As a solo developer I'd rather make two or three lanes work properly. Here's the tradeoff list.
+date: 2026-08-05
+publishAt: 2026-08-05T09:00:00+08:00
+slug: why-im-not-building-an-agent-factory
+tags:
+  [
+    parallel agents,
+    agent orchestration,
+    indie development,
+    product tradeoffs,
+    Claude Code,
+    terminal workstation,
+  ]
+---
+
+## Everyone is shouting a number right now
+
+Open the homepages of this generation of tools and the headlines all point the same way:
+
+- Orca: **"Ship 100x With The Agent IDE"**, built around "a fleet of agents", with a testimonial on the front page that reads "Orchestrating 600 agents from my phone".
+- Superset: **"Run 10+ parallel coding agents on your machine"**, plus a published roadmap whose goal is **100 parallel agents per person by the end of 2026**.
+
+I read those pages carefully, and I genuinely think the direction is right — the marginal cost of an agent really is falling. That Superset roadmap has a very clear-eyed line in it: *"Agent compute is already cheap enough, you can run hundreds of agents a month all for less than the cost of one engineer."*
+
+So this isn't a takedown. I just want to be precise about why, as a solo developer building a tool, **I'm not building that layer first**.
+
+## Start with one number: even they run 5–7
+
+The most honest part of that same roadmap is its opening:
+
+> *"Right now at Superset, we're able to reliably manage 5-7 coding agents in parallel... Our goal is to be able to manage 100 coding agents in parallel each by the end of 2026."*
+
+> *"What's stopping us is every agent needs a human to review its code, give feedback, and decide what to work on next. Scale the agents all you want - it's the humans that don't scale."*
+
+> *"Right now, most of our agents spend more time waiting for us to review their work than they spend doing it."*
+
+Read that again. A company whose entire product is parallel orchestration reliably runs **5 to 7** today, and most of their agents spend more time waiting on a human than working. 100 is the goal, not the status quo — they say so themselves.
+
+So: what's your number?
+
+Don't guess. Count it. Count the task lanes you actually had running *and followed through on* last week. Not "how many terminal windows did I open" — how many lanes did you actually read the diff for and make a call on.
+
+My own number is single digits: two or three on an ordinary day, a couple more when it's busy. 2code is designed for that number.
+
+Here's the part that's easy to miss: **your parallelism isn't capped by model quality, it's capped by how much review you can digest.** Every lane ends with a human scanning a diff and deciding whether it ships. Spinning up ninety more agents does not make that step faster — which is exactly Superset's own point: "You can't review 100 diffs a day."
+
+The 100-agent factory is a team-scale goal that requires automating review itself. It's worth building. It just isn't the problem in front of me today.
+
+## The four things that actually slow me down
+
+If my real concurrency is two or three lanes, where does my day actually go? I wrote it out once. It's these four:
+
+**1. Recovery.** Quit the app, reboot the machine, come back the next morning — are those three lanes still there? The code is, obviously; it's all in git. What's gone is *which lane was doing what, how far it got, and what comes next*. Every restart means re-excavating. I pay that cost several times a week.
+
+**2. Notification.** The agent finished. Who tells me? Nobody, unless something does — so I become the poller, cycling through windows every couple of minutes to see who's done. Three lanes is already enough polling that I don't dare leave my desk. And "go do something else while the agent works" was supposed to be the entire point of running things in parallel.
+
+**3. The distance to review.** The agent says it's done. How many app switches sit between that sentence and "I've seen the diff and made a decision"? Terminal → editor → git GUI → back again. I walk that path a dozen times a day.
+
+**4. Context switching.** Stack the three above and you get a day chopped into fragments — not by the agents, but by **the gaps between tools**.
+
+Notice what those four have in common: **none of them are about how many lanes you run.** They hurt with one lane too. Scaling to 100 makes them hurt more, but the number was never the root cause.
+
+That's my call: for a solo developer, the thing that kills you first isn't "I can't schedule 100 agents." It's those four gaps.
+
+## The 2code tradeoff list
+
+So 2code is built around those four things, and **only** those four things.
+
+What it does:
+
+- **Persistent terminals and restore.** Terminal sessions, scrollback, and window layout come back after a restart. You return to what you left, not to blank panes.
+- **Agent status detection.** It reads terminal output, OSC titles, and progress sequences to tell whether an agent is running, waiting on you, or finished — then lights a green dot and plays a sound when it lands. Polling becomes push.
+- **Worktree lanes.** Each worktree gets its own window and its own terminal context. Profiles live under `~/.2code/workspace/{id}`, run the setup script you defined in `2code.json` on creation, and run teardown on delete.
+- **Built-in git and a light editor.** Diffs, staged changes, and commit history live in the same app, so a quick config tweak doesn't cost you an app switch.
+
+What it deliberately does not do — not now, and not soon:
+
+- **No task scheduler or queue.** 2code doesn't decide which agent runs next, or on what.
+- **No automated review gate.** There is no "agent commits → lint/test gate → merge" pipeline. Review is still yours; 2code just drags it as close to you as it can get.
+- **No cloud runners, no remote fleet.** Everything runs on your machine.
+- **It isn't an IDE.** The editor goes as far as "fix this one line" and no further. I'm not trying to take your editor's job.
+- **macOS first.** Windows and Linux are experimental, and some of the Windows system-customization surface is still being validated.
+
+I know that list reads as *small*. But small and deliberate are different things — every line in the "does not" column is there because it serves a different layer of the problem, not because it hasn't come up the queue yet.
+
+One reference I keep coming back to: when JetBrains wrote about winding Fleet down, the valuable part wasn't what they said they'd build. It was what they said they'd **stop** building. A tool's honesty usually shows up in that list.
+
+## When you should go use Orca or Superset
+
+I want to write this section more carefully than the part where I praise my own thing.
+
+**Go use an orchestrator if:**
+
+- You're a team that needs to hand tasks out to a pool of agents instead of starting each one by hand.
+- Your bottleneck is provably "review doesn't scale", and you need automated gates, batch diff review, and cross-task scheduling policy.
+- You genuinely need dozens or hundreds of lanes — bulk migrations, large-scale refactors, racing several approaches and picking a winner.
+- You want 25+ agents preconfigured and sitting side by side for comparison.
+
+**Use 2code if:**
+
+- Your real concurrency is 2–5 lanes, and what's left hurting is recovery, notification, and the distance to review.
+- You want a workstation you leave open all day, not a system you have to configure a workflow into before you can start.
+- You live in the terminal and want your CLI agent running where it already belongs, instead of stuffed into a side panel.
+
+These aren't mutually exclusive. The workstation is the floor; orchestration is the layer above it. **When the floor is uneven, the layer above pays for it** — an orchestrator can spin up fifty agents for you, but something still has to tell you whether the three on your own desktop are done.
+
+The day my own real concurrency goes from 3 lanes to 30, I'll think hard about that upper layer. Until then, promising 100 would be dishonest.
+
+## Make three lanes work first
+
+If you counted your own number and it also came out at two or three — and what actually hurts is re-excavating after every restart, not daring to leave your desk, and the diff being too far away — then we're solving the same problem.
+
+```bash
+brew install --cask akarachen/tap/2code
+```
+
+- Site: <https://2code.akr.moe/>
+- GitHub: <https://github.com/AkaraChen/2code> — open source, issues and stars welcome
+- Latest release: <https://github.com/AkaraChen/2code/releases/latest>
+
+2code is early and still moving. But what it promises is small: make the two or three lanes you actually have today stop costing you attention.

--- a/website/content/blog/zh-cn/why-im-not-building-an-agent-factory.md
+++ b/website/content/blog/zh-cn/why-im-not-building-an-agent-factory.md
@@ -1,0 +1,123 @@
+---
+title: 为什么我不先做「百 Agent 工厂」
+description: Orca 说 Ship 100x，Superset 的目标是年底并行管理 100 个 agent。方向没错，但连他们自己现在也只稳定跑 5–7 个。作为独立开发者，我选择先把两三条泳道做顺——这是 2code 的取舍清单。
+date: 2026-08-05
+publishAt: 2026-08-05T09:00:00+08:00
+slug: why-im-not-building-an-agent-factory
+tags:
+  [
+    并行 Agent,
+    agent orchestration,
+    独立开发,
+    产品取舍,
+    Claude Code,
+    终端工作站,
+  ]
+---
+
+## 这一轮，大家都在喊数量
+
+打开这一批工具的官网，标题几乎都在同一个方向上：
+
+- Orca：**"Ship 100x With The Agent IDE"**，主打「a fleet of agents」，首页的用户证言是「Orchestrating 600 agents from my phone」。
+- Superset：**"Run 10+ parallel coding agents on your machine"**，并且写了一篇路线图，目标是**年底每人并行管理 100 个 agent**。
+
+我认真读了这些页面，也认真觉得这个方向是对的——agent 的边际成本确实在往下掉。Superset 那篇路线图里有句很清醒的话：*"Agent compute is already cheap enough, you can run hundreds of agents a month all for less than the cost of one engineer."*
+
+所以这篇不是拆台。我只是要说清楚，作为一个独立开发者做工具，我**为什么不先做那一层**。
+
+## 先看一个数字：连他们自己也只跑 5–7 个
+
+还是 Superset 那篇路线图，它最诚实的地方在开头：
+
+> *"Right now at Superset, we're able to reliably manage 5-7 coding agents in parallel... Our goal is to be able to manage 100 coding agents in parallel each by the end of 2026."*
+
+> *"What's stopping us is every agent needs a human to review its code, give feedback, and decide what to work on next. Scale the agents all you want - it's the humans that don't scale."*
+
+> *"Right now, most of our agents spend more time waiting for us to review their work than they spend doing it."*
+
+也就是说：一家专门做并行编排的公司，今天的稳定并发是 **5–7**，而且它们的 agent **大部分时间在等人 review**。100 是目标，不是现状——他们自己就是这么写的。
+
+那你呢？
+
+别拍脑袋，去数一下。数你上周真正**同时在跑、并且你真的跟进到底**的任务线有几条。不是「我开过多少个终端窗口」，是「有几条线我最后真的看了 diff、做了决定」。
+
+我自己数出来的量级是个位数，日常在 2 到 3 条之间，忙的时候多一两条。2code 就是照着这个量级设计的。
+
+这里有个容易被忽略的事实：**并发数不是由模型能力决定的，是由你能消化多少 review 决定的**。一条线跑完，最后总要有个人扫一眼 diff、判断合不合。这一步不会因为你多起 90 个 agent 而变快——Superset 自己也是这么说的：「You can't review 100 diffs a day」。
+
+所以「百 Agent 工厂」是一个团队级的、需要把 review 也自动化掉的目标。它很值得做。但它不是我今天要解决的问题。
+
+## 真正拖后腿的四件事
+
+如果我的真实并发只有两三条，那我每天的时间到底花在哪了？我列过一次，是这四件：
+
+**一、恢复。** 关掉 App、重启一次电脑、第二天早上打开——那三条线还在吗？代码当然在，git 里都在。丢掉的是「哪条线在干嘛、跑到哪了、下一步是什么」。每次重启都要重新考古一遍，这个成本我每周要付好几次。
+
+**二、通知。** Agent 跑完了，谁告诉我？没人的话，我就变成了轮询器：每两分钟切一圈窗口看看谁好了。三条线的轮询成本已经足够让我不敢离开桌子——而「让 agent 干活的时候我去干别的」本来才是并行的全部意义。
+
+**三、review 的距离。** Agent 说改完了。从这句话到「我看清了 diff 并做了决定」中间隔着几次应用切换？终端 → 编辑器 → git GUI → 再切回来。这段路每天要走十几次。
+
+**四、上下文切换。** 上面三件事叠起来，就是一天里被切碎的注意力。不是被 agent 切碎的，是被**工具之间的缝隙**切碎的。
+
+注意这四件事有个共同点：**它们都跟你并行几条线没关系，跑一条线也一样疼。** 加到 100 条只会让它们更疼，但根源不在数量。
+
+这就是我的判断：对独立开发者来说，先死的不是「我调度不了 100 个 agent」，而是这四条缝隙。
+
+## 2code 的取舍清单
+
+所以 2code 是围绕这四件事做的，也**只**围绕这四件事做。
+
+做了：
+
+- **持久终端 + 恢复。** 终端会话、scrollback、窗口布局在重启后恢复。回来看到的是离开时的样子。
+- **Agent 状态检测。** 从终端输出、OSC 标题和进度序列里识别 agent 在跑 / 在等你 / 已结束，跑完亮绿点、响一声。把轮询换成推送。
+- **Worktree 泳道。** 每个 worktree 一个独立窗口和独立终端上下文，profile 建在 `~/.2code/workspace/{id}`，创建时跑你在 `2code.json` 里定义的 setup script，删除时跑 teardown。
+- **内置 git 与轻量编辑器。** diff、暂存区、提交历史就在同一个 App 里，顺手改个配置也不用切走。
+
+刻意没做（现在不做，短期也不做）：
+
+- **没有任务调度器 / 队列。** 2code 不替你决定哪个 agent 先跑、跑什么。
+- **没有自动化 review 关卡。** 没有「agent 提交 → 自动 lint/test 门禁 → 合并」这条流水线。review 仍然是你来做，2code 只负责把它拉到离你最近的地方。
+- **没有云端 runner / 远程 fleet。** 全部跑在你自己的机器上。
+- **不做 IDE。** 编辑器只到「顺手改一下」的程度，我不打算和你现在的编辑器抢主力位置。
+- **macOS 优先。** Windows 和 Linux 是实验支持，其中 Windows 的部分系统自定义能力还在验证。
+
+我知道这份清单看起来「少」。但少和取舍是两回事——上面每一条「没做」，都是因为它服务的是另一个层级的问题，而不是因为我还没排上期。
+
+顺带说一句我很喜欢的参照：JetBrains 在给 Fleet 收尾时那篇文章，最有价值的部分不是讲他们要做什么，而是讲他们**决定不做什么**。工具的诚实度，往往体现在这份清单上。
+
+## 什么时候你该去用 Orca 或 Superset
+
+这一段我想写得比夸自己更认真。
+
+**去用编排器，如果：**
+
+- 你是团队，需要把任务分配给一批 agent，而不是自己一条条起。
+- 你的瓶颈已经明确是「review 扩不过去」，需要自动化关卡、批量 diff 审阅、跨任务的调度策略。
+- 你真的需要几十上百条并行——比如批量迁移、大规模重构、跑 A/B 方案挑赢家。
+- 你想要 25+ 个 agent 开箱即用地摆在一起随时对比。
+
+**用 2code，如果：**
+
+- 你的真实并发是 2–5 条，剩下的痛点是恢复、通知和 review 距离。
+- 你想要的是一个每天都开着的工作台，而不是一套需要先配置好流程才能开始的系统。
+- 你重度用终端，希望 CLI agent 就在它本来该在的地方跑，而不是被塞进某个侧边栏。
+
+这两件事不互斥。工作台是底座，编排是上层。**底座没做好的时候，上层的收益是会打折的**——编排器可以帮你起 50 个 agent，但你桌面上那三个到底跑完没有，仍然要有人告诉你。
+
+等到有一天，我自己的真实并发从 3 条涨到 30 条，我会认真去想上面那层怎么做。在那之前，承诺 100 是不诚实的。
+
+## 先把三条泳道用顺
+
+如果你数完自己的真实并发，发现也是两三条，而每天真正难受的是重启后要重新考古、是不敢离开桌子、是 diff 离你太远——那我们要解决的是同一个问题。
+
+```bash
+brew install --cask akarachen/tap/2code
+```
+
+- 官网：<https://2code.akr.moe/zh-cn>
+- GitHub：<https://github.com/AkaraChen/2code> — 开源，欢迎 issue 和 star
+- 最新版本：<https://github.com/AkaraChen/2code/releases/latest>
+
+2code 还很早期，也还在动。但它承诺的东西很小：把你今天真实的那两三条线，做得不用你操心。


### PR DESCRIPTION
P1 选题 KIT-433《为什么我不先做「百 Agent 工厂」》，中英双语。

- `website/content/blog/zh-cn/why-im-not-building-an-agent-factory.md`
- `website/content/blog/en/why-im-not-building-an-agent-factory.md`

排期 `publishAt: 2026-08-05T09:00:00+08:00`，接在 worktree 那篇（08-02）之后。

## 论点

反潮流但不贬低：承认 Orca / Superset 的方向对，但用他们自己的公开数据做支点 —— Superset 路线图写明「Right now at Superset, we're able to reliably manage 5-7 coding agents in parallel」，且「most of our agents spend more time waiting for us to review their work than they spend doing it」。100 是目标不是现状，瓶颈是 review 而不是模型。

由此落到取舍：真实并发 2–5 条时，先死的是恢复 / 通知 / review 距离 / 上下文切换这四条缝隙。文中给了明确的「做了 / 刻意不做」清单（不做调度器、不做自动 review 关卡、不做云端 fleet、不做 IDE、macOS 优先），并单列一节写「什么时候你该去用 Orca / Superset」。

引用均来自公开页面：Orca 首页 "Ship 100x With The Agent IDE"、Superset 首页 "Run 10+ parallel coding agents on your machine"、Superset 100-agent 路线图。

## 验证

- `bun run build` 通过；`bun run lint` 无 error
- `BLOG_NOW=2026-08-06 bun run build` 下 `/blog/...` 与 `/zh-cn/blog/...` 两条路由都生成，sitemap 含新路径
- 默认构建（当前时间）正确把它当排期文章排除

🤖 Generated with [Claude Code](https://claude.com/claude-code)
