### PR TITLE
KIT-651: resize all profile sidebar panels

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -154,7 +154,7 @@
 	"radiusXLarge": "Extra Large",
 	"changes": "Changes",
 	"history": "History",
-	"fileTreeResizeSeparator": "Resize file tree",
+	"profileSidebarResizeSeparator": "Resize sidebar",
 	"sidebarFilesTab": "Files",
 	"sidebarGitTab": "Git",
 	"gitOpenDiffView": "Open diff view",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -154,7 +154,7 @@
 	"radiusXLarge": "超大",
 	"changes": "变更",
 	"history": "历史",
-	"fileTreeResizeSeparator": "调整文件树宽度",
+	"profileSidebarResizeSeparator": "调整侧边栏宽度",
 	"sidebarFilesTab": "文件",
 	"sidebarGitTab": "Git",
 	"gitOpenDiffView": "打开差异视图",

--- a/src/features/projects/FileTreePanel.tsx
+++ b/src/features/projects/FileTreePanel.tsx
@@ -20,15 +20,13 @@ import {
   useEffect,
   useMemo,
   useReducer,
-  useRef,
-  useState } from
+  useRef } from
 "react";
 import {
   DropdownMenuItem,
   DropdownMenuSeparator } from
 "@/components/ui/dropdown-menu";
 import * as m from "@/paraglide/messages.js";
-import { useHorizontalResize } from "@/shared/hooks/useHorizontalResize";
 import { copyTextToClipboard } from "@/shared/lib/clipboard";
 import { getErrorMessage } from "@/shared/lib/errors";
 import {
@@ -55,20 +53,10 @@ import {
   useRevealPathInFileManager } from
 "./hooks";
 
-const FILE_TREE_PANEL_TRANSITION = {
-  type: "spring",
-  stiffness: 320,
-  damping: 34,
-  mass: 0.9
-} as const;
 const FILE_TREE_CONTENT_TRANSITION = {
   duration: 0.18,
   ease: [0.22, 1, 0.36, 1]
 } as const;
-const FILE_TREE_PANEL_MIN_WIDTH = 180;
-const FILE_TREE_PANEL_MAX_WIDTH = 560;
-const DEFAULT_FILE_TREE_PANEL_WIDTH = 208;
-const FILE_TREE_PANEL_STORAGE_KEY = "file-tree-panel";
 const TRAILING_PATH_SEPARATOR_RE = /[\\/]+$/;
 const FILE_TREE_CREATE_NAMES = {
   directory: "New Folder",
@@ -118,59 +106,6 @@ function getTreeItemPath(event: MouseEvent<HTMLElement>) {
 function toAbsolutePath(rootPath: string, relativePath: string) {
   const normalizedRoot = rootPath.replace(TRAILING_PATH_SEPARATOR_RE, "");
   return `${normalizedRoot}/${relativePath}`;
-}
-
-function clampFileTreePanelWidth(width: number) {
-  return Math.min(
-    FILE_TREE_PANEL_MAX_WIDTH,
-    Math.max(FILE_TREE_PANEL_MIN_WIDTH, width)
-  );
-}
-
-function sanitizeFileTreePanelWidth(width: unknown) {
-  return typeof width === "number" && Number.isFinite(width) ?
-  clampFileTreePanelWidth(width) :
-  DEFAULT_FILE_TREE_PANEL_WIDTH;
-}
-
-function readStoredFileTreePanelWidth() {
-  if (typeof window === "undefined") return DEFAULT_FILE_TREE_PANEL_WIDTH;
-  try {
-    const raw = window.localStorage.getItem(FILE_TREE_PANEL_STORAGE_KEY);
-    if (!raw) return DEFAULT_FILE_TREE_PANEL_WIDTH;
-    const parsed = JSON.parse(raw) as {
-      panelWidth?: unknown;
-      state?: {panelWidth?: unknown;};
-    };
-    return sanitizeFileTreePanelWidth(
-      parsed.state?.panelWidth ?? parsed.panelWidth
-    );
-  } catch {
-    return DEFAULT_FILE_TREE_PANEL_WIDTH;
-  }
-}
-
-function writeStoredFileTreePanelWidth(width: number) {
-  try {
-    window.localStorage.setItem(
-      FILE_TREE_PANEL_STORAGE_KEY,
-      JSON.stringify({ state: { panelWidth: width }, version: 2 })
-    );
-  } catch {
-
-    // Ignore restricted storage; resizing should still work in-memory.
-  }}
-
-function useFileTreePanelWidth() {
-  const [panelWidth, setPanelWidth] = useState(
-    readStoredFileTreePanelWidth
-  );
-  const updatePanelWidth = useCallback((width: number) => {
-    const nextWidth = clampFileTreePanelWidth(width);
-    setPanelWidth(nextWidth);
-    writeStoredFileTreePanelWidth(nextWidth);
-  }, []);
-  return [panelWidth, updatePanelWidth] as const;
 }
 
 function toPathCollisionKey(path: string) {
@@ -681,15 +616,6 @@ export default function FileTreePanel({
   const renameFileTreePathRef = useRef((_event: FileTreeRenameEvent) => {});
   const moveFileTreePathsRef = useRef((_event: FileTreeDropResult) => {});
   const prefersReducedMotion = useReducedMotion() ?? false;
-  const [panelWidth, setPanelWidth] = useFileTreePanelWidth();
-  const resize = useHorizontalResize({
-    value: panelWidth,
-    min: FILE_TREE_PANEL_MIN_WIDTH,
-    max: FILE_TREE_PANEL_MAX_WIDTH,
-    disabled: !isOpen,
-    onChange: setPanelWidth
-  });
-
   const {
     data: rootChildPaths,
     error: treePathsError,
@@ -1189,31 +1115,7 @@ export default function FileTreePanel({
   );
 
   return (
-    <>
-			<div
-        className="h-full shrink-0"
-        style={{ pointerEvents: isOpen ? "auto" : "none" }}
-        aria-hidden={!isOpen}>
-        
-				<motion.div
-            initial={false}
-            animate={{ width: isOpen ? panelWidth : 0 }}
-            transition={
-            prefersReducedMotion || resize.isDragging ?
-            { duration: 0 } :
-            FILE_TREE_PANEL_TRANSITION
-            }
-            style={{
-              display: "flex",
-              flexDirection: "column",
-              height: "100%",
-              minWidth: 0,
-              overflow: "visible",
-              position: "relative",
-              willChange: "width"
-            }}>
-            
-						<div className="flex min-h-0 flex-1 overflow-hidden">
+		<div className="flex h-full min-h-0 min-w-0 overflow-hidden">
 							<motion.div
                   initial={false}
                   animate={{
@@ -1319,23 +1221,6 @@ export default function FileTreePanel({
                     }
 									</div>
 								</motion.div>
-						</div>
-						{isOpen &&
-            <div
-              role="separator"
-              aria-label={m.fileTreeResizeSeparator()}
-              aria-orientation="vertical"
-              aria-valuemin={FILE_TREE_PANEL_MIN_WIDTH}
-              aria-valuemax={FILE_TREE_PANEL_MAX_WIDTH}
-              aria-valuenow={panelWidth}
-              tabIndex={0}
-              className="absolute top-0 -right-1 bottom-0 z-[1] w-2 cursor-col-resize focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-[var(--app-focus-ring)]"
-              onPointerDown={resize.handlePointerDown}
-              onKeyDown={resize.handleKeyDown} />
-
-            }
-					</motion.div>
-			</div>
-		</>);
+		</div>);
 
 }

--- a/src/features/projects/ProfileSidebar.test.tsx
+++ b/src/features/projects/ProfileSidebar.test.tsx
@@ -1,0 +1,58 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Profile } from "@/generated";
+import ProfileSidebar from "./ProfileSidebar";
+
+vi.mock("@/features/git/components/SidebarGitPanel", () => ({
+	default: () => <div>Git panel</div>,
+}));
+
+vi.mock("@/features/profiles/ProfileNotesEditor", () => ({
+	default: () => <div>Notes panel</div>,
+}));
+
+vi.mock("./FileTreePanel", () => ({
+	default: () => <div>File tree</div>,
+}));
+
+const profile: Profile = {
+	id: "profile-1",
+	project_id: "project-1",
+	branch_name: "main",
+	worktree_path: "/tmp/project",
+	created_at: "2026-08-09T00:00:00Z",
+	is_default: true,
+	notes: "",
+};
+
+describe("profileSidebar", () => {
+	beforeEach(() => {
+		window.localStorage.clear();
+	});
+
+	it.each(["files", "git", "notes"] as const)(
+		"exposes the shared resize separator in %s mode",
+		(mode) => {
+			render(
+				<ProfileSidebar
+					profile={profile}
+					mode={mode}
+					isOpen
+					isActive
+					onOpenFile={vi.fn()}
+				/>,
+			);
+
+			const separator = screen.getByRole("separator", {
+				name: "Resize sidebar",
+			});
+			expect(separator).toHaveAttribute("aria-valuenow", "208");
+
+			fireEvent.keyDown(separator, { key: "ArrowRight" });
+
+			expect(separator).toHaveAttribute("aria-valuenow", "224");
+			expect(JSON.parse(window.localStorage.getItem("file-tree-panel") ?? ""))
+				.toMatchObject({ state: { panelWidth: 224 } });
+		},
+	);
+});

--- a/src/features/projects/ProfileSidebar.tsx
+++ b/src/features/projects/ProfileSidebar.tsx
@@ -1,5 +1,5 @@
 import { motion, useReducedMotion } from "motion/react";
-import { lazy, useState, type ReactNode } from "react";
+import { lazy, useCallback, useState, type ReactNode } from "react";
 import SidebarGitPanel from "@/features/git/components/SidebarGitPanel";
 import FileTreePanel from "@/features/projects/FileTreePanel";
 import type { ProfileSidebarMode } from "@/features/projects/SidebarModeSwitch";
@@ -9,6 +9,8 @@ import {
 	LoadingError,
 	LoadingSpinner,
 } from "@/shared/components/Fallbacks";
+import { useHorizontalResize } from "@/shared/hooks/useHorizontalResize";
+import * as m from "@/paraglide/messages.js";
 
 const ProfileNotesEditor = lazy(
 	() => import("@/features/profiles/ProfileNotesEditor"),
@@ -20,11 +22,17 @@ const SIDEBAR_PANEL_TRANSITION = {
 	damping: 34,
 	mass: 0.9,
 } as const;
-// Mirrors FileTreePanel's persisted width so all sidebar modes line up.
 const SIDEBAR_PANEL_MIN_WIDTH = 180;
 const SIDEBAR_PANEL_MAX_WIDTH = 560;
 const DEFAULT_SIDEBAR_PANEL_WIDTH = 208;
 const SIDEBAR_PANEL_STORAGE_KEY = "file-tree-panel";
+
+function clampSidebarPanelWidth(width: number) {
+	return Math.min(
+		SIDEBAR_PANEL_MAX_WIDTH,
+		Math.max(SIDEBAR_PANEL_MIN_WIDTH, width),
+	);
+}
 
 function readStoredSidebarPanelWidth() {
 	if (typeof window === "undefined") return DEFAULT_SIDEBAR_PANEL_WIDTH;
@@ -37,59 +45,35 @@ function readStoredSidebarPanelWidth() {
 		};
 		const width = parsed.state?.panelWidth ?? parsed.panelWidth;
 		return typeof width === "number" && Number.isFinite(width)
-			? Math.min(
-					SIDEBAR_PANEL_MAX_WIDTH,
-					Math.max(SIDEBAR_PANEL_MIN_WIDTH, width),
-				)
+			? clampSidebarPanelWidth(width)
 			: DEFAULT_SIDEBAR_PANEL_WIDTH;
 	} catch {
 		return DEFAULT_SIDEBAR_PANEL_WIDTH;
 	}
 }
 
-// Fixed-width sibling of FileTreePanel for the non-tree sidebar modes,
-// matching its stored width and open/close animation.
-function SidebarAltPanel({
-	isOpen,
-	children,
-}: {
-	isOpen: boolean;
-	children: ReactNode;
-}) {
-	const prefersReducedMotion = useReducedMotion() ?? false;
-	// Read once per mount — mode switches remount and pick up resizes.
-	const [panelWidth] = useState(readStoredSidebarPanelWidth);
+function writeStoredSidebarPanelWidth(width: number) {
+	try {
+		window.localStorage.setItem(
+			SIDEBAR_PANEL_STORAGE_KEY,
+			JSON.stringify({ state: { panelWidth: width }, version: 2 }),
+		);
+	} catch {
+		// Resizing should still work in-memory when storage is unavailable.
+	}
+}
 
+function SidebarPanelContent({ children }: { children: ReactNode }) {
 	return (
-		<div
-			className="h-full shrink-0"
-			style={{ pointerEvents: isOpen ? "auto" : "none" }}
-			aria-hidden={!isOpen}
-		>
-			<motion.div
-				initial={false}
-				animate={{ width: isOpen ? panelWidth : 0 }}
-				transition={
-					prefersReducedMotion ? { duration: 0 } : SIDEBAR_PANEL_TRANSITION
-				}
-				style={{
-					display: "flex",
-					height: "100%",
-					minWidth: 0,
-					overflow: "hidden",
-				}}
+		<div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden border-r">
+			<AsyncBoundary
+				fallback={<LoadingSpinner />}
+				errorFallback={({ error, onRetry }) => (
+					<LoadingError error={error} onRetry={onRetry} />
+				)}
 			>
-				<div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden border-r">
-					<AsyncBoundary
-						fallback={<LoadingSpinner />}
-						errorFallback={({ error, onRetry }) => (
-							<LoadingError error={error} onRetry={onRetry} />
-						)}
-					>
-						{children}
-					</AsyncBoundary>
-				</div>
-			</motion.div>
+				{children}
+			</AsyncBoundary>
 		</div>
 	);
 }
@@ -110,40 +94,84 @@ export default function ProfileSidebar({
 	onOpenFile,
 }: ProfileSidebarProps) {
 	const isFilesMode = mode === "files";
+	const prefersReducedMotion = useReducedMotion() ?? false;
+	const [panelWidth, setPanelWidth] = useState(readStoredSidebarPanelWidth);
+	const updatePanelWidth = useCallback((width: number) => {
+		const nextWidth = clampSidebarPanelWidth(width);
+		setPanelWidth(nextWidth);
+		writeStoredSidebarPanelWidth(nextWidth);
+	}, []);
+	const resize = useHorizontalResize({
+		value: panelWidth,
+		min: SIDEBAR_PANEL_MIN_WIDTH,
+		max: SIDEBAR_PANEL_MAX_WIDTH,
+		disabled: !isOpen,
+		onChange: updatePanelWidth,
+	});
 
 	return (
-		<div className="flex h-full shrink-0 flex-col">
-			{/* File tree stays mounted across mode switches to keep expansion
-			    and selection state — hidden via CSS only */}
-			<div
-				className="min-h-0 flex-1"
-				style={{ display: isFilesMode ? "block" : "none" }}
+		<div
+			className="h-full shrink-0"
+			style={{ pointerEvents: isOpen ? "auto" : "none" }}
+			aria-hidden={!isOpen}
+		>
+			<motion.div
+				initial={false}
+				animate={{ width: isOpen ? panelWidth : 0 }}
+				transition={
+					prefersReducedMotion || resize.isDragging
+						? { duration: 0 }
+						: SIDEBAR_PANEL_TRANSITION
+				}
+				className="relative flex h-full min-w-0 flex-col"
+				style={{ overflow: "visible", willChange: "width" }}
 			>
-				<FileTreePanel
-					profileId={profile.id}
-					rootPath={profile.worktree_path}
-					isOpen={isOpen}
-					isActive={isActive && isFilesMode}
-					onOpenFile={onOpenFile}
-				/>
-			</div>
-
-			{mode === "git" && (
-				<SidebarAltPanel isOpen={isOpen}>
-					<SidebarGitPanel
+				{/* Keep the tree mounted across mode switches to preserve its UI state. */}
+				<div
+					className="min-h-0 flex-1"
+					style={{ display: isFilesMode ? "block" : "none" }}
+				>
+					<FileTreePanel
 						profileId={profile.id}
-						worktreePath={profile.worktree_path}
+						rootPath={profile.worktree_path}
+						isOpen={isOpen}
+						isActive={isActive && isFilesMode}
+						onOpenFile={onOpenFile}
 					/>
-				</SidebarAltPanel>
-			)}
+				</div>
 
-			{mode === "notes" && (
-				<SidebarAltPanel isOpen={isOpen}>
-					<div className="min-h-0 flex-1 overflow-hidden">
-						<ProfileNotesEditor profile={profile} />
-					</div>
-				</SidebarAltPanel>
-			)}
+				{mode === "git" && (
+					<SidebarPanelContent>
+						<SidebarGitPanel
+							profileId={profile.id}
+							worktreePath={profile.worktree_path}
+						/>
+					</SidebarPanelContent>
+				)}
+
+				{mode === "notes" && (
+					<SidebarPanelContent>
+						<div className="min-h-0 flex-1 overflow-hidden">
+							<ProfileNotesEditor profile={profile} />
+						</div>
+					</SidebarPanelContent>
+				)}
+
+				{isOpen && (
+					<div
+						role="separator"
+						aria-label={m.profileSidebarResizeSeparator()}
+						aria-orientation="vertical"
+						aria-valuemin={SIDEBAR_PANEL_MIN_WIDTH}
+						aria-valuemax={SIDEBAR_PANEL_MAX_WIDTH}
+						aria-valuenow={panelWidth}
+						tabIndex={0}
+						className="absolute top-0 -right-1 bottom-0 z-[1] w-2 cursor-col-resize focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-[var(--app-focus-ring)]"
+						onPointerDown={resize.handlePointerDown}
+						onKeyDown={resize.handleKeyDown}
+					/>
+				)}
+			</motion.div>
 		</div>
 	);
 }


### PR DESCRIPTION
Closes KIT-651

- move width state and resize handle to the shared ProfileSidebar container
- make Files, Git, and Notes modes use the same resizable width
- add regression coverage for all three modes

Tests:
- bunx vitest run src/features/projects/ProfileSidebar.test.tsx src/shared/hooks/useHorizontalResize.test.ts src/features/projects/FileTreePanel.test.tsx
- bun run typecheck