### PR TITLE
docs(website): 博客《误区：「Worktree 太重，branch 就够」》中英双语

### DIFF
--- a/website/content/blog/en/git-worktree-too-heavy-branch-enough.md
+++ b/website/content/blog/en/git-worktree-too-heavy-branch-enough.md
@@ -1,0 +1,105 @@
+---
+title: "The Myth: \"Worktrees Are Too Heavy — Branches Are Enough\""
+description: "Branch switching shares a single working directory, so two agents editing files at once will trample each other. A worktree is one object store with multiple working directories — it isn't showing off, and the heavy part has long been automated away."
+date: 2026-08-10
+publishAt: 2026-08-10T00:00:00+08:00
+slug: git-worktree-too-heavy-branch-enough
+tags:
+  [
+    Git worktree,
+    git worktrees,
+    git branch,
+    parallel agents,
+    parallel coding agents,
+    Claude Code,
+    Codex,
+    Superset,
+    Orca,
+    JetBrains Air,
+    agent workstation,
+    terminal workstation,
+  ]
+---
+
+## The myth, verbatim
+
+> "Git worktrees are too heavy. An extra directory, another dependency install, more paths to remember — I just want two agents working at the same time. Isn't two branches enough?"
+
+It sounds reasonable, because branches really are light: `git switch -c`, done in a second. And "worktree" sounds like "cloning the repo all over again."
+
+But the comparison is mismatched from the start: **branches and worktrees isolate different layers.**
+
+## One picture: what actually differs
+
+```text
+branch switching: one working directory, playing one branch at a time
+
+  ~/repo/                  ← the only working directory
+    currently feature-a
+    git switch hotfix → same directory, contents replaced by hotfix
+
+worktrees: one object store, several working directories at once
+
+  .git/ (a single object store — no duplicated history)
+    ├── ~/repo/            ← main
+    ├── ~/repo-feature/    ← feature-a
+    └── ~/repo-hotfix/     ← hotfix — three directories, all present
+```
+
+`git switch` swaps branches by replacing the files in **one shared working directory**. There is a single directory, and "which branch it currently is" is mutually exclusive.
+
+`git worktree add` checks out another directory from **the same object store**. History and objects are fully shared — the only extra disk cost is the working files — but now there are two directories, each on its own branch, **present at the same time**.
+
+This is no new toy. Worktrees shipped in Git 2.5 back in 2015, built for people who had to drop half-finished work to fix an urgent bug. The feature spent a decade waiting for parallel agents to become its obvious use case.
+
+## Fairness first: when a branch really is enough
+
+One person, one agent, one thing at a time — in that setup, "worktrees are too heavy" is correct.
+
+You watch the agent while it runs, commit, then switch to the next task. The whole workflow is serial, and a single working directory has no problem at all. Adding worktrees here really does just add a directory to remember.
+
+The test is one sentence:
+
+**At any given moment, are there two things that write files working in the same directory? If not, a branch is enough. If yes, it isn't.**
+
+## Parallel agents: branches isolate exactly the layer agents don't work in
+
+An agent doesn't read code — it **edits** code, for ten minutes or more at a stretch.
+
+Two perfectly ordinary scenarios:
+
+**One agent plus you.** Agent A is halfway through a change when an urgent bug lands, and you want to fix it yourself. The moment you `git switch`, the ground shifts under A: the files it just read now have different contents, its uncommitted changes either block the checkout or get carried into the other branch, and the test suite it left running is now executing against a directory it no longer recognizes.
+
+**Two agents.** Two writers fight over the same files and the diff becomes porridge. `git status` can't tell you which line came from which agent, or for which task. Dev servers collide on ports, and you can't tell who started which process or which one to kill.
+
+The root cause: **branches isolate commit history, not the filesystem. Agents live in the filesystem.** You're using a history tool to solve a working-directory conflict — wrong layer.
+
+## Which part is actually "heavy"
+
+Break it down and the worktree itself is not heavy at all: `git worktree add ../repo-fix fix` is one command, the object store is shared, and there is no second clone.
+
+What's genuinely heavy is the **environment**: `node_modules` needs installing again, `.env` needs copying, ports need staggering, and the whole thing needs deleting when you're done. Done by hand, that's a few extra minutes per task line — and easy to forget. When most people say "worktrees are too heavy," this is the part they're actually complaining about.
+
+And this part is exactly what tooling should absorb:
+
+- **Scripts**: wrap setup and teardown into two commands, so creating and cleaning up no longer rely on memory;
+- **2code workstations**: creating a workstation runs `git worktree add` for you and executes the setup written into the project's `2code.json` (say, `npm install`); deleting it runs teardown and removes the directory and branch together. Once the heavy part is automated, only the upside is left.
+
+For the record, this isn't just 2code's opinion. In Orca, a task is a worktree. JetBrains Air offers exactly three run environments: Local Workspace, Git Worktree, Docker. Superset's entire parallel model is built on worktrees too. Several tools independently settled on the same isolation unit because a worktree is precisely "just isolated enough" — **harder than a branch, lighter than a clone or a container.**
+
+So the cost equation runs in reverse: a branch saves you a few one-time minutes of environment setup, and costs you half an hour every time a parallel run collides. Once tooling erases the setup cost, the "lightness" of branches only holds in a serial workflow.
+
+## Further reading
+
+To put worktrees into a real day of parallel work, continue with the companion piece, [Git Worktrees as Agent Workstations: One Day in Parallel](/blog/worktree-as-agent-workstations) — three task lines running all day, and you come back to scan diffs when the green dot lights up.
+
+```bash
+brew install --cask akarachen/tap/2code
+```
+
+- Website: <https://2code.akr.moe/> ([中文](https://2code.akr.moe/zh-cn))
+- GitHub: <https://github.com/AkaraChen/2code> — open source, issues and stars welcome
+- Latest release: <https://github.com/AkaraChen/2code/releases/latest>
+- `git worktree` docs: <https://git-scm.com/docs/git-worktree>
+
+Worktrees aren't heavy. **Two writers squeezed at the same desk — that's heavy.**

--- a/website/content/blog/zh-cn/git-worktree-too-heavy-branch-enough.md
+++ b/website/content/blog/zh-cn/git-worktree-too-heavy-branch-enough.md
@@ -1,0 +1,105 @@
+---
+title: "误区：「Worktree 太重，branch 就够」"
+description: "Branch 切换共享同一份工作目录，两个 agent 同时改文件必然互踩。Worktree 是同一个对象库、多份工作目录——它不为炫技存在，重的部分也早已被工具吃掉。"
+date: 2026-08-10
+publishAt: 2026-08-10T00:00:00+08:00
+slug: git-worktree-too-heavy-branch-enough
+tags:
+  [
+    Git worktree,
+    git worktrees,
+    git branch,
+    并行 Agent,
+    parallel coding agents,
+    Claude Code,
+    Codex,
+    Superset,
+    Orca,
+    JetBrains Air,
+    Agent 工位,
+    终端工作站,
+  ]
+---
+
+## 误区原话
+
+> 「Git worktree 太重了。多一份目录、多装一遍依赖、多记一堆路径——我就想让两个 agent 同时干活，开两条 branch 不就行了？」
+
+这话听起来非常有道理，因为 branch 是真的轻：`git switch -c`，一秒钟的事。而 worktree 听起来像「把仓库又克隆了一遍」。
+
+但这个对比从一开始就错位了：**branch 和 worktree 隔离的不是同一层东西。**
+
+## 一张图：branch 和 worktree 到底差在哪
+
+```text
+branch 切换：一份工作目录，轮流扮演每条分支
+
+  ~/repo/                  ← 唯一的工作目录
+    此刻是 feature-a
+    git switch hotfix → 同一个目录，内容被替换成 hotfix
+
+worktree：一个对象库，多份工作目录同时在场
+
+  .git/（对象库只有一份，不重复占磁盘）
+    ├── ~/repo/            ← main
+    ├── ~/repo-feature/    ← feature-a
+    └── ~/repo-hotfix/     ← hotfix，三份目录同时存在
+```
+
+`git switch` 换分支，是把**同一份工作目录**里的文件替换成另一条分支的样子。目录只有一个，「它此刻是哪条分支」是互斥的。
+
+`git worktree add` 是从**同一个对象库**再检出一份目录。提交历史、对象数据全部共享，磁盘上多的只是工作文件；但目录有两份，各自一条分支，**同时在场**。
+
+这不是什么新玩具。Worktree 在 2015 年的 Git 2.5 就有了，原本是给「改到一半要切去修紧急 bug」的人准备的。它等并行 agent 这个场景，等了十多年。
+
+## 先说公道话：什么时候 branch 真的够
+
+单人、单 agent、一次只推进一件事——这种情况下说 worktree 太重，是对的。
+
+Agent 在跑的时候你就盯着它，改完、提交、再切下一条。整个工作流是串行的，一份工作目录没有任何问题。这时候引入 worktree，确实只是多了一份要记的目录。
+
+判断标准只有一句话：
+
+**同一时刻，有没有两个「会写文件的东西」在同一个目录里工作？没有，branch 够；有，branch 就不够。**
+
+## 并行 agent：branch 隔离的那层，恰好不是 agent 工作的那层
+
+Agent 不是在看代码，是在**改**代码——而且一跑就是十几分钟。
+
+设想两个很普通的场景：
+
+**场景一：一个 agent + 你自己。** Agent A 改到一半，线上来个紧急 bug，你想自己上手修。`git switch` 一切，A 脚下的地就换了：它刚读过的文件内容变了，未提交的改动要么挡住 checkout，要么被带进另一条分支；测试跑到一半，目录已经不是它以为的那个目录。
+
+**场景二：两个 agent。** 两个写者抢同一批文件，diff 搅成一锅粥；`git status` 里分不清哪行是谁改的、为了哪件事；dev server 端口互踩，你分不清是谁起的、该杀哪个。
+
+问题的根源是：**branch 隔离的是提交历史，不是文件系统。而 agent 恰恰活在文件系统里。** 你拿一个管历史的工具，去解决工作目录的冲突，层就不对。
+
+## 「重」的到底是哪部分
+
+拆开看，worktree 本身一点都不重：`git worktree add ../repo-fix fix` 一条命令的事，对象库共享，没有第二次克隆。
+
+真正重的是**环境**：`node_modules` 要重新装，`.env` 要拷，端口要错开，用完了要记得删。手动做，每条任务线多花几分钟，还经常忘。大多数人骂的「worktree 太重」，骂的其实是这部分。
+
+而这部分恰恰是工具该吃掉的：
+
+- **脚本**：把 setup / teardown 写成两条命令，建和删都不再靠记性；
+- **2code 工位**：建工位时自动 `git worktree add`，并跑项目 `2code.json` 里写好的 setup（比如 `npm install`）；删工位时跑 teardown，目录和分支一起清掉。重的部分自动化之后，剩下的只有收益。
+
+顺带一提，这不只是 2code 的判断。Orca 里一个 task 就是一个 worktree；JetBrains Air 的运行环境就三档：Local Workspace / Git Worktree / Docker；Superset 的整个并行模型同样建立在 worktree 上。几家不约而同把隔离单位定在这里，因为 worktree 恰好是「刚好够隔离」的那一层——**比 branch 硬，比 clone 和容器轻。**
+
+所以成本公式是反的：branch 省的是一次性建环境的几分钟，代价是并行时每次冲突丢掉的半小时。工具把前者抹平之后，branch 的「轻」只在串行时成立。
+
+## 延伸阅读
+
+想把 worktree 真正用进一天的并行工作流，推荐接着读姊妹篇《[用 Worktree 当 Agent 工位：我的一天并行工作流](/zh-cn/blog/worktree-as-agent-workstations)》——三条任务线跑一整天，绿点亮了再回来扫 diff。
+
+```bash
+brew install --cask akarachen/tap/2code
+```
+
+- 官网：<https://2code.akr.moe/>（[English](https://2code.akr.moe/)）
+- GitHub：<https://github.com/AkaraChen/2code> — 开源，欢迎 issue 和 star
+- 最新版本：<https://github.com/AkaraChen/2code/releases/latest>
+- Worktree 官方文档：<https://git-scm.com/docs/git-worktree>
+
+Worktree 不重。**让两个写者挤在同一张桌子上，才重。**


### PR DESCRIPTION
KIT-442（P2 / Stage 3，误区短文 #3/3）的正文。

- `website/content/blog/zh-cn/git-worktree-too-heavy-branch-enough.md`
- `website/content/blog/en/git-worktree-too-heavy-branch-enough.md`

slug `git-worktree-too-heavy-branch-enough`，`publishAt: 2026-08-10 00:00 +08`（给误区 #1/#2 和姊妹篇《简明指南》留出前面的档期；要改哪天说一声）。

论证主线：branch 和 worktree 隔离的不是同一层——branch 隔离提交历史，worktree 隔离文件系统，而 agent 恰好活在文件系统里。结构按 issue 大纲：误区原话 → ASCII 图（branch = 一份目录轮流扮演分支 / worktree = 一个对象库多份目录同时在场）→ 诚实段「单人单 agent 时 branch 真的够」（判断标准一句话：同一时刻有没有两个会写文件的东西在同一目录工作）→ 并行互踩两个场景 → 拆解「重的是环境不是 worktree」，落到脚本和 2code 工位的 setup/teardown → CTA 链到已发布的《用 Worktree 当 Agent 工位》。

事实都核过：worktree 出自 Git 2.5（2015）；Air 运行环境三档 Local Workspace / Git Worktree / Docker 对过官方 quickstart；Orca task = worktree、Superset 并行模型基于 worktree 沿用了 issue 素材口径。

`bun run build`（生产构建按预期不含这篇定时文章）、`bun run build:scheduled`（中英两版均正常预渲染）、`bun run lint` 均通过；预渲染 HTML 里核对过 diagram、表格、内外链完整。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
