### PR TITLE
KIT-553: fix website blog schema and content lang for indexing

### DIFF
--- a/website/app/blog/blog-list-content.tsx
+++ b/website/app/blog/blog-list-content.tsx
@@ -1,5 +1,6 @@
 import { type AppLocale, type resources } from '../i18n/resources'
 import { siteConfig } from '../site-config'
+import { htmlLang } from '../structured-data'
 import { BlogShell } from './blog-shell'
 import type { BlogPostMeta } from './lib/posts'
 import {
@@ -33,7 +34,7 @@ export function BlogListContent({
     url: listUrl,
     name: t.blog.metadataTitle,
     description: t.blog.metadataDescription,
-    inLanguage: locale === 'zh-cn' ? 'zh-CN' : 'en',
+    inLanguage: htmlLang(locale),
     publisher: { '@id': `${siteConfig.url}/#organization` },
     blogPost: posts.map((post) => ({
       '@type': 'BlogPosting',
@@ -41,7 +42,9 @@ export function BlogListContent({
       description: post.description,
       datePublished: post.date,
       url: `${siteConfig.url}${blogPostPath(locale, post.slug)}`,
+      inLanguage: htmlLang(locale),
       keywords: [...post.tags],
+      isPartOf: { '@id': `${listUrl}#blog` },
     })),
   }
 

--- a/website/app/blog/blog-post-content.tsx
+++ b/website/app/blog/blog-post-content.tsx
@@ -1,5 +1,6 @@
 import { type AppLocale, type resources } from '../i18n/resources'
 import { siteConfig } from '../site-config'
+import { htmlLang } from '../structured-data'
 import { BlogShell } from './blog-shell'
 import type { BlogPost } from './lib/posts'
 import {
@@ -39,11 +40,18 @@ export function BlogPostContent({
     datePublished: post.date,
     dateModified: post.date,
     url: postUrl,
-    mainEntityOfPage: postUrl,
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': postUrl,
+    },
     image: [imageUrl],
     keywords: [...post.tags],
-    inLanguage: locale === 'zh-cn' ? 'zh-CN' : 'en',
-    author: { '@type': 'Organization', name: siteConfig.name },
+    inLanguage: htmlLang(locale),
+    author: {
+      '@type': 'Organization',
+      '@id': `${siteConfig.url}/#organization`,
+      name: siteConfig.name,
+    },
     publisher: { '@id': `${siteConfig.url}/#organization` },
     isPartOf: { '@id': `${siteConfig.url}${blogListPath(locale)}#blog` },
   }

--- a/website/app/blog/blog-shell.tsx
+++ b/website/app/blog/blog-shell.tsx
@@ -3,6 +3,7 @@ import { type AppLocale, type resources } from '../i18n/resources'
 import { LocaleSwitch } from '../locale-switch'
 import { SiteHeader } from '../site-header'
 import { siteConfig } from '../site-config'
+import { htmlLang, organizationNode } from '../structured-data'
 import { blogFeedPath } from './lib/routes'
 
 type Messages = (typeof resources)[AppLocale]
@@ -26,8 +27,20 @@ export function BlogShell({
   localeHrefs,
   children,
 }: BlogShellProps) {
+  // Publisher @id on Blog/BlogPosting JSON-LD resolves only when this node is
+  // present on the same page — homepage already emits it; blog pages did not.
+  const organizationData = {
+    '@context': 'https://schema.org',
+    ...organizationNode(),
+  }
+
   return (
-    <div className="page-shell">
+    <div className="page-shell" lang={htmlLang(locale)}>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationData) }}
+      />
+
       <SiteHeader locale={locale} messages={messages} />
 
       <main>{children}</main>

--- a/website/app/home-page-content.tsx
+++ b/website/app/home-page-content.tsx
@@ -1,5 +1,6 @@
 import { type AppLocale, type resources } from './i18n/resources'
 import { LocaleSwitch } from './locale-switch'
+import { htmlLang, organizationNode } from './structured-data'
 import { PageEffects } from './page-effects'
 import { SiteHeader } from './site-header'
 import { siteConfig } from './site-config'
@@ -56,20 +57,14 @@ export function HomePageContent({
   const structuredData = {
     '@context': 'https://schema.org',
     '@graph': [
-      {
-        '@type': 'Organization',
-        '@id': `${siteConfig.url}/#organization`,
-        name: siteConfig.name,
-        url: siteConfig.url,
-        sameAs: [siteConfig.githubUrl],
-      },
+      organizationNode(),
       {
         '@type': 'WebSite',
         '@id': `${siteConfig.url}/#website`,
         name: siteConfig.name,
         url: pageUrl,
         description: t.metadata.description,
-        inLanguage: locale === 'zh-cn' ? 'zh-CN' : 'en',
+        inLanguage: htmlLang(locale),
         publisher: {
           '@id': `${siteConfig.url}/#organization`,
         },
@@ -82,7 +77,7 @@ export function HomePageContent({
         description: t.metadata.description,
         isPartOf: { '@id': `${siteConfig.url}/#website` },
         about: { '@id': `${siteConfig.url}/#software` },
-        inLanguage: locale === 'zh-cn' ? 'zh-CN' : 'en',
+        inLanguage: htmlLang(locale),
         // Machine-readable alternate (GEO: rel=alternate type=text/markdown)
         encodingFormat: 'text/html',
         relatedLink: [
@@ -124,7 +119,7 @@ export function HomePageContent({
   }
 
   return (
-    <div className="page-shell">
+    <div className="page-shell" lang={htmlLang(locale)}>
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}

--- a/website/app/structured-data.ts
+++ b/website/app/structured-data.ts
@@ -1,0 +1,18 @@
+import type { AppLocale } from './i18n/resources'
+import { siteConfig } from './site-config'
+
+/** BCP 47 tag used for HTML `lang` and schema.org `inLanguage`. */
+export function htmlLang(locale: AppLocale): 'zh-CN' | 'en' {
+  return locale === 'zh-cn' ? 'zh-CN' : 'en'
+}
+
+/** Shared Organization node — blog posts reference it via `@id`. */
+export function organizationNode() {
+  return {
+    '@type': 'Organization' as const,
+    '@id': `${siteConfig.url}/#organization`,
+    name: siteConfig.name,
+    url: siteConfig.url,
+    sameAs: [siteConfig.githubUrl],
+  }
+}


### PR DESCRIPTION
## Summary
- Diagnose why `https://2code.akr.moe/zh-cn/blog` and its posts are not in search indexes
- Fix incomplete blog JSON-LD (Organization `@id` was referenced but never emitted on blog pages)
- Emit SSR `lang` on page shells so Chinese content is not only corrected client-side

## Diagnosis (main finding)
**No hard noindex / robots / sitemap omission blocks Chinese blog URLs today.**

Verified live:
- HTTP 200, `robots: index, follow`, correct canonicals
- hreflang en / zh-CN / x-default present
- `sitemap.xml` includes `/zh-cn/blog` and all published ZH posts
- Homepage + `llms.txt` link to the ZH blog
- Draft/scheduled posts correctly excluded (`example-post`, `ade-orchestrator…` with publishAt 2026-08-04)

Primary reason pages are not yet indexed: **content is brand-new** (first posts dated 2026-07-31 → 2026-08-02). Search engines often take days–weeks to crawl/index new low-authority URLs even when technical SEO is clean. Bing `site:` queries currently return no real matches for these paths.

## Code changes
- Shared `organizationNode()` / `htmlLang()` helper
- Blog shell emits Organization JSON-LD + `lang` on page shell
- Blog list/post schema tightened (`mainEntityOfPage` WebPage, author/publisher `@id`)

## Test plan
- [x] `bun run lint` (website)
- [x] `bun run build` (website) — `/zh-cn/blog` + 3 ZH posts prerendered; scheduled ADE post excluded
- [ ] After merge/deploy: recheck `sitemap.xml` still lists ZH URLs
- [ ] Google Search Console / Bing Webmaster: submit sitemap + URL Inspection → Request indexing for `/zh-cn/blog` and top posts

Closes KIT-553