### PR TITLE
SEO: llms.txt points at hub and sibling products

### DIFF
--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -25,6 +25,12 @@
 - [GitHub](https://github.com/AkaraChen/2code)
 - [Latest release](https://github.com/AkaraChen/2code/releases/latest)
 
+## Also from Akara
+
+- [akr.moe](https://akr.moe) — Akara Chen's site (hub)
+- [Angel Engine](https://ag.akr.moe) — Local desktop for coding agents
+- [OGKit](https://ogkit.akr.moe) — Open Graph lint for web, extension, and CLI
+
 ## Install
 
 ```bash


### PR DESCRIPTION
Adds an Also from Akara section to `/llms.txt` with https://akr.moe, https://ag.akr.moe, and https://ogkit.akr.moe.

Competitor comparison list is unchanged.

Tracked in AkaraChen/seo#1.