### PR TITLE
docs(website): 博客《误区：多开几个终端窗口 = 并行 Agent 工作流》中英双语

### DIFF
--- a/website/content/blog/en/terminal-windows-are-not-a-parallel-workflow.md
+++ b/website/content/blog/en/terminal-windows-are-not-a-parallel-workflow.md
@@ -1,0 +1,79 @@
+---
+title: "Myth: A Few More Terminal Windows = a Parallel Agent Workflow"
+description: "Four terminal windows, four agents — looks like parallelism. But windows only put characters on a screen. They don't give you file isolation, session recovery, or a review path, and those are the three places it actually blows up."
+date: 2026-08-07
+publishAt: 2026-08-07T00:00:00+08:00
+slug: terminal-windows-are-not-a-parallel-workflow
+tags:
+  [
+    parallel agents,
+    git worktrees,
+    agent orchestration,
+    agentic IDE,
+    Superset,
+    Orca,
+    JetBrains Air,
+    Claude Code,
+    Codex,
+    agent workstation,
+    terminal workstation,
+  ]
+---
+
+## "Just open a few more windows, right?"
+
+"What's so hard about running agents in parallel? Open a few terminal windows, one Claude Code per window, done."
+
+This is the most popular take on parallel AI coding, and the most expensive one. It equates a parallel workflow with windows sitting side by side — and between those two things sit three failure modes that actually explode.
+
+## Why it looks right
+
+Because windows do solve one problem: visibility.
+
+Tile four windows, and every agent's output is on screen. For a single agent, a terminal window is even the whole truth — CLI agents live in the terminal anyway. So the intuition extrapolates: one agent, one window; N agents, N windows.
+
+For the first hour, the equation almost holds. The trouble starts after the first hour.
+
+## The three places it blows up
+
+**One, files trample each other.** Four windows `cd`'d into the same repo means four agents sharing one working copy and one git index. Superset's [parallel guide](https://superset.sh/blog/parallel-coding-agents-guide) puts it bluntly: even when two agents edit different files, a shared git index means their commits can sweep up each other's unfinished changes. The windows are separate. The filesystem isn't.
+
+**Two, sessions die.** Laptop lid closes, a window gets closed by accident, a system update reboots the machine — the terminal session dies and the context dies with it. With one agent that's annoying. With four it's a disaster: which window was fixing the bug, how far it got, what the next step was — no window remembers any of this for you. Your brain does, and your brain is also supposed to be writing code.
+
+**Three, review hell.** The agent says it's done, and the changes are scattered across four windows and four branches — assuming you remembered to cut a branch per window at all. So you bounce between terminals, a git tool, and your editor, reassembling "who changed which files, for which task." The time parallelism saved gets paid back right here.
+
+And one more thing, for free: windows only solve half of "visibility" anyway. You can see characters, not state. A finished agent and a stuck agent can look identical on screen. That's its own topic — we took it apart in [How Do You Know Your Agent Is Done?](/blog/how-do-you-know-your-agent-is-done).
+
+## The minimum correct setup
+
+Fill those three holes and you get a minimum viable checklist — four items:
+
+- **One isolated working copy per task.** Use git worktrees: separate directory, separate branch, separate index, shared object store, created in seconds.
+- **Sessions outlive windows.** Close the window, restart, come back tomorrow — terminal history and agent context are still where you left them.
+- **Completion comes to you.** A status signal or notification polls for you, instead of you cycling through windows every two minutes.
+- **Diffs land in one place.** One glance decides merge, fix, or discard — no app-hopping in between.
+
+Notice that none of the four is "open more windows." Windows are the display layer. A workflow is the state layer.
+
+## 2code makes the checklist cheap
+
+You can assemble all four yourself: tmux for sessions, scripts for worktrees, some app for diffs. It works — and then you maintain the assembly itself.
+
+2code is a terminal emulator, with the difference that the checklist is the default configuration: creating a profile runs `git worktree add` for you, with setup commands in the project's `2code.json`; terminal sessions, scrollback, and window layout come back after a restart; agent state is read off the terminal output — a green dot when it's done, a yellow dot plus a sound when it's waiting on your call; built-in git diff and history keep review inside the same window.
+
+We call it an **agent workstation**: one task, one desk, with its own worktree, terminal, and agent — you walk over to accept the work.
+
+## Try it
+
+If your current "parallel" is four Terminal.app windows plus a good memory, there's a different way to spend the afternoon:
+
+```bash
+brew install --cask akarachen/tap/2code
+```
+
+- Website: <https://2code.akr.moe/>
+- GitHub: <https://github.com/AkaraChen/2code> — open source, issues and stars welcome
+- Latest release: <https://github.com/AkaraChen/2code/releases/latest>
+- Further reading: [Git Worktrees as Agent Workstations: One Day in Parallel](/blog/worktree-as-agent-workstations) · [How Do You Know Your Agent Is Done?](/blog/how-do-you-know-your-agent-is-done)
+
+More windows isn't wrong — it's the starting point. But the workflow starts beyond the windows: isolation, recovery, notification, and a review path that doesn't require archaeology.

--- a/website/content/blog/zh-cn/terminal-windows-are-not-a-parallel-workflow.md
+++ b/website/content/blog/zh-cn/terminal-windows-are-not-a-parallel-workflow.md
@@ -1,0 +1,81 @@
+---
+title: "误区：多开几个终端窗口 = 并行 Agent 工作流"
+description: "开四个终端窗口跑四个 agent，看起来就是并行了。但窗口只解决「字符看得见」，不解决文件隔离、会话恢复和 review——这三件事才会真的炸。"
+date: 2026-08-07
+publishAt: 2026-08-07T00:00:00+08:00
+slug: terminal-windows-are-not-a-parallel-workflow
+tags:
+  [
+    误区,
+    并行 Agent,
+    git worktrees,
+    parallel coding agents,
+    agent orchestration,
+    Agentic IDE,
+    Superset,
+    Orca,
+    JetBrains Air,
+    Claude Code,
+    Codex,
+    Agent 工位,
+    终端工作站,
+  ]
+---
+
+## 「多开几个窗口，不就并行了？」
+
+「并行跑 agent 有什么难的？多开几个终端窗口，一个窗口一个 Claude Code，搞定。」
+
+这是关于并行 AI 编程最流行的判断，也是最贵的一个。它把「并行工作流」和「并排的窗口」划上了等号，而这两者之间隔着三件会爆炸的事。
+
+## 为什么它看起来像那么回事
+
+因为窗口确实解决了一个问题：看得见。
+
+四个窗口铺开，每个 agent 的输出都在屏幕上。对单个 agent 来说，终端窗口甚至就是全部真相——CLI agent 本来就长在终端里。于是直觉外推：一个 agent 一个窗口，N 个 agent N 个窗口。
+
+头一个小时，这个等式几乎成立。问题出在第一个小时之后。
+
+## 真正会炸的三个点
+
+**一、文件互相踩。** 四个窗口 `cd` 进同一个仓库，等于四个 agent 共用一份工作副本、一个 git 暂存区。Superset 的[并行指南](https://superset.sh/blog/parallel-coding-agents-guide)写得很直白：哪怕两个 agent 改的是不同文件，共享的 git index 也会让提交裹进彼此没改完的东西。窗口是分开的，文件系统不是。
+
+**二、丢会话。** 笔记本合盖、手滑关了窗口、系统更新重启，终端会话一死，上下文跟着死。一个 agent 时这叫烦人，四个 agent 时这叫灾难：哪个窗口在修 bug、跑到哪一步、接下来要干嘛，窗口从来不替你记，全靠你的脑子——而你的脑子同时还要用来写代码。
+
+**三、review 地狱。** Agent 说改完了，改动散在四个窗口、四条分支里——如果你还记得给每个窗口切分支的话。于是你在终端、git 工具、编辑器之间来回切，把「谁改了哪些文件、为了哪件事」重新拼出来。并行省下的时间，在这里又还了回去。
+
+顺带一提，窗口连「看得见」也只解决了一半：你能看见字符，看不见状态。一个跑完的 agent 和一个卡住的 agent，在屏幕上可以长得一模一样。这块是另一个话题，我们在[《Agent 跑完了，你怎么知道？》](/zh-cn/blog/how-do-you-know-your-agent-is-done)里单独拆过。
+
+## 最小正确做法
+
+把上面三个坑填上，就得到一份最小正确做法清单，四条：
+
+- **一个任务一份隔离的工作副本。** 用 git worktree：独立目录、独立分支、独立暂存区，共享对象库，建一个只要几秒。
+- **会话比窗口活得久。** 关窗、重启、第二天再开，终端历史和 agent 上下文还在原地。
+- **完成主动来找你。** 状态标识或通知替你轮询，而不是你每两分钟切一圈。
+- **diff 收进一处。** 扫一眼决定合、改还是丢，中间不跨 App。
+
+注意，四条里没有一条是「开更多窗口」。窗口是显示层，工作流是状态层。
+
+## 2code 把这张清单做便宜
+
+这四条你自己也拼得出来：tmux 管会话，脚本管 worktree，再找个 App 看 diff。能跑，但你要维护这套拼装本身。
+
+2code 是一个终端模拟器，区别是它把清单做成了默认配置：建 profile 时自动 `git worktree add`，初始化命令写在项目根的 `2code.json` 里；终端会话、scrollback 和窗口布局重启后恢复；agent 状态从终端输出里识别，跑完亮绿点，等你拍板时黄点加一声提示音；内置 git diff 和提交历史，review 不用离开窗口。
+
+英文里这叫 workstation，中文我们叫它 **agent 工位**：一个任务一张桌子，桌上是独立的 worktree、终端和 agent，你走过来验收。
+
+## 试一下
+
+如果你现在的「并行」是四个 Terminal.app 窗口加一个好记性，可以换一种过法：
+
+```bash
+brew install --cask akarachen/tap/2code
+```
+
+- 官网：<https://2code.akr.moe/>（[中文](https://2code.akr.moe/zh-cn)）
+- GitHub：<https://github.com/AkaraChen/2code> — 开源，欢迎 issue 和 star
+- 最新版本：<https://github.com/AkaraChen/2code/releases/latest>
+- 延伸阅读：[用 Worktree 当 Agent 工位：我的一天并行工作流](/zh-cn/blog/worktree-as-agent-workstations) · [Agent 跑完了，你怎么知道？](/zh-cn/blog/how-do-you-know-your-agent-is-done)
+
+多开窗口不是错，它是起点。但工作流从窗口之外开始：隔离、恢复、通知，和一条不用考古的 review 路径。


### PR DESCRIPTION
误区短文系列 #1/3（KIT-439）。

新增中英双语博客文章，反驳「多开几个终端窗口 = 并行 agent 工作流」：

- `website/content/blog/zh-cn/terminal-windows-are-not-a-parallel-workflow.md`（正文 990 字，符合 600–1200 验收）
- `website/content/blog/en/terminal-windows-are-not-a-parallel-workflow.md`

结构按选题卡：误区原话 → 为什么像那么回事 → 三个会炸的点（文件互相踩 / 丢会话 / review 地狱）→ 最小正确做法四条清单 → 2code 如何降低清单成本 → CTA。

- slug: `terminal-windows-are-not-a-parallel-workflow`
- publishAt: 2026-08-07 00:00 +08（接在 08-05 两篇之后）
- 术语沿用已定的「agent 工位 / 任务线」，正文内链到工位一天和通知两篇旧文
- 本地 `BLOG_INCLUDE_SCHEDULED=1 bun run build` 通过，两条新路由均正常预渲染
