### PR TITLE
docs(website): 博客《我们如何用 Tauri 做终端工作站》中英双语

### DIFF
--- a/website/content/blog/en/building-a-terminal-workstation-with-tauri.md
+++ b/website/content/blog/en/building-a-terminal-workstation-with-tauri.md
@@ -1,0 +1,140 @@
+---
+title: How We Built a Terminal Workstation with Tauri
+description: A tour of 2code's stack — Tauri 2, React 19, a four-crate Rust workspace, xterm.js — and why PTY output moved out of SQLite into plain files.
+date: 2026-08-06
+publishAt: 2026-08-06T09:00:00+08:00
+slug: building-a-terminal-workstation-with-tauri
+tags:
+  [
+    Tauri,
+    Tauri 2,
+    Rust,
+    Electron,
+    xterm.js,
+    PTY,
+    terminal emulator,
+    React,
+    open source,
+    git worktree,
+    terminal workstation,
+  ]
+---
+
+2code is an open-source desktop terminal workstation: terminals, AI CLI agents, Git, and worktree lanes living in one app. This post is its engineering anatomy — how we picked the stack, how we solved the three hardest problems in the terminal layer, and where we're still fighting bugs. Every path mentioned links into [the repo](https://github.com/AkaraChen/2code) so you can read along.
+
+## Module boundaries first
+
+```text
+┌─────────────────────────────────────────────────┐
+│ Frontend src/ (React 19 + xterm.js)              │
+│   features/terminal — rendering, agent detection │
+├─────────────────────────────────────────────────┤
+│ IPC: #[tauri::command] + Channel<&[u8]>          │
+│   src-tauri/src/handler — ~70 command entries    │
+│   src-tauri/src/bridge  — service trait impls    │
+├─────────────────────────────────────────────────┤
+│ Rust workspace (src-tauri/crates/)               │
+│   service — session lifecycle, reader threads    │
+│   infra   — PTY, git, log files, DB init         │
+│   repo    — Diesel CRUD                          │
+│   model   — DTOs, schema, error types            │
+├─────────────────────────────────────────────────┤
+│ Storage: app.db (SQLite, WAL) + pty_logs/*.log   │
+└─────────────────────────────────────────────────┘
+```
+
+Three design decisions worth expanding:
+
+**The service crate doesn't know Tauri exists.** [service](https://github.com/AkaraChen/2code/tree/dev/src-tauri/crates/service) defines two traits, `PtyEventEmitter` and `WatchEventSender`, which the app layer implements in `bridge.rs`. Business logic runs under plain `cargo test`, and "which layer may touch what" is enforced at compile time.
+
+**The DB stores metadata only.** Four tables — projects, project_groups, profiles, pty_sessions — and not a single byte of terminal output. There's a war story about why, further down.
+
+**The frontend never hand-writes IPC clients.** After adding a Rust command you run `cargo tauri-typegen generate` and `src/generated/` updates itself. Hand-written clients are banned in the README because they inevitably drift from the Rust signatures.
+
+## Why Tauri instead of Electron
+
+To be clear: this isn't a benchmark shootout. It's the reasoning I used at the time, and three points still hold up.
+
+**One: the heavy part of this app is the backend.** PTY management, git subprocesses, file watching, shell-injection scripts — the Rust side of 2code isn't "an API for the frontend", it's a real systems program. Rust is the natural home for that layer: [portable-pty](https://crates.io/crates/portable-pty) for pseudo-terminals, [notify](https://crates.io/crates/notify) for file watching, and no async runtime at all — tokio only shows up with its `sync` feature for channels, and the reader threads are plain `std::thread`. With Electron, that layer would be Node, and you'd be back to fighting node-pty's native module builds and distribution. Choosing Tauri meant putting the hardest layer in the language best suited to it.
+
+**Two: no bundled Chromium.** Using the system webview makes the installer and the resident memory an order of magnitude smaller. The cost is a "webview variance tax": three platforms, three rendering engines, subtly different behavior. We've paid that tax — details in the war stories below.
+
+**Three: the permission model.** Tauri 2 [capabilities](https://github.com/AkaraChen/2code/blob/dev/src-tauri/capabilities/default.json) let us narrow permissions down to "may execute `open` / `explorer` / `xdg-open`, with argument validation". For an app whose day job is spawning processes on your behalf, encoding the attack surface in a config file is a real security win.
+
+One more nicety at the IPC layer: terminal output rides on Tauri's `Channel`, one independent byte stream per session — no hand-rolled multiplexing over the event bus.
+
+## Hard problem 1: getting shells to behave in a PTY
+
+Spawning a PTY is easy — portable-pty does it in a dozen lines. The hard part is shell integration: we want events like "a command started here, ended there, exited with this code, cwd is now this", because the title bar and status detection depend on them.
+
+So we stand on VS Code's shoulders. Its [shell integration](https://code.visualstudio.com/docs/terminal/shell-integration) scripts are MIT-licensed; we embed them in the binary ([shell_init.rs](https://github.com/AkaraChen/2code/blob/dev/src-tauri/crates/infra/src/shell_init.rs)) and inject per shell: `--init-file` for bash, a swapped `ZDOTDIR` for zsh, `--init-command` for fish, `-NoExit -Command` for PowerShell. Then we set `TERM_PROGRAM=vscode` so the scripts believe they live inside a VS Code terminal and work as designed. 2code's own init scripts stay minimal on purpose — no agent wrappers, no PATH edits.
+
+## Hard problem 2: the output pipeline, and why it left SQLite
+
+This is my favorite war story.
+
+In the first version, terminal output went into SQLite. Then [a migration dated 2026-07-01](https://github.com/AkaraChen/2code/tree/dev/src-tauri/migrations) dropped the whole `pty_session_output` table, and output moved to files: `pty_logs/{session_id}.log`.
+
+The reason is physical. The DB is a single global connection (`Arc<Mutex<SqliteConnection>>`), and one chatty session — say, a scrolling `cargo build` — queues up write transactions until every other session's metadata writes are stuck behind the lock. Terminal write volume and relational-database write volume are different species; force them together and the mutex becomes the single point of failure.
+
+The pipeline today: one reader thread per session pulls 4 KB chunks and splits them two ways. One way goes straight to the frontend over `Channel<&[u8]>` for rendering; the other crosses a channel to a dedicated persistence thread that flushes to disk every 32 KB or 250 ms. Rendering and disk never block each other, and the DB only shows up when a session is created, renamed, or closed.
+
+## Hard problem 3: switching tabs must not kill the session
+
+Once an xterm.js instance unmounts, its canvas state is gone; what mounts again is a brand-new terminal — scrollback and any running TUI program destroyed. So 2code has an iron rule written in the [terminal module's AGENTS.md](https://github.com/AkaraChen/2code/blob/dev/src/features/terminal/AGENTS.md): **Never unmount terminals**. It lands as three layers of defense:
+
+1. **TerminalLayer**: every lane's terminals render inside a persistent overlay; inactive lanes get `display: none`.
+2. **TerminalTabs**: tabs within a lane are stacked with absolute positioning; inactive ones get `visibility: hidden`.
+3. **Parking**: when React 19's ref-cleanup ordering really does unmount a component whose tab is still open, the xterm DOM node is moved into an off-screen `#terminal-parking` container (`left/top: -9999px`) instead of being disposed. The trick is borrowed from VS Code's `setVisible(false)`.
+
+A supporting detail: every mount generates a fresh `stream_id`, so cleanup left over from the previous mount can't kill the new stream.
+
+What about restarting the app? The sessions really are dead then. Restore comes in a hot path and a cold path. Hot, on the Rust side: replay the log file through a [vt100](https://crates.io/crates/vt100) emulator — 10,000 lines of scrollback, alternate screen stripped so vim's ghost doesn't smear into history — spawn a fresh PTY, replay the "scene" onto the screen, and swap in a new session row. Cold, on the frontend: each session caches 1,000 serialized lines in localStorage, so a "looks-right" terminal appears instantly, then gets byte-level overlap de-duplication against the hot history.
+
+## Worktree lanes: Git and UI each own half
+
+A lane (profile) has its lifecycle orchestrated by the service crate: `git worktree add -b` creates the working copy, a `profiles` row lands, and the `setup_script` from your `2code.json` (say, `bun i`) runs inside the worktree. Paths follow a small convention: `~/.2code/workspace/{project}-{branch}-{8-char id}`, with CJK branch names transliterated to pinyin first. If you can't be bothered naming a branch, you get `pr/{city}-{8 hex}` — tokyo, osaka, seoul, and friends on rotation.
+
+Deletion runs the sequence backwards: `teardown_script` → `git worktree remove --force` → `git branch -D` → DB foreign keys cascade the session rows away. Create and delete are both whole-operation affairs; no half-finished state left behind.
+
+`init_script` takes a different route: it doesn't belong to the worktree flow but gets spliced into every new terminal's shell injection, so the env vars and aliases you put there apply to all of the lane's terminals.
+
+On the UI side, the state collaboration is mostly agent detection: a rule engine living entirely in the frontend, with 18 agent rule manifests under [detector/rules](https://github.com/AkaraChen/2code/tree/dev/src/features/terminal/detector/rules) — Claude Code, Codex, Gemini, Kimi, and more. Three inputs: xterm screen text, OSC window titles, and OSC 9;4 progress sequences, evaluated every 250 ms, translating working / blocked / idle into the green dot and the sound on your tabs. We covered the product logic in [How Do You Know Your Agent Is Done?](/blog/how-do-you-know-your-agent-is-done) and the daily lane workflow in [Worktrees as Agent Workstations](/blog/worktree-as-agent-workstations); here it's just about where the code lives.
+
+## War stories and the experimental bits
+
+The README's first screen says macOS is the primary platform and Windows/Linux are experimental. That's not politeness:
+
+- **macOS WebKit has a font-metrics trap.** When the canvas xterm uses to measure character widths isn't attached to the DOM, WebKit returns wrong metrics and the cursor drifts. The fix patches its measurement surfaces ([xtermMetricsPatch.ts](https://github.com/AkaraChen/2code/blob/dev/src/features/terminal/lib/xtermMetricsPatch.ts)). That's the webview variance tax — Electron users don't pay it, but you only pay it once.
+- **Windows has opinions.** No native window decorations, so the title bar is frontend-drawn; subprocesses go through `command_without_windows_console` or every command flashes a console window; startup commands need a one-second sleep, a `\x1b[1;1R`, and `\r` line endings. ConPTY homework — everyone building terminals has to do it.
+- **Linux odds and ends.** Sound goes through canberra / paplay, font enumeration through fontdb. The only cross-platform gate in CI is an Ubuntu 24.04 + xvfb smoke test — which at least guarantees Linux boots the app and opens a terminal.
+
+## Run it locally
+
+```bash
+git clone https://github.com/AkaraChen/2code.git
+cd 2code
+bun install
+bun tauri dev      # full desktop app with hot reload on both ends
+```
+
+Other usual suspects: `bun run dev` for the frontend only; `cd src-tauri && cargo test` for the Rust tests; `just verify` to run lint, typecheck, and all tests in one go. After changing a Rust command, remember `cargo tauri-typegen generate` to regenerate the frontend bindings.
+
+## Where to contribute
+
+There's no CONTRIBUTING.md yet, but a few things serve better:
+
+- **[The AGENTS.md series](https://github.com/AkaraChen/2code/blob/dev/AGENTS.md)**: one overview at the root, plus dedicated files for terminal, src-tauri, handler, and e2e. They're named for coding agents, but they're the best map of the codebase for humans too.
+- **[openspec/specs](https://github.com/AkaraChen/2code/tree/dev/openspec/specs)**: 13 feature specs — PTY management, terminal tabs, lanes, and more. Read them before changing behavior.
+- **[plans/](https://github.com/AkaraChen/2code/tree/dev/plans)**: 28 confirmed optimization plans from a performance audit, plus 5 rejected ones with benchmarks. If you want a good first issue, this is a ready-made list, and every plan ships its own measurements.
+- **[detector/rules](https://github.com/AkaraChen/2code/tree/dev/src/features/terminal/detector/rules)**: your favorite agent missing from the 18? Adding one rule file is a complete contribution.
+
+Windows and Linux polish is permanently welcome — the flip side of "experimental" is that there's a reachable problem everywhere.
+
+## Wrapping up
+
+2code is open source on GitHub: <https://github.com/AkaraChen/2code> — stars, issues, and PRs all welcome. Or just try it:
+
+```bash
+brew install --cask akarachen/tap/2code
+```

--- a/website/content/blog/zh-cn/building-a-terminal-workstation-with-tauri.md
+++ b/website/content/blog/zh-cn/building-a-terminal-workstation-with-tauri.md
@@ -1,0 +1,140 @@
+---
+title: 我们如何用 Tauri 做终端工作站
+description: 2code 的栈是 Tauri 2 + React 19 + Rust workspace + xterm.js。这篇讲清四个 crate 的分工、终端 tab 永不卸载的三层防护、PTY 输出为什么从 SQLite 搬进文件，以及 Windows 上踩过的坑。
+date: 2026-08-06
+publishAt: 2026-08-06T09:00:00+08:00
+slug: building-a-terminal-workstation-with-tauri
+tags:
+  [
+    Tauri,
+    Tauri 2,
+    Rust,
+    Electron,
+    xterm.js,
+    PTY,
+    终端模拟器,
+    React,
+    开源,
+    git worktree,
+    终端工作站,
+  ]
+---
+
+2code 是一个开源的桌面终端工作站：终端、AI CLI agent、git、worktree 泳道待在同一个 App 里。这篇是它的工程解剖——技术栈怎么选的，终端这层最难的三个问题怎么解的，哪些地方还在踩坑。所有提到的路径都能点进[仓库](https://github.com/AkaraChen/2code)对照着看。
+
+## 先看模块边界
+
+```text
+┌─────────────────────────────────────────────────┐
+│ 前端 src/（React 19 + xterm.js）                 │
+│   features/terminal — 渲染、agent 检测、tab 状态 │
+├─────────────────────────────────────────────────┤
+│ IPC：#[tauri::command] + Channel<&[u8]>          │
+│   src-tauri/src/handler — 七十来个命令入口       │
+│   src-tauri/src/bridge  — service trait 的实现   │
+├─────────────────────────────────────────────────┤
+│ Rust workspace（src-tauri/crates/）              │
+│   service — 会话生命周期、读线程、泳道编排       │
+│   infra   — PTY、git、日志文件、DB 初始化        │
+│   repo    — Diesel CRUD                         │
+│   model   — DTO、schema、错误类型                │
+├─────────────────────────────────────────────────┤
+│ 存储：app.db（SQLite，WAL）+ pty_logs/*.log      │
+└─────────────────────────────────────────────────┘
+```
+
+三个值得展开的设计决定：
+
+**service 不认识 Tauri。** [service crate](https://github.com/AkaraChen/2code/tree/dev/src-tauri/crates/service) 定义了 `PtyEventEmitter`、`WatchEventSender` 两个 trait，由 app 层的 `bridge.rs` 在 Tauri 侧实现。业务逻辑因此可以脱离桌面壳跑 `cargo test`，也让「哪一层能碰什么」在编译期就钉死了。
+
+**DB 只存元数据。** projects、project_groups、profiles、pty_sessions 四张表，终端输出一个字节都不进 SQLite。为什么，后面有一个翻车故事专门讲。
+
+**前端不手写 IPC client。** Rust 侧加完 command，跑 `cargo tauri-typegen generate`，`src/generated/` 自动更新。README 把「手写 API client」列为禁止事项，因为手写一定会和 Rust 签名漂移。
+
+## 为什么是 Tauri，不是 Electron
+
+先说清楚：这不是 benchmark 对比文，是我当时的选型理由。回头看，依然成立的有三条。
+
+**一、这个 App 的重头在后端。** PTY 管理、git 子进程、文件监听、shell 注入脚本——2code 的 Rust 侧不是「给前端当 API」，它是一个真的系统程序。这一层用 Rust 写最顺：[portable-pty](https://crates.io/crates/portable-pty) 管伪终端，[notify](https://crates.io/crates/notify) 管文件监听，连 async runtime 都没请，tokio 只开了 `sync` feature 借个 channel，读线程就是朴素的 `std::thread`。如果用 Electron，这一层就得用 Node 写，然后绕回 node-pty 原生模块的编译和分发问题。选 Tauri，等于把最难的一层放进最擅长的语言。
+
+**二、不打包 Chromium。** 用系统 webview，安装包和常驻内存都小一个量级。代价是「webview 差异税」：三个平台三种渲染内核，行为不完全一致。这个税我们真交过，踩坑一节细说。
+
+**三、权限模型。** Tauri 2 的 [capabilities](https://github.com/AkaraChen/2code/blob/dev/src-tauri/capabilities/default.json) 可以把权限收窄到「只允许执行 `open` / `explorer` / `xdg-open`，且参数要过校验」。对一个本职工作是「替你起进程」的 App 来说，能把攻击面写进配置文件，是实际的安全收益。
+
+IPC 层还有个顺手的点：终端输出走 Tauri 的 `Channel`，每个会话一条独立的字节流，不用在事件总线上自己拼多路复用。
+
+## 难点一：把 shell 老老实实塞进 PTY
+
+spawn 一个 PTY 本身不难，portable-pty 十几行代码的事。真正麻烦的是 shell integration：我们想拿到「命令从哪开始、到哪结束、退出码多少、cwd 在哪」这些事件，标题栏和状态检测都靠它们。
+
+做法是站在 VS Code 肩上。VS Code 的 [shell integration](https://code.visualstudio.com/docs/terminal/shell-integration) 脚本是 MIT 协议的，我们把它们嵌进二进制（[shell_init.rs](https://github.com/AkaraChen/2code/blob/dev/src-tauri/crates/infra/src/shell_init.rs)），按 shell 类型注入：bash 给 `--init-file`，zsh 换掉 `ZDOTDIR`，fish 用 `--init-command`，PowerShell 走 `-NoExit -Command`。再把 `TERM_PROGRAM` 设成 `vscode`，脚本就以为自己活在 VS Code 终端里，照常工作。2code 自己的初始化脚本保持极简，不装 agent wrapper，不动 PATH。
+
+## 难点二：输出管道，为什么从 SQLite 搬进文件
+
+这是我最喜欢讲的翻车故事。
+
+最早的版本，终端输出是进 SQLite 的。后来 [2026-07-01 的一个 migration](https://github.com/AkaraChen/2code/tree/dev/src-tauri/migrations) 把 `pty_session_output` 整张表删了，输出改成写文件：`pty_logs/{session_id}.log`。
+
+原因很物理。DB 是全局单连接（`Arc<Mutex<SqliteConnection>>`），一个话痨会话，比如 `cargo build` 刷屏，会把写事务排成长队，其他会话的元数据写入全部堵在锁后面。终端的写入量级和关系数据库的写入量级不是一个物种，硬塞在一起，锁就是单点。
+
+现在的管道长这样：每个会话一个读线程，4 KB 一块读出来，兵分两路。一路经 `Channel<&[u8]>` 直推前端渲染；另一路过 channel 交给专门的持久化线程，攒够 32 KB 或 250 ms 落一次盘。前端和磁盘互不阻塞，DB 只在会话创建、改名、关闭时露面。
+
+## 难点三：切 tab 不能丢会话
+
+xterm.js 的实例一旦 unmount，canvas 状态就没了，再挂回来的是一个崭新的终端，滚动历史、进行中的 TUI 程序全废。所以 2code 有条铁律写在 [terminal 模块的 AGENTS.md](https://github.com/AkaraChen/2code/blob/dev/src/features/terminal/AGENTS.md) 里：**Never unmount terminals**。落地是三层防护：
+
+1. **TerminalLayer**：所有泳道的终端渲染在一个常驻 overlay 里，不活跃的泳道 `display: none`。
+2. **TerminalTabs**：同一泳道里的多个 tab 绝对定位叠放，不活跃的 `visibility: hidden`。
+3. **停车**：React 19 的 ref cleanup 时序下，组件真的被卸载而 tab 还开着时，把 xterm 的 DOM 节点挪到屏幕外的 `#terminal-parking` 容器（`left/top: -9999px`），而不是 dispose。这个手法借自 VS Code 的 `setVisible(false)`。
+
+配套细节：每次挂载生成新的 `stream_id`，上一次卸载留下的清理逻辑就不会把新流掐掉。
+
+那重启 App 呢？会话毕竟是真的死了。恢复分冷热两路。热路在 Rust 侧：拿日志文件过一遍 [vt100](https://crates.io/crates/vt100) 模拟器，一万行 scrollback，剥掉 alternate screen（不然 vim 的残影会糊进历史），起一个新 PTY，把「现场」回放到屏幕上，session 表里换一条新记录。冷路在前端：每个会话在 localStorage 里缓存了 1000 行序列化结果，先秒开一个「看起来像」的终端，再和热历史做字节级 overlap 去重。
+
+## Worktree 泳道：git 和 UI 各管一段
+
+泳道（profile）的生命周期由 service crate 编排：`git worktree add -b` 建工作副本，落一行 `profiles` 表，然后在 worktree 里跑你在 `2code.json` 里写的 `setup_script`（比如 `bun i`）。路径有个小约定：`~/.2code/workspace/{项目}-{分支}-{8 位 id}`，分支名是中文就先转拼音；懒得想名字的，自动生成 `pr/{城市}-{8 位 hex}`，tokyo、osaka、seoul 轮着来。
+
+删除反着来一遍：`teardown_script` → `git worktree remove --force` → `git branch -D` → DB 外键级联清掉会话记录。建和删都是全仓操作，不留半截状态。
+
+`init_script` 走另一条路：它不进 worktree 流程，而是拼进每个新终端的 shell 注入里。你写在里面的环境变量和 alias，对该泳道所有终端生效。
+
+UI 这边的状态协作主要是 agent 检测。一个纯前端的规则引擎，[detector/rules](https://github.com/AkaraChen/2code/tree/dev/src/features/terminal/detector/rules) 下目前有 18 个 agent 的规则清单：Claude Code、Codex、Gemini、Kimi……输入有三种——xterm 屏幕文本、OSC 窗口标题、OSC 9;4 进度序列，每 250 ms 跑一轮，把 working / blocked / idle 翻译成标签页上的绿点和提示音。这套机制的产品逻辑在[《Agent 跑完了，你怎么知道？》](/zh-cn/blog/how-do-you-know-your-agent-is-done)里讲过，泳道的日常用法在[《用 Worktree 当 Agent 工位》](/zh-cn/blog/worktree-as-agent-workstations)里，这篇只说实现位置。
+
+## 踩坑与还在实验的部分
+
+README 第一屏就写着 macOS 是主平台、Windows 和 Linux 是实验支持，这不是客套：
+
+- **macOS WebKit 的字体度量有个坑。** xterm 用来量字符宽度的 canvas 如果没 attach 到 DOM，WebKit 返回的度量是错的，光标位置整体漂移。解法是 patch 掉它的测量面（[xtermMetricsPatch.ts](https://github.com/AkaraChen/2code/blob/dev/src/features/terminal/lib/xtermMetricsPatch.ts)）。这就是前面说的 webview 差异税，Electron 用户不用交，但交完也就这一次。
+- **Windows 的脾气。** 没有原生窗口装饰，标题栏是前端自绘的；起子进程要过一道 `command_without_windows_console`，不然每跑一条命令闪一个黑窗；启动命令还得先睡一秒、发个 `\x1b[1;1R`、换行用 `\r`。ConPTY 的功课，做终端的都躲不掉。
+- **Linux 的边角。** 声音提示走 canberra / paplay，字体枚举换 fontdb。CI 里唯一跨平台的守门员是一条 Ubuntu 24.04 + xvfb 的冒烟测试——至少保证 Linux 能起得来、开得了终端。
+
+## 本地跑起来
+
+```bash
+git clone https://github.com/AkaraChen/2code.git
+cd 2code
+bun install
+bun tauri dev      # 完整桌面 App，前后端热更新
+```
+
+其他常用命令：`bun run dev` 只起前端；`cd src-tauri && cargo test` 跑 Rust 测试；`just verify` 把 lint、类型检查、前后端测试一把跑完。改了 Rust command 记得 `cargo tauri-typegen generate` 重新生成前端绑定。
+
+## 欢迎贡献的方向
+
+仓库里暂时没有 CONTRIBUTING.md，但有几样东西比它管用：
+
+- **[AGENTS.md 系列](https://github.com/AkaraChen/2code/blob/dev/AGENTS.md)**：根目录一份总图，terminal、src-tauri、handler、e2e 各有专题。名字是写给 coding agent 的，对人同样是最好的代码地图。
+- **[openspec/specs](https://github.com/AkaraChen/2code/tree/dev/openspec/specs)**：13 份功能 spec，PTY 管理、终端 tab、泳道……改行为之前先读它。
+- **[plans/](https://github.com/AkaraChen/2code/tree/dev/plans)**：一次性能审计留下的 28 个已确认优化方案，外加 5 个带 benchmark 的否决记录。想找 good first issue，这就是现成清单，每个方案自带测量数据。
+- **[detector/rules](https://github.com/AkaraChen/2code/tree/dev/src/features/terminal/detector/rules)**：你常用的 agent 不在 18 个里面？加一个规则文件就是一次完整贡献。
+
+Windows 和 Linux 的打磨也长期欢迎。实验支持的另一面，是到处都有够得着的问题。
+
+## 最后
+
+2code 开源在 GitHub：<https://github.com/AkaraChen/2code>，star、issue、PR 都欢迎。想先用起来：
+
+```bash
+brew install --cask akarachen/tap/2code
+```


### PR DESCRIPTION
## 内容

新增博客《我们如何用 Tauri 做终端工作站》，中英双语：

- `website/content/blog/zh-cn/building-a-terminal-workstation-with-tauri.md`
- `website/content/blog/en/building-a-terminal-workstation-with-tauri.md`

工程向选题（KIT-437），面向 Rust / Tauri / 终端爱好者与潜在贡献者，转化目标是 GitHub star / contribute。

文章要点：

- 模块边界图：前端 → handler/bridge → 四个 crate（service / infra / repo / model）→ SQLite + pty_logs 文件
- 为什么选 Tauri 而不是 Electron（后端重量、系统 webview、capabilities 权限模型）
- 三个终端难点：shell integration 注入、输出管道从 SQLite 搬到文件（`pty_session_output` 删表始末）、tab 切换不丢会话的三层防护（display:none / visibility / terminal parking）
- worktree 泳道生命周期与 `2code.json` 约定、18 个 agent 检测规则
- 踩坑实录：WebKit 字体度量 patch、Windows ConPTY 三件套、Linux 声音与冒烟 CI
- 本地 dev 命令 + 贡献入口（AGENTS.md 系列 / openspec specs / plans 性能清单 / detector rules）

所有技术细节对照仓库逐条核实（crate 分工、常量数值、migrations、AGENTS.md 规则原文），仓库内链接统一指向 `dev` 分支具体路径；系列内链接到通知篇与 worktree 篇。

排期 `publishAt: 2026-08-06T09:00:00+08:00`，接在 08-05 两篇之后。

## 验证

- `bun run lint` 无 error
- `bun run build` 通过，默认构建正确把排期文章排除在外
- `BLOG_NOW=2026-08-07 bun run build` 下中英两条路由均生成，sitemap 含新 slug，预渲染 HTML 标题与正文抽查无误
