### PR TITLE
docs(website): 博客《误区：有了 Cursor 就不需要终端工作站》中英双语

### DIFF
--- a/website/content/blog/en/cursor-vs-terminal-workstation.md
+++ b/website/content/blog/en/cursor-vs-terminal-workstation.md
@@ -1,0 +1,88 @@
+---
+title: "Myth: With Cursor, You Don't Need a Terminal Workstation"
+description: "Cursor handles the agent inside your editor. Claude Code and Codex still live in the terminal. Those are two different problem domains, and the answer is both — not either-or."
+date: 2026-08-06
+publishAt: 2026-08-06T00:00:00+08:00
+slug: cursor-vs-terminal-workstation
+tags:
+  [
+    Cursor,
+    AI editor,
+    Claude Code,
+    Codex,
+    terminal workstation,
+    agentic IDE,
+    parallel agents,
+    git worktree,
+    2code,
+  ]
+---
+
+"My editor already has an agent. Why would I need a terminal tool?"
+
+The reasoning sounds clean: Cursor completes your code, rewrites it inline, and keeps an agent in the sidebar that can even run commands. Everything a terminal workstation does — shells, tasks, output — the editor seems to cover on the side.
+
+But these two tools answer two different questions.
+
+## Two problem domains
+
+Cursor orbits **files and the cursor**: how code gets written, edited, and understood. However strong its agent gets, the host is still an editor.
+
+CLI agents like Claude Code and Codex orbit **the shell and its processes**: running tests, starting dev servers, executing migration scripts, waiting for you to press `y` on a permission prompt. Their home is the terminal, not anyone's sidebar — in fact they don't care which editor you read your code in.
+
+| | AI editor (Cursor et al.) | Terminal workstation |
+| --- | --- | --- |
+| Home turf | Files and the cursor | Shell sessions and processes |
+| Agent shape | Completion, inline, sidebar | CLIs (Claude Code, Codex, …) |
+| Manages | How code gets written | How tasks get run |
+| Unit of parallelism | Tabs | Worktrees + terminal sessions |
+| State question | What does this code mean | Who finished, who's waiting on me |
+
+JetBrains reached the same conclusion when building Air: an IDE and an agentic environment are different things, and forcing them into one tool serves neither. Air itself says it doesn't replace your IDE. Orca's pitch is "bring your own agent CLI" — the whole category assumes CLI agents keep living in the terminal.
+
+## When Cursor alone is enough
+
+The honest part first:
+
+- You work on one project, one task at a time.
+- The changes stay inside the editor — the agent writes, you approve.
+- There are no dev servers, scripts, or branch experiments to babysit in parallel.
+
+Used this way, the terminal is a launcher and a log window. Adding a workstation genuinely is overhead. Cursor is good. Just use it.
+
+## When the terminal side still hurts
+
+The pain shows up after you cross two thresholds.
+
+**Threshold one: you start using CLI agents.** Claude Code runs a long task and stops midway at a permission prompt, waiting for you. That happens in the terminal. How long it has been running, whether it is blocked on you, which branch the result landed on — the editor knows none of this. Cursor ships its own CLI (cursor-agent), which suggests this form factor is not a transitional phase.
+
+**Threshold two: you run more than one lane at a time.** A bugfix lane, a feature lane, an experiment lane. Each needs its own worktree, its own dependency install, its own dev server port, its own shell context. Editor tabs manage files; they cannot tell you whether a task lane's whole set of processes is still alive. Reboot the machine, and which lane was in what state lives only in your head.
+
+Past those thresholds, what you lack is not editor features. It is **lifecycle management for task lanes** — and that is the terminal workstation's problem domain.
+
+## Where 2code fits: the other half
+
+2code is a full terminal emulator first, with project management, worktree lanes, command templates, and session restore layered on top. It does not touch the editor side:
+
+- Each worktree lane gets its own window and terminal context, so dev servers and agents never step on each other.
+- Agent state is read from terminal output, titles, and progress sequences — a green dot when one finishes, a sound when one is waiting on you.
+- After a restart, projects, lanes, and terminal history come back close to where you left them.
+- The detection rules cover 18 CLI agents — cursor-agent included. Keep writing code in Cursor while 2code watches the lanes in the terminal.
+
+Use whichever editor you like. 2code runs the terminal lanes. Each side covers its own problem domain; there is no either-or.
+
+The boundaries, as usual: 2code is early, macOS is the mature platform, and it is not trying to replace your IDE or offer editor-grade completion and indexing. It fills the terminal-shaped gap that CLI agents opened up.
+
+## Try it
+
+If your day looks like "write a bit in Cursor, keep three lanes running in the terminal", the missing piece is probably a workbench for the second half:
+
+```bash
+brew install --cask akarachen/tap/2code
+```
+
+- Website: <https://2code.akr.moe/> ([中文](https://2code.akr.moe/zh-cn))
+- GitHub: <https://github.com/AkaraChen/2code> — open source, issues and stars welcome
+- Latest release: <https://github.com/AkaraChen/2code/releases/latest>
+
+The editor manages how code gets written. The terminal workstation manages how tasks get run. A complete workbench has both halves working.

--- a/website/content/blog/zh-cn/cursor-vs-terminal-workstation.md
+++ b/website/content/blog/zh-cn/cursor-vs-terminal-workstation.md
@@ -1,0 +1,89 @@
+---
+title: "误区：有了 Cursor 就不需要终端工作站"
+description: "Cursor 解决的是编辑器里的 agent，Claude Code 和 Codex 的主场仍是终端。这是两个问题域，答案是并存，不是二选一。"
+date: 2026-08-06
+publishAt: 2026-08-06T00:00:00+08:00
+slug: cursor-vs-terminal-workstation
+tags:
+  [
+    Cursor,
+    AI 编辑器,
+    Claude Code,
+    Codex,
+    终端工作站,
+    terminal workstation,
+    Agentic IDE,
+    并行 Agent,
+    git worktree,
+    2code,
+  ]
+---
+
+「我编辑器里已经有 agent 了，为什么还要一个终端工具？」
+
+这个推论听起来很顺：Cursor 能补全、能 inline 改代码、侧边栏里还住着一个能跑命令的 agent。终端工作站管的那摊事——开 shell、跑任务、看输出——编辑器好像都能顺手做掉。
+
+但这两个工具回答的，其实是两个问题。
+
+## 两套问题域
+
+Cursor 围着**文件和光标**转：代码怎么写、怎么改、这段什么意思。它的 agent 再强，宿主仍然是编辑器。
+
+Claude Code、Codex 这类 CLI agent 围着 **shell 和进程**转：跑测试、起 dev server、执行迁移脚本、等你在权限提示上按一个 y。它们的主场是终端，不是哪个编辑器的侧边栏——事实上它们根本不挑编辑器，你拿什么看代码都行。
+
+| | AI 编辑器（Cursor 等） | 终端工作站 |
+| --- | --- | --- |
+| 主战场 | 文件和光标 | shell 会话和进程 |
+| agent 形态 | 补全、inline、侧边栏 | CLI（Claude Code、Codex 等） |
+| 管什么 | 代码怎么写 | 任务怎么跑 |
+| 并行单位 | 标签页 | worktree + 终端会话 |
+| 状态问题 | 这段代码什么意思 | 谁跑完了、谁在等我 |
+
+JetBrains 做 Air 时的判断也是同一个：IDE 和 agentic 环境是两种东西，硬塞进一个工具会两头不靠。Air 自己明说它不替代 IDE。Orca 那边则是「bring your own agent CLI」——整个品类都默认 CLI agent 会继续活在终端里。
+
+## 什么时候只要 Cursor 就够
+
+先把诚实的话说了：
+
+- 你一次只在一个项目、一条任务上；
+- 改动集中在编辑器里，agent 帮你写、你来拍板；
+- 没有 dev server、脚本、多分支实验要同时照看。
+
+这种用法下终端只是启动器和日志窗口，多一个工作站确实是负担。Cursor 够好，用就完了。
+
+## 什么时候终端现场仍然痛
+
+痛点出现在你跨过两个门槛之后。
+
+**门槛一：你开始用 CLI agent。** Claude Code 跑一个长任务，中途停在权限提示上等你确认——这件事发生在终端里。它跑了多久、是不是在等你、结果落在哪个分支，编辑器一概不知道。Cursor 自己也有 CLI（cursor-agent），说明这个形态不是过渡产物。
+
+**门槛二：你同时跑不止一条线。** 修 bug 一条、新功能一条、实验一条。每条线要自己的 worktree、自己的依赖安装、自己的 dev server 端口、自己的 shell 现场。编辑器的标签页管的是文件，管不了「这条任务线的整套进程还活着没有」。重启一下电脑，哪条线在哪个状态，全靠你脑子里的便签。
+
+过了这两个门槛，你缺的就不是编辑器功能，而是**任务线的生命周期管理**——这是终端工作站的问题域。
+
+## 2code 的位置：管另一半
+
+2code 是一个完整的终端模拟器，先把这个做好，再往上加项目管理、worktree 泳道、命令模板和会话恢复。它不碰编辑器那一侧：
+
+- 每条 worktree 泳道有自己的窗口和终端现场，dev server 和 agent 互不踩；
+- agent 状态从终端输出、标题和进度序列里识别，跑完了亮绿点，等你确认时响一声；
+- 重启之后，项目、泳道、终端历史恢复到离开时的样子；
+- 识别规则覆盖 18 个 CLI agent——包括 cursor-agent。你可以继续在 Cursor 里写代码，同时让 2code 看着终端里的这些线。
+
+编辑器用你喜欢的。2code 管终端泳道。两边各管各的问题域，不用二选一。
+
+边界也说清楚：2code 早期、macOS 最成熟，它不是要替代你的 IDE，也不提供编辑器级的补全和索引。它补的是 CLI agent 时代终端这一半的缺口。
+
+## 试一下
+
+如果你的一天是「Cursor 里写两笔，终端里三条线在跑」，缺的很可能就是后者的工作台：
+
+```bash
+brew install --cask akarachen/tap/2code
+```
+
+- 官网：<https://2code.akr.moe/>（[English](https://2code.akr.moe/)）
+- GitHub：<https://github.com/AkaraChen/2code> — 开源，欢迎 issue 和 star
+- 最新版本：<https://github.com/AkaraChen/2code/releases/latest>
+
+编辑器管代码怎么写，终端工作站管任务怎么跑。两个都顺手，才是完整的工作台。


### PR DESCRIPTION
误区短文系列 #2/3（KIT-440）。

## 内容

- 中：《误区：有了 Cursor 就不需要终端工作站》
- 英：*Myth: With Cursor, You Don't Need a Terminal Workstation*
- slug：`cursor-vs-terminal-workstation`，publishAt 2026-08-06 00:00 (+08:00)

按 issue 建议结构写：误区原话 → 编辑器 vs 终端工作站对照表 → 什么时候 Cursor 就够 → 什么时候终端现场仍痛（两个门槛：开始用 CLI agent、同时跑多条任务线）→ 2code 的互补位置 → CTA。

## 验收对照

- 不贬低 Cursor：第三节明确「这种用法下 Cursor 够好，用就完了」，全文讲互补而非替代
- 表格清晰：五维对照（主战场 / agent 形态 / 管什么 / 并行单位 / 状态问题）

## 事实来源

- 2code 功能表述均取自仓库 README 与官网 FAQ（完整终端模拟器 first、worktree 泳道、18 个 agent 识别规则含 cursor-agent、会话恢复）
- Air「不替代 IDE」与 Orca「BYO agent CLI」为品类公开表述，用于支撑「CLI agent 留在终端」的论据

## 验证

- `BLOG_INCLUDE_SCHEDULED=1 bun run build` 通过，`/blog/cursor-vs-terminal-workstation` 与 `/zh-cn/blog/cursor-vs-terminal-workstation` 均预渲染成功
- 生产模式起服后 curl 两页 200，表格正常渲染，无 frontmatter 泄漏
