### PR TITLE
docs: complete Tauri UI inventory for a future framework rewrite

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -70,3 +70,7 @@
 | [API Reference](api-reference.md) | All Tauri commands, Tauri events, HTTP endpoints                          |
 | [Configuration](configuration.md) | Config files, environment variables, database schema                      |
 | [Notification Behavior](notification-behavior.md) | Terminal unread-dot state machine and click behavior          |
+| [UI Inventory](ui-inventory.md) | Framework-agnostic rewrite spec for every window, screen, component, layout, and dialog |
+| [Sidebar UI Inventory](sidebar-ui-inventory.md) | Pixel-level appendix: app sidebar + profile sidebar |
+| [Home / Project UI Inventory](ui-inventory-home-project.md) | Pixel-level appendix: home, file tree, viewer, command palette, project dialogs |
+| [Settings / Terminal / Git UI Inventory](ui-inventory-settings-terminal-git-debug-updater.md) | Pixel-level appendix: settings window, terminal, git, debug, updater |

--- a/docs/sidebar-ui-inventory.md
+++ b/docs/sidebar-ui-inventory.md
@@ -1,0 +1,1073 @@
+# 2code Sidebar / Left-Nav UI Inventory
+
+Framework-agnostic inventory of every visual and interactive element in the app’s left navigation surfaces. Derived exclusively from source files listed in the exploration scope; nothing below is inferred beyond what the code defines.
+
+**Scope:** Primary app sidebar (`AppSidebar`), profile secondary sidebar (`ProfileSidebar`), related primitives, loading/error fallbacks, window chrome that affects sidebar layout, and the top-bar mode switch that controls the profile sidebar.
+
+**Last audited against:** `src/layout/*`, `src/features/projects/ProfileSidebar.tsx`, `src/features/projects/SidebarModeSwitch.tsx`, `src/features/git/components/SidebarGitPanel.tsx`, `src/components/ui/sidebar.tsx`, and supporting shared components.
+
+---
+
+## 1. Application layout context
+
+```
+App (flex h-full flex-col)
+└── div (flex min-h-0 flex-1)                    ← horizontal split
+    ├── AsyncBoundary
+    │   └── AppSidebar OR SidebarSkeleton OR SidebarError
+    └── main (relative flex-1 overflow-y-auto bg-card)
+        ├── Routes (HomePage, ProjectDetailPage, …)
+        └── TerminalLayer (persistent overlay)
+
+ProjectDetailPage → ProfileLayout
+└── div (flex h-full flex-col)
+    ├── CommandPalette
+    ├── div.border-b → ProjectTopBar (contains SidebarModeSwitch + expand-sidebar when collapsed)
+    └── div (flex min-h-0 min-w-0 flex-1)
+        ├── ProfileSidebar (files | git | notes)
+        └── div.min-h-0.flex-1 → main content (terminals, file viewer, …)
+
+Windows only: WindowControls (fixed top-right, h-7)
+```
+
+When `useAppSidebarStore.isCollapsed === true`, `AppSidebar` renders **nothing** (`return null`). The expand control appears in `ProjectTopBar` (project routes only), not on `HomePage`.
+
+---
+
+## 2. Design tokens and numeric constants
+
+### 2.1 App sidebar width (`sidebarStore.ts`)
+
+| Constant | Value | Usage |
+|----------|-------|--------|
+| `APP_SIDEBAR_MIN_WIDTH` | **220** px | Resize separator `aria-valuemin`, clamp |
+| `APP_SIDEBAR_MAX_WIDTH` | **420** px | Resize separator `aria-valuemax`, clamp |
+| `APP_SIDEBAR_DEFAULT_WIDTH` | **250** px | Initial persisted width |
+| Resize keyboard step | **16** px | `useHorizontalResize` default `step` |
+
+CSS variable `--sidebar-width` is set on:
+- `SidebarProvider` inline style in `AppSidebar`
+- `document.documentElement` via `sidebarStore` subscribe/sync
+
+Default in `app.css`: `--sidebar-width: 250px`
+
+### 2.2 Profile sidebar panel width (`ProfileSidebar.tsx`)
+
+| Constant | Value |
+|----------|-------|
+| `SIDEBAR_PANEL_MIN_WIDTH` | **180** px |
+| `SIDEBAR_PANEL_MAX_WIDTH` | **560** px |
+| `DEFAULT_SIDEBAR_PANEL_WIDTH` | **208** px |
+| localStorage key | `"file-tree-panel"` |
+| Resize keyboard step | **16** px |
+
+### 2.3 shadcn sidebar primitives (`sidebar.tsx`) — used but partially overridden
+
+| Token | Value | Notes |
+|-------|-------|-------|
+| `SIDEBAR_WIDTH` | `16rem` (**256** px at 16px root) | Overridden by AppSidebar dynamic px |
+| `SIDEBAR_WIDTH_MOBILE` | `18rem` (**288** px) | Not used: AppSidebar sets `collapsible="none"` |
+| `SIDEBAR_WIDTH_ICON` | `3rem` (**48** px) | Not used in AppSidebar |
+| `SIDEBAR_KEYBOARD_SHORTCUT` | `"b"` | Cmd/Ctrl+B in `SidebarProvider` — AppSidebar does not use shadcn collapse |
+
+### 2.4 Sidebar color tokens (`app.css`)
+
+Light `:root`:
+- `--sidebar`: oklch(0.985 0 0)
+- `--sidebar-foreground`: oklch(0.145 0 0)
+- `--sidebar-accent`: oklch(0.97 0 0)
+- `--sidebar-accent-foreground`: oklch(0.205 0 0)
+- `--sidebar-border`: oklch(0.922 0 0)
+- `--sidebar-ring`: oklch(0.708 0 0)
+
+Dark `.dark` overrides exist for the same keys.
+
+### 2.5 Tailwind size reference (used in sidebar UI)
+
+| Class | Computed (16px root) |
+|-------|----------------------|
+| `size-4` / `[&_svg]:size-4` | 16×16 px |
+| `size-3.5` | 14×14 px |
+| `size-2` | 8×8 px (agent dot) |
+| `size-6` | 24×24 px (maximize button) |
+| `h-7` | 28 px |
+| `h-8` | 32 px |
+| `h-12` | 48 px (header brand button) |
+| `w-5` / `min-w-5` / `h-5` | 20 px (badges, group actions) |
+| `w-2` | 8 px (resize hit area) |
+| `w-[250px]` | 250 px (skeleton/error fallback) |
+| `pt-8` | 32 px (macOS header) |
+| `pt-2` | 8 px (non-macOS header) |
+| `p-2` | 8 px (header/footer/group padding) |
+| `px-2` / `py-1.5` | horizontal 8 / vertical 6 px |
+| `mx-3` | horizontal margin 12 px |
+| `pl-4` | padding-left 16 px (reorder nested projects) |
+| `right-9` | right offset 36 px (edit-order action) |
+| `right-[-4px]` | extends resize handle 4 px past edge |
+| `text-xs` | 12 px font |
+| `text-sm` | 14 px font |
+| `text-[0.625rem]` | 10 px (avatar fallback letter) |
+| `rounded-md` | `--radius` related (~10 px with 0.625rem radius) |
+
+---
+
+## 3. Shared UI primitives (`components/ui/sidebar.tsx`)
+
+App sidebar composes these building blocks. `AppSidebar` passes `collapsible="none"`, so only the **non-collapsible** code path runs (fixed-width column, no Sheet/mobile/offcanvas).
+
+### 3.1 `SidebarProvider`
+
+- Wrapper: `div.group/sidebar-wrapper.flex.min-h-svh.w-full`
+- Merges CSS vars: `--sidebar-width`, `--sidebar-width-icon`
+- AppSidebar adds: `className="h-full min-h-0 w-auto shrink-0"` and inline `--sidebar-width: ${sidebarWidth}px`
+
+### 3.2 `Sidebar` (collapsible="none" branch)
+
+- `div[data-slot=sidebar]`
+- Classes: `flex h-full w-(--sidebar-width) flex-col bg-sidebar text-sidebar-foreground` + AppSidebar: `relative min-h-0 shrink-0 border-r`
+- AppSidebar adds: `role="navigation"`, `aria-label={m.sideNavLabel()}`, `onKeyDown={handleKeyDown}`
+
+### 3.3 `SidebarHeader`
+
+- `div[data-slot=sidebar-header]`
+- Default: `flex flex-col gap-2 p-2`
+- AppSidebar: `shrink-0`, `data-tauri-drag-region`, platform padding (see §10)
+
+### 3.4 `SidebarContent`
+
+- `div[data-slot=sidebar-content]`
+- Default: `no-scrollbar flex min-h-0 flex-1 flex-col gap-0 overflow-auto …`
+- AppSidebar: `overflow-x-hidden [scrollbar-gutter:stable]`
+
+### 3.5 `SidebarFooter`
+
+- `div[data-slot=sidebar-footer]`
+- Default: `flex flex-col gap-2 p-2`
+- AppSidebar: `shrink-0`
+
+### 3.6 `SidebarGroup`
+
+- `div[data-slot=sidebar-group]`
+- `relative flex w-full min-w-0 flex-col p-2`
+
+### 3.7 `SidebarGroupLabel`
+
+- `div` with: `flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 …`
+- Contains section title text + optional `SidebarGroupAction` buttons (absolutely positioned)
+
+### 3.8 `SidebarGroupAction`
+
+- Button: `absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 … [&>svg]:size-4`
+- Reorder-mode “done” variant adds: `right-9 bg-sidebar-accent text-sidebar-accent-foreground`
+- Normal edit-order: `right-9` only on pencil button; plus button at default `right-3`
+
+### 3.9 `SidebarGroupContent`
+
+- `div`: `w-full text-sm`
+
+### 3.10 `SidebarMenu` / `SidebarMenuItem`
+
+- Menu: `ul.flex.w-full.min-w-0.flex-col.gap-0`
+- Item: `li.group/menu-item.relative`
+
+### 3.11 `SidebarMenuButton` (variants)
+
+Base (`sidebarMenuButtonVariants`):
+- `peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm …`
+- `group-has-data-[sidebar=menu-action]/menu-item:pr-8` — reserves space for trailing action
+- `[&_svg]:size-4 [&_svg]:shrink-0`
+- `[&>span:last-child]:truncate`
+- **Hover:** `hover:bg-sidebar-accent hover:text-sidebar-accent-foreground`
+- **Active:** `data-active:bg-sidebar-accent data-active:font-medium data-active:text-sidebar-accent-foreground`
+- **Focus:** `focus-visible:ring-2` on `ring-sidebar-ring`
+
+Sizes:
+- `default`: `h-8 text-sm`
+- `sm`: `h-7 text-xs`
+- `lg`: `h-12 text-sm` (header brand)
+
+### 3.12 `SidebarMenuAction`
+
+- `absolute top-1.5 right-1 flex aspect-square w-5 … [&>svg]:size-4`
+- **Hover:** `hover:bg-sidebar-accent hover:text-sidebar-accent-foreground`
+- `showOnHover` mode (not used in AppSidebar project items): opacity 0 until group hover
+
+### 3.13 `SidebarMenuBadge`
+
+- `absolute right-1 flex h-5 min-w-5 items-center justify-center rounded-md px-1 text-xs font-medium tabular-nums`
+- Used for project-group project counts
+
+### 3.14 `SidebarMenuSub`
+
+- Default: `ul.mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l border-sidebar-border px-2.5 py-0.5`
+- `ProjectGroupSection` override: `mx-0 translate-x-0 gap-0 border-l-0 px-0 py-0`
+
+### 3.15 `SidebarMenuSubItem`
+
+- `li.group/menu-sub-item.relative`
+
+### 3.16 `SidebarMenuSubButton`
+
+- `flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sm …`
+- `[&>svg]:size-4`, active/hover same accent pattern as menu button
+
+---
+
+## 4. Primary app sidebar — `AppSidebar.tsx`
+
+### 4.1 Visibility and collapse
+
+- **Fully hidden** when `isCollapsed === true` (entire component returns `null`).
+- Collapse toggle: header `SidebarMenuAction` with `SidebarSimpleIcon`, `aria-label={m.collapseSidebar()}`, `aria-expanded={true}`, `onClick={toggleCollapsed}`.
+- Persisted in localStorage key `"app-sidebar-width"` (partialized: `width`, `isCollapsed`, `collapsedProjectGroupIds`; `isReorderMode` is **not** persisted).
+
+### 4.2 Component tree (normal mode, projects exist)
+
+```
+AppSidebar
+├── SidebarProvider (--sidebar-width: Npx)
+│   └── Sidebar [role=navigation, aria-label=sideNavLabel]
+│       ├── LayoutGroup id="app-sidebar"
+│       │   ├── SidebarHeader [data-tauri-drag-region]
+│       │   │   └── SidebarMenu
+│       │   │       └── SidebarMenuItem
+│       │   │           ├── SidebarMenuButton size=lg pointer-events-none
+│       │   │           │   └── span.font-semibold → "2Code"
+│       │   │           └── SidebarMenuAction → SidebarSimpleIcon (collapse)
+│       │   ├── SidebarContent
+│       │   │   ├── [optional] SidebarGroup "Pinned"
+│       │   │   │   ├── SidebarGroupLabel → pinnedProjects
+│       │   │   │   └── SidebarGroupContent → SidebarMenu
+│       │   │   │       └── ProjectMenuItem × N
+│       │   │   └── SidebarGroup "Projects"
+│       │   │       ├── SidebarGroupLabel
+│       │   │       │   ├── span → sidebarProjectsSection
+│       │   │       │   ├── SidebarGroupAction → PencilSimpleLineIcon (edit order)
+│       │   │       │   └── SidebarGroupAction id=add-project-button → PlusIcon
+│       │   │       └── SidebarGroupContent → SidebarMenu
+│       │   │           ├── ProjectGroupSection × groups
+│       │   │           └── ProjectMenuItem × top-level projects
+│       │   └── SidebarFooter
+│       │       └── SidebarMenu
+│       │           └── SidebarMenuItem
+│       │               └── SidebarMenuButton → GearSixIcon + settings
+│       └── div[role=separator] (width resize handle)
+└── CreateProjectDialog
+```
+
+### 4.3 Header row
+
+| Element | Content | Layout / classes | Interaction |
+|---------|---------|------------------|-------------|
+| Brand button | Text **"2Code"** (hardcoded, not i18n) | `SidebarMenuButton size="lg" className="pointer-events-none"`, inner `span.font-semibold` | Non-interactive (`pointer-events-none`) |
+| Collapse action | `SidebarSimpleIcon` weight `regular` | `SidebarMenuAction`, default action positioning | Click → `toggleCollapsed`; a11y: `collapseSidebar` |
+
+Both sit in one `SidebarMenuItem`. Menu button height **48 px** (`lg`).
+
+### 4.4 Empty projects state
+
+When `projects.length === 0`:
+
+```
+SidebarGroup
+└── SidebarGroupContent
+    └── SidebarMenu
+        └── SidebarLink to="/" icon=HouseIcon → home
+```
+
+No pinned/projects sections, no footer change (footer still shows Settings).
+
+### 4.5 Pinned projects section
+
+**Visible when:** `sidebarLayout.pinnedProjects.length > 0` (normal mode).
+
+| Element | Content |
+|---------|---------|
+| `SidebarGroupLabel` | `m.pinnedProjects()` → **"Pinned"** |
+| Rows | `ProjectMenuItem` per pinned project |
+
+### 4.6 Projects section (normal mode)
+
+| Element | Content | a11y |
+|---------|---------|------|
+| Label text | `m.sidebarProjectsSection()` → **"Projects"** | — |
+| Edit order | `PencilSimpleLineIcon`, `className="right-9"` | `aria-label={editProjectOrder}`, `aria-pressed={isReorderMode}`, `disabled={isSidebarLayoutSaving}` |
+| New project | `PlusIcon`, `id="add-project-button"` | `aria-label={newProject}` → **"New Project"** |
+| Body | `ProjectGroupSection` or `ProjectMenuItem` per `topEntries` | — |
+
+**Dialog launched:** `CreateProjectDialog` via plus button.
+
+### 4.7 Reorder mode (`isReorderMode === true`)
+
+Replaces normal pinned/projects rendering with drag-and-drop UI.
+
+#### 4.7.1 Pinned group (reorder)
+
+- Label: **"Pinned"**
+- `DndContext` + `SortableContext` + `SortableProjectRow` per pinned project
+- Trailing `SidebarDropZone` id=`sidebar-drop:pinned`, label `dropHereToPin`, `compact` when pinned list non-empty
+
+#### 4.7.2 Projects group (reorder)
+
+- Label row: **"Projects"** + **CheckIcon** action (`doneEditingProjectOrder`, `className="right-9 bg-sidebar-accent text-sidebar-accent-foreground"`) + **PlusIcon** (new project)
+- Top-level sortable entries:
+  - **Group:** `SortableGroupRow` with nested `SidebarMenu className="pl-4"` containing nested `SortableProjectRow` + group drop zone
+  - **Project:** `SortableProjectRow`
+- Bottom `SidebarDropZone` id=`sidebar-drop:top-level`, label `dropHereToUnpinOrMoveOut`
+
+#### 4.7.3 `SortableProjectRow`
+
+```
+SidebarMenuItem [opacity 0.45 when dragging]
+├── SidebarMenuButton [data-sidebar-item, bg-sidebar-accent when dragging]
+│   ├── span [cursor-grab] → DotsSixVerticalIcon (muted)
+│   ├── ProjectAvatar
+│   └── span → project.name
+└── SidebarMenuAction
+    ├── aria-label: pinProject | unpinProject
+    ├── aria-pressed={isPinned}
+    └── StarIcon
+```
+
+- Drag activation: `PointerSensor` distance **5** px
+- Pin toggle calls `handleTogglePinned` (disabled while save in flight)
+
+#### 4.7.4 `SortableGroupRow`
+
+Same drag handle + `FolderIcon` + group name; `SidebarMenuBadge` shows `{projects.length}`; children = nested project list + drop zone.
+
+#### 4.7.5 `SidebarDropZone`
+
+- Container: `mx-3 rounded-md border border-dashed px-3 text-center text-xs text-muted-foreground`
+- Spacing: `compact ? "my-1 py-1" : "my-2 py-2"`
+- **isOver:** `border-foreground/30 bg-muted`; else `border-border`
+
+### 4.8 Footer — Settings
+
+| Element | Icon | Label | Action |
+|---------|------|-------|--------|
+| `SidebarMenuButton` | `GearSixIcon` | `m.settings()` → **"Settings"** | `openSettingsWindow()` (separate Tauri window) |
+| Attribute | `data-sidebar-item` | — | Included in arrow-key nav |
+
+### 4.9 Width resize separator
+
+```
+div[role=separator]
+  aria-label="Resize sidebar"          ← hardcoded English, not i18n
+  aria-orientation="vertical"
+  aria-valuemin=220 aria-valuemax=420 aria-valuenow={sidebarWidth}
+  tabIndex=0
+  className:
+    absolute top-0 right-[-4px] bottom-0 w-2 cursor-col-resize
+    before: absolute vertical 1px line at center
+    hover:before:bg-border
+    focus-visible:outline-2 outline-offset-[-2px] outline-(--app-focus-ring)
+    dragging: before:bg-foreground/30
+```
+
+Keyboard on separator: ArrowLeft/Right ±16 px, Home=min, End=max.
+
+### 4.10 Keyboard navigation (`handleKeyDown` on `Sidebar`)
+
+- **ArrowDown / ArrowUp:** Cycle focus among `[data-sidebar-item]` elements inside sidebar ref.
+- Does not wrap parent containers; flat query of all items in DOM order (includes nested profile rows when expanded).
+
+### 4.11 Global shortcuts affecting sidebar (from `App.tsx`)
+
+| Shortcut | Action |
+|----------|--------|
+| Cmd/Ctrl+, | `openSettingsWindow()` (same as footer) |
+| Cmd/Ctrl+Shift+D | Debug panel (unrelated) |
+
+### 4.12 Error toast
+
+Failed layout persist: `toast.error(sidebarOrderUpdateFailed)` with error message description.
+
+---
+
+## 5. `ProjectMenuItem.tsx`
+
+One row per project in the app sidebar (normal mode).
+
+### 5.1 Tree
+
+```
+SidebarMenuItem.group/project-item
+├── ContextMenu
+│   ├── ContextMenuTrigger → SidebarMenuButton → NavLink
+│   │   ├── ProjectAvatar
+│   │   └── span.min-w-0.flex-1.truncate.font-medium → project.name
+│   └── ContextMenuContent
+│       ├── ProjectGroupMenu (submenu)
+│       ├── projectSettings
+│       ├── renameProject
+│       ├── [separator]
+│       └── deleteProject (destructive)
+├── [branch A] hasOnlyDefaultProfile
+│   └── Tooltip → SidebarMenuAction (create profile)
+│       ├── PlusIcon (hidden until group-hover/group-focus-within)
+│       └── AgentStatusDot (hidden on hover/focus-within when indicator present)
+├── [branch B] multiple profiles
+│   └── SidebarMenuAction (expand/collapse)
+│       └── CaretDownIcon | CaretRightIcon
+└── [if expanded && !hasOnlyDefaultProfile]
+    └── SidebarMenuSub
+        ├── SidebarMenuSubItem → default profile row
+        ├── ProfileList (non-default profiles)
+        └── (CreateProfileDialog only in branch A on action)
+```
+
+### 5.2 Project row button
+
+- **Link target:** `/projects/{id}/profiles/{defaultProfileId}` or `/projects/{id}` if no default profile
+- **Attributes:** `data-project-id`, `data-testid="project-sidebar-item"`, `data-sidebar-item`
+- **Active when:** `hasOnlyDefaultProfile && activeProfileId === defaultProfile.id`
+- **Text:** `project.name`, truncated, `font-medium`
+
+### 5.3 Trailing action — single-profile projects
+
+When `nonDefaultProfiles.length === 0`:
+
+| State | Visible control |
+|-------|-----------------|
+| Default | `AgentStatusDot` if agent status/completion exists |
+| `:hover` / `:focus-within` on `.group/project-item` | `PlusIcon` (`hidden group-hover/project-item:block group-focus-within/project-item:block`) |
+
+- **Tooltip:** side `right`, text `createProfile` → **"New Profile"**
+- **aria-label:** `createProfile`
+- Click/Enter/Space → `CreateProfileDialog`
+
+Agent indicator source: `useProfileAgentStatus(defaultProfileId) ?? useProfileAgentCompletion(defaultProfileId)`.
+
+### 5.4 Trailing action — multi-profile projects
+
+- **Icon:** `CaretDownIcon` (expanded) or `CaretRightIcon` (collapsed)
+- **aria-label:** `toggleProjectGroup({ name: project.name })` → **"Toggle project group {name}"**
+- **aria-expanded:** `expanded` (default expanded: `userExpanded ?? true`)
+- Click toggles local `userExpanded` state
+
+### 5.5 Default profile sub-row (multi-profile only)
+
+```
+SidebarMenuSubButton → NavLink(defaultProfileUrl)
+├── TerminalWindowIcon
+├── OverflowTooltipText(displayValue=defaultProfile, tooltipValue=defaultProfile)
+└── AgentStatusDot (if indicator)
+```
+
+- **Label i18n:** `defaultProfile` → **"Default"**
+- **Active when:** `activeProfileId === defaultProfile.id`
+
+### 5.6 Context menu items
+
+| Item | i18n key | English | Opens |
+|------|----------|---------|-------|
+| Submenu | `addToProjectGroup` | Add to Project Group | Inline submenu |
+| | `projectSettings` | Project Settings | `ProjectSettingsDialog` |
+| | `renameProject` | Rename | `RenameProjectDialog` |
+| Separator | — | — | — |
+| Destructive | `deleteProject` | Delete Project | `DeleteProjectDialog` |
+
+---
+
+## 6. `ProjectGroupSection.tsx`
+
+Folder row grouping projects under a `ProjectGroup`.
+
+### 6.1 Tree
+
+```
+SidebarMenuItem
+├── SidebarMenuButton [type=button, data-sidebar-item]
+│   ├── CaretRightIcon | CaretDownIcon
+│   └── span → group.name
+├── SidebarMenuBadge → projects.length
+└── AnimatePresence
+    └── motion.div (height/opacity animation, overflow hidden)
+        └── SidebarMenuSub [mx-0 translate-x-0 gap-0 border-l-0 px-0 py-0]
+            └── ProjectMenuItem × projects
+```
+
+### 6.2 Collapse state
+
+- Stored in `useAppSidebarStore.collapsedProjectGroupIds` (persisted)
+- `collapsed === true` → caret right, children not rendered
+- **aria-expanded:** `!collapsed`
+- **aria-label:** `toggleProjectGroup({ name: group.name })`
+- Enter/Space on button toggles
+
+### 6.3 Animation
+
+- Duration **0.18** s, ease `[0.22, 1, 0.36, 1]`
+- `prefers-reduced-motion`: no height/opacity animation (exit keeps opacity 1; enter skips initial)
+
+---
+
+## 7. `ProjectGroupMenu.tsx` (context submenu)
+
+Rendered inside project context menu.
+
+### 7.1 Structure
+
+```
+ContextMenuSub
+├── ContextMenuSubTrigger → addToProjectGroup (truncated)
+└── ContextMenuSubContent.min-w-56
+    ├── [if no groups] div.px-3.py-2.text-sm.text-muted-foreground → noProjectGroups
+    ├── [else] ContextMenuItem per group
+    │   ├── CheckIcon (opacity-0 if not current)
+    │   └── span.truncate → group.name
+    ├── [if project in group] separator + removeFromProjectGroup (XIcon)
+    ├── separator
+    └── create flow OR createProjectGroup item
+```
+
+### 7.2 Create group inline input
+
+When `isCreating || projectGroups.length === 0`:
+- Wrapper: `px-2 py-1.5`
+- `Input` placeholder `projectGroupNamePlaceholder` → **"e.g. Work"**
+- **Enter:** submit create + assign
+- **Escape:** cancel, clear name
+
+### 7.3 Pending/disabled
+
+- `disabled={isPending || isCurrent}` on group items
+- Errors: toast `somethingWentWrong` + description
+
+---
+
+## 8. `ProjectAvatar.tsx`
+
+| Setting | Behavior |
+|---------|----------|
+| `useSidebarSettingsStore.showProjectAvatars` | default **true**, persisted `"sidebar-settings"` |
+| When false | Renders **null** (no placeholder gap in button — icon slot omitted) |
+| When true | `span.grid.size-4.shrink-0.place-items-center.overflow-hidden.rounded-md.bg-sidebar-accent.text-sidebar-accent-foreground` |
+
+**Image path:** `useProjectAvatar(projectId)` when enabled.
+
+**Fallback:** first grapheme of trimmed `projectName` uppercased, or `"?"`; text `text-[0.625rem] leading-none font-medium` (**10 px**).
+
+**Image:** `img.size-full.object-cover`, `alt={projectName}`, onError → fallback letter.
+
+---
+
+## 9. `ProfileList.tsx` + `ProfileItem.tsx`
+
+### 9.1 ProfileList
+
+Maps `profiles` (non-default only) to `ProfileItem`, then append:
+
+```
+SidebarMenuSubItem
+└── SidebarMenuSubButton [button, data-sidebar-item]
+    ├── PlusIcon weight=regular
+    └── span → createProfile ("New Profile")
+```
+
+Opens `CreateProfileDialog` for `projectId`.
+
+### 9.2 ProfileItem
+
+```
+SidebarMenuSubItem
+├── ContextMenu
+│   ├── ContextMenuTrigger → SidebarMenuSubButton → NavLink
+│   │   ├── GitBranchIcon
+│   │   ├── OverflowTooltipText(branch_name)
+│   │   └── AgentStatusDot?
+│   └── ContextMenuContent
+│       └── deleteProfile (destructive)
+└── DeleteProfileDialog
+```
+
+- **Route:** `/projects/{projectId}/profiles/{profile.id}`
+- **Active:** `isActive` prop
+- **Label:** `profile.branch_name` (not i18n — raw git branch name)
+
+---
+
+## 10. `AgentStatusDot.tsx`
+
+| Property | Value |
+|----------|-------|
+| Size | `size-2` → **8×8 px** circle |
+| `aria-hidden` | `true` (decorative) |
+| `data-agent-status` | `waiting` \| `running` \| `completed` |
+
+| Status | Visual |
+|--------|--------|
+| `waiting` | `bg-yellow-400` |
+| `completed` | `bg-green-500` |
+| `running` | `bg-emerald-400` + pulsing shadow; class `agent-status-dot--running` |
+
+**Running animation** (`app.css`): `agent-status-pulse` 1.4s ease-in-out infinite; disabled under `prefers-reduced-motion`.
+
+---
+
+## 11. `SidebarLink.tsx`
+
+Used only for Home link when no projects.
+
+```
+SidebarMenuItem
+└── SidebarMenuButton → NavLink
+    ├── {icon}
+    └── span → {children}
+```
+
+- **Active:** `useMatch(pattern ?? to)`
+- **`data-sidebar-item`:** yes
+
+---
+
+## 12. `OverflowTooltipText.tsx`
+
+Used on profile branch names and default profile label.
+
+- Display: `span.min-w-0.truncate` (+ passed `className`)
+- Tooltip: only when measured text overflows (>0.5 px); side **top**, align **start**
+- Tooltip content: `max-w-[min(480px,calc(100vw-32px))] break-all whitespace-normal`
+- Prop `tooltipDisabled` suppresses tooltip (not used in sidebar profile rows)
+
+---
+
+## 13. Loading and error fallbacks — `Fallbacks.tsx`
+
+### 13.1 `SidebarSkeleton`
+
+```
+aside.w-[250px].shrink-0.border-r.bg-muted/40.p-4
+└── div.flex.flex-col.gap-3
+    ├── Skeleton h-6 w-full
+    ├── Skeleton mt-2 h-3 w-1/2
+    └── Skeleton ml-5 h-5 w-3/4 × 3
+```
+
+Fixed width **250 px** (matches default sidebar width, not dynamic store width).
+
+### 13.2 `SidebarError`
+
+Same shell as skeleton (`w-[250px] … p-4`) with centered `ErrorStack`:
+- Title: `somethingWentWrong` → **"Something went wrong"**
+- Message: `error.message`
+- Button: `tryAgain` → **"Try again"**
+
+---
+
+## 14. Profile sidebar — `ProfileSidebar.tsx`
+
+Secondary left panel inside project view; not the app sidebar, but part of left-nav UX.
+
+### 14.1 Placement
+
+```
+ProfileLayout
+└── flex row
+    ├── ProfileSidebar (this)
+    └── main content
+```
+
+Controlled by `ProfileLayout` state: `fileTreeOpen` (default **true**), `sidebarMode` (`"files"` \| `"git"` \| `"notes"`).
+
+### 14.2 Outer wrapper
+
+```
+div.h-full.shrink-0
+  pointerEvents: isOpen ? auto : none
+  aria-hidden: !isOpen
+└── motion.div
+    animate width: isOpen ? panelWidth : 0
+    spring transition (stiffness 320, damping 34, mass 0.9) unless reduced motion or dragging
+    className: relative flex h-full min-w-0 flex-col
+    overflow: visible
+```
+
+### 14.3 Mode panels
+
+| Mode | Visibility | Content wrapper |
+|------|------------|-----------------|
+| `files` | `display: block/none` on wrapper | `FileTreePanel` |
+| `git` | conditional render | `SidebarPanelContent` → `SidebarGitPanel` |
+| `notes` | conditional render | `SidebarPanelContent` → `ProfileNotesEditor` |
+
+`SidebarPanelContent`: `div.flex.min-h-0.min-w-0.flex-1.flex-col.overflow-hidden.border-r` + `AsyncBoundary` (spinner / error).
+
+**Files tree stays mounted** when switching modes (`display:none` when not files).
+
+### 14.4 Resize separator (profile panel)
+
+```
+div[role=separator]
+  aria-label=profileSidebarResizeSeparator → "Resize sidebar"
+  aria-valuemin=180 aria-valuemax=560 aria-valuenow={panelWidth}
+  className: absolute top-0 -right-1 bottom-0 z-[1] w-2 cursor-col-resize
+             focus-visible:outline-2 -outline-offset-2 outline-[var(--app-focus-ring)]
+```
+
+Same keyboard resize behavior as app sidebar (±16 px, Home/End).
+
+---
+
+## 15. `SidebarModeSwitch.tsx` (top bar control for profile sidebar)
+
+Located in `ProjectTopBar` left cluster — controls profile sidebar mode, not app sidebar.
+
+### 15.1 Structure
+
+```
+Tabs value={isOpen ? mode : null}
+└── TabsList.h-7
+    └── ×3 Tooltip
+        └── TabsTrigger.px-2 aria-label={label()}
+            ├── Icon className=size-3.5 (14px)
+            └── [git only] +{additions} text-green-500, -{deletions} text-red-500
+```
+
+### 15.2 Tabs
+
+| value | Icon | i18n | English |
+|-------|------|------|---------|
+| `files` | `FolderSimpleIcon` | `sidebarFilesTab` | Files |
+| `git` | `GitBranchIcon` | `sidebarGitTab` | Git |
+| `notes` | `NoteIcon` | `notes` | Notes |
+
+**Git badge:** `useGitDiffStats(profileId, isActive)` when tab is git; shows `+N` / `-M` in `text-xs`.
+
+**Behavior (ProfileLayout):** Re-clicking active mode while open closes sidebar; switching mode opens sidebar.
+
+### 15.3 TabsList / TabsTrigger styling (from `tabs.tsx`)
+
+- List: `inline-flex … rounded-lg p-[3px] bg-muted`, height overridden to **28 px** (`h-7`)
+- Trigger: `text-sm`, active gets `data-active:bg-background` + shadow
+
+---
+
+## 16. Profile sidebar — Files mode (`FileTreePanel.tsx`)
+
+### 16.1 Container
+
+```
+div.flex.h-full.min-h-0.min-w-0.overflow-hidden
+└── motion.div (opacity/x slide when isOpen)
+    └── div.relative.min-h-0.min-w-0.flex-1.border-r.px-1.5.py-1
+        ├── FileTree (@pierre/trees) + context menus
+        ├── FileTreeRootContextMenu (positioned)
+        └── [error overlay] absolute inset-0 centered text-xs muted
+```
+
+### 16.2 File tree visual tokens (`FILE_TREE_HOST_STYLE`)
+
+| CSS variable override | Value |
+|-----------------------|-------|
+| `--trees-font-size-override` | **13px** |
+| `--trees-border-radius-override` | **4px** |
+| `--trees-level-gap-override` | **12px** |
+| `--trees-item-margin-x-override` | **4px** |
+| `--trees-item-padding-x-override` | **4px** |
+| `--trees-padding-inline-override` | **4px** |
+| Colors | map to `--muted`, `--muted-foreground`, `--foreground` |
+
+Density: `"compact"`, icons: `"complete"`, initial expansion: `"closed"`.
+
+### 16.3 Animation
+
+- Opacity 0→1, x -12→0 when opening; duration **0.18** s (same easing as project group)
+
+### 16.4 Context menus (sidebar-relevant)
+
+**Root menu items (i18n keys):** `fileTreeContextMenuNewFile`, `NewFolder`, `Refresh`, `RevealInFileManager`, `CopyRelativePath`, `CopyAbsolutePath`
+
+**Item menu adds:** Open, OpenInDefaultApp, Rename, Delete, etc.
+
+Popup: `min-w-40 rounded-lg bg-popover p-1 shadow-md ring-1 ring-foreground/10`
+
+### 16.5 Error state
+
+Absolute overlay, `pointer-events-none`, shows `getErrorMessage(treePathsError)` in `text-xs text-muted-foreground`.
+
+---
+
+## 17. Profile sidebar — Git mode (`SidebarGitPanel.tsx`)
+
+Vertical stack:
+
+```
+div.flex.min-h-0.min-w-0.flex-1.flex-col.overflow-hidden
+├── ChangesFileList (tooltipsDisabled, emptyMessage=noChangesDetected, onMaximize)
+└── CommitComposer
+```
+
+Plus modal `GitDiffDialog` (not inline in panel).
+
+### 17.1 ChangesFileList header (sticky)
+
+```
+div.sticky.top-0.z-[1].flex.items-center.gap-2.border-b.bg-background.px-3.py-2.5
+├── Checkbox (include all/none) aria-label=gitCommitIncludeAll → "All"
+├── p.text-xs.text-muted-foreground → changedFiles({ count })
+└── [optional] Button size=xs ghost ml-auto size-6 → ArrowsOutSimpleIcon (gitOpenDiffView)
+```
+
+**Empty state:** centered `p-6`, `text-xs text-muted-foreground` → **"No changes detected"**
+
+### 17.2 File row (`FileListItem`)
+
+```
+div.flex.w-full.items-start.gap-2.px-3.py-2
+├── Checkbox.mt-0.5
+├── OverflowTooltipText basename (text-sm, font-medium if active)
+├── optional parent path (text-xs muted)
+└── Badge size-4 (change type letter)
+```
+
+- **Active row:** `bg-muted`
+- **Inactive hover:** `hover:bg-muted/70`
+- **Excluded:** `opacity-70`
+- **Double-click:** opens `GitDiffDialog` focused on file
+- **Context menu:** discard action (`gitDiscardFileAction`)
+
+Context menu width constant: **200** px.
+
+### 17.3 CommitComposer footer
+
+```
+div.shrink-0.border-t.px-2.5.py-2
+├── p.text-xs.font-medium.uppercase.text-muted-foreground → gitCommitSectionTitle ("Commit")
+├── Field: gitCommitSummary + Input h-7 text-xs
+├── Field: gitCommitBody + Textarea min-h-[4.5rem] text-xs
+└── flex justify-end gap-2
+    ├── [if no files] Push button (UploadSimpleIcon, optional ahead count)
+    └── [else] Commit button (Spinner when pending)
+```
+
+**Commit shortcut:** Cmd/Ctrl+Enter when `canSubmit`.
+
+---
+
+## 18. Profile sidebar — Notes mode
+
+`ProfileNotesEditor` → `MarkdownEditor` full flex area inside `SidebarPanelContent`.
+
+| UI element | i18n |
+|------------|------|
+| Placeholder | `notesPlaceholder` |
+| Save failed toast | `notesSaveFailedTitle` |
+| Editor save status labels | `notesSaved`, `notesSaveFailedShort` (in MarkdownEditor) |
+
+---
+
+## 19. `WindowControls.tsx` (Windows platform)
+
+Not part of sidebar column but affects top-bar padding when app sidebar collapsed.
+
+```
+div.fixed.top-0.right-0.flex.h-7 [data-window-controls]
+├── Minimize (MinusIcon 12px) aria-label="Minimize"
+├── Maximize/Restore (SquareIcon | CopySimpleIcon 12px)
+└── Close (XIcon 12px) aria-label="Close"
+```
+
+| Button | Size | Hover |
+|--------|------|-------|
+| Minimize / Maximize | `h-7 w-9` (28×36 px) | `hover:bg-muted` |
+| Close | same | `hover:bg-[#c42b1c] hover:text-white` |
+
+`[-webkit-app-region:no-drag]` on buttons.
+
+`ProjectTopBar` adds `pr-[118px]` on Windows to clear controls.
+
+---
+
+## 20. Platform differences
+
+### 20.1 macOS
+
+| Location | Adjustment |
+|----------|------------|
+| `AppSidebar` `SidebarHeader` | `pt-8` (**32 px**) — comment: clear traffic lights at y:26+12px |
+| `ProjectTopBar` | When app sidebar collapsed: `pl-[84px]` to clear traffic lights |
+| Window controls | Native overlay (not `WindowControls` component) |
+| Header drag | `data-tauri-drag-region` on sidebar header + top bar |
+
+### 20.2 Windows
+
+| Location | Adjustment |
+|----------|------------|
+| `AppSidebar` header | `pt-2` (**8 px**) |
+| `WindowControls` | Rendered fixed top-right |
+| `ProjectTopBar` | `pr-[118px]` for custom window buttons |
+
+### 20.3 Linux / other
+
+Same as Windows for header padding (`pt-2`); no `WindowControls` unless Windows platform check passes.
+
+---
+
+## 21. Keyboard shortcuts summary (sidebar-related)
+
+| Context | Shortcut | Action |
+|---------|----------|--------|
+| App | Cmd/Ctrl+, | Open settings window |
+| App sidebar | ArrowUp/Down | Focus prev/next `[data-sidebar-item]` |
+| App sidebar resize | ArrowLeft/Right | ±16 px width |
+| App sidebar resize | Home / End | Min / max width |
+| ProjectTopBar (active profile) | Cmd/Ctrl+E | Toggle profile sidebar open/closed |
+| ProjectTopBar (active profile) | Cmd/Ctrl+G | Open git diff dialog (not sidebar panel) |
+| Profile panel resize | ArrowLeft/Right, Home, End | Same as app sidebar |
+| Commit composer | Cmd/Ctrl+Enter | Commit when valid |
+| Project group menu input | Enter / Escape | Create / cancel |
+| shadcn SidebarProvider | Cmd/Ctrl+B | Toggle shadcn sidebar — **not wired** for AppSidebar collapse |
+
+---
+
+## 22. Persisted client state
+
+| Store | Key | Fields |
+|-------|-----|--------|
+| `useAppSidebarStore` | `app-sidebar-width` | `width`, `isCollapsed`, `collapsedProjectGroupIds` |
+| `useSidebarSettingsStore` | `sidebar-settings` | `showProjectAvatars` (default true) |
+| Profile panel width | `file-tree-panel` | `{ state: { panelWidth }, version: 2 }` |
+
+---
+
+## 23. Complete i18n key → English map (sidebar scope)
+
+| Key | English text |
+|-----|--------------|
+| `home` | Home |
+| `sideNavLabel` | Side navigation |
+| `collapseSidebar` | Collapse sidebar |
+| `expandSidebar` | Expand sidebar |
+| `settings` | Settings |
+| `pinnedProjects` | Pinned |
+| `sidebarProjectsSection` | Projects |
+| `editProjectOrder` | Edit project order |
+| `doneEditingProjectOrder` | Done editing project order |
+| `newProject` | New Project |
+| `pinProject` | Pin project |
+| `unpinProject` | Unpin project |
+| `dropHereToPin` | Drop here to pin |
+| `dropProjectIntoFolder` | Drop project into folder |
+| `dropHereToUnpinOrMoveOut` | Drop here to unpin or move out |
+| `sidebarOrderUpdateFailed` | Failed to update sidebar order |
+| `toggleProjectGroup` | Toggle project group {name} |
+| `defaultProfile` | Default |
+| `createProfile` | New Profile |
+| `projectSettings` | Project Settings |
+| `renameProject` | Rename |
+| `deleteProject` | Delete Project |
+| `deleteProfile` | Delete Profile |
+| `addToProjectGroup` | Add to Project Group |
+| `noProjectGroups` | No project groups yet. |
+| `removeFromProjectGroup` | Remove from Project Group |
+| `projectGroupNamePlaceholder` | e.g. Work |
+| `createProjectGroup` | Create Project Group |
+| `somethingWentWrong` | Something went wrong |
+| `tryAgain` | Try again |
+| `sidebarFilesTab` | Files |
+| `sidebarGitTab` | Git |
+| `notes` | Notes |
+| `profileSidebarResizeSeparator` | Resize sidebar |
+| `noChangesDetected` | No changes detected |
+| `changedFiles` | {count} changed file(s) |
+| `gitOpenDiffView` | Open diff view |
+| `gitCommitIncludeAll` | All |
+| `gitCommitSectionTitle` | Commit |
+| `gitCommitSummary` | Summary |
+| `gitCommitSummaryPlaceholder` | Describe the changes you're committing |
+| `gitCommitBody` | Description |
+| `gitCommitBodyPlaceholder` | Add an optional extended description |
+| `gitCommitButton` | Commit |
+| `gitPushButton` | Push |
+| `gitDiscardFileAction` | Discard changes to this file |
+| `notesPlaceholder` | (see messages/en.json) |
+| `notesSaveFailedTitle` | Notes save failed |
+
+**Hardcoded non-i18n strings in sidebar UI:** `"2Code"` (brand), resize separator `aria-label="Resize sidebar"` on app sidebar, Windows control labels `"Minimize"`, `"Maximize"`, `"Restore"`, `"Close"`.
+
+---
+
+## 24. Dialogs and menus launched from sidebar surfaces
+
+| Trigger location | UI | Component |
+|------------------|-----|-----------|
+| Projects `+` | New project | `CreateProjectDialog` |
+| Project context menu | Settings / Rename / Delete | respective dialogs |
+| Project context submenu | Group assign/create | inline + API |
+| Single-profile `+` action | New profile | `CreateProfileDialog` |
+| ProfileList footer | New profile | `CreateProfileDialog` |
+| Profile context menu | Delete profile | `DeleteProfileDialog` |
+| Settings footer | Settings | `openSettingsWindow()` |
+| Git panel maximize | Full diff | `GitDiffDialog` |
+| File tree context menus | File operations | `@pierre/trees` + dropdown items |
+
+---
+
+## 25. Interactive state matrix (app sidebar)
+
+| State | Visual evidence in code |
+|-------|-------------------------|
+| Nav item hover | `SidebarMenuButton` / `SubButton` accent background |
+| Nav item active/route | `data-active` / `isActive` → accent bg + medium font (project name) |
+| Project row hover (single profile) | Swap agent dot ↔ plus icon |
+| Reorder dragging | opacity **0.45**, optional `bg-sidebar-accent` on button |
+| Drop zone hover | dashed border `border-foreground/30`, `bg-muted` |
+| Reorder saving | actions `disabled={isSidebarLayoutSaving}` |
+| Group collapsed | caret right, animated height 0 |
+| Project expanded (multi) | caret down + `SidebarMenuSub` visible |
+| Sidebar collapsed | entire `AppSidebar` unmounted |
+| Loading projects | `SidebarSkeleton` 250 px |
+| Load error | `SidebarError` with retry |
+
+---
+
+## 26. Data model driving layout (`sidebarLayout.ts`)
+
+**Pinned:** projects with `pinned_order != null`, sorted by pinned_order.
+
+**Top entries:** merge of `ProjectGroup` entries (with nested grouped projects) and ungrouped top-level projects; sorted by `sort_order` / `created_at`.
+
+**Reorder persistence:** `createSidebarLayoutUpdates` emits sort orders in steps of **1000** (`SIDEBAR_ORDER_STEP`).
+
+Drop zone IDs:
+- `sidebar-drop:pinned`
+- `sidebar-drop:top-level`
+- `sidebar-drop:group:{groupId}`
+
+Entry IDs: `project:{id}`, `group:{id}`.
+
+---
+
+## 27. Parent → child index (quick reference)
+
+```
+AppSidebar
+├── Header: brand + collapse
+├── Content
+│   ├── [empty] Home link
+│   ├── [normal] Pinned → ProjectMenuItem*
+│   ├── [normal] Projects → ProjectGroupSection* | ProjectMenuItem*
+│   └── [reorder] Pinned DnD + Projects DnD
+├── Footer: Settings
+└── Resize handle
+
+ProjectMenuItem
+├── Project row (avatar, name, context menu)
+├── Action (plus+dot | caret)
+└── Sub: Default row + ProfileList + dialogs
+
+ProjectGroupSection
+├── Group row (caret, name, badge)
+└── Sub: ProjectMenuItem*
+
+ProfileSidebar
+├── FileTreePanel | SidebarGitPanel | ProfileNotesEditor
+└── Resize handle
+
+ProjectTopBar (when app sidebar collapsed)
+└── Expand sidebar button (SidebarSimpleIcon)
+```
+
+This document is intended as the single source of truth for reimplementing the sidebar UI in a non-React/non-web stack while preserving layout, spacing, states, and behavior.

--- a/docs/ui-inventory-home-project.md
+++ b/docs/ui-inventory-home-project.md
@@ -1,0 +1,948 @@
+# 2code UI Inventory — Home, Project Detail, Profile Layout, File Tree/Viewer, Notes, Dialogs
+
+Framework-agnostic inventory derived from source files listed in the exploration task. Numeric sizes and class names are taken directly from code. English labels reference `messages/en.json` keys and resolved text.
+
+---
+
+## 1. Global routing context
+
+| Route | Page component | Notes |
+|-------|----------------|-------|
+| `/` | `HomePage` | Auto-redirects to first project's default profile when projects exist |
+| `/projects/:id/profiles/:profileId` | `ProjectDetailPage` + persistent `TerminalLayer` overlay | Invalid/missing profile redirects to default profile or `/` |
+
+**Project detail rendering split:**
+
+- **`TerminalLayer`** (absolute overlay, `inset: 0`, `display: flex/none` per active profile): renders `ProfileLayout` + `TerminalTabs` for every profile that has open terminal or file tabs.
+- **`ProjectDetailPage`**: only mounts `ProfileLayout` + `TerminalTabs` when **both** terminal tabs and file tabs are empty (`shouldRenderEmptyState`), showing the empty-terminal CTA. Once any tab opens, `TerminalLayer` owns the view; `ProjectDetailPage` renders `null`.
+
+---
+
+## 2. Home Page (`HomePage.tsx`)
+
+### 2.1 Component tree
+
+```
+HomePage (root: div.h-full)
+├── header (data-tauri-drag-region)
+│   ├── FolderIcon (Phosphor, className: size-4 text-muted-foreground)
+│   └── h1 (select-none text-sm font-semibold) → i18n: home ("Home")
+├── [conditional: hasNoProjects]
+│   └── div (flex h-[calc(100%-52px)] items-center justify-center)
+│       └── Empty
+│           └── EmptyHeader
+│               ├── EmptyMedia variant="icon" → FolderPlusIcon
+│               ├── EmptyTitle → emptyProjectsTitle ("No projects yet")
+│               └── EmptyDescription → emptyProjectsDesc
+└── TourOnboarding (renders null; driver.js overlay when enabled)
+```
+
+### 2.2 Layout regions
+
+| Region | Dimensions / classes | Behavior |
+|--------|---------------------|----------|
+| Page root | `h-full` | Fills main content area beside app sidebar |
+| Header bar | `h-[52px]`, `border-b`, `px-5`, `flex items-center gap-2` | macOS draggable title region |
+| Empty state area | `h-[calc(100%-52px)]`, centered flex | Only when `projects.length === 0` |
+| Content when projects exist | Header only visible briefly | `useEffect` navigates to `/projects/{id}/profiles/{defaultProfileId}` with `replace: true` |
+
+### 2.3 Interactive states
+
+| State | UI |
+|-------|-----|
+| No projects | Centered empty state with folder-plus icon |
+| Has projects | Immediate redirect; user rarely sees Home content except header flash |
+| Onboarding tour active | driver.js popover anchored to `#add-project-button` in app sidebar (not in HomePage DOM) |
+
+### 2.4 TourOnboarding (`TourOnboarding.tsx`)
+
+- **Trigger:** `isEnabled={hasNoProjects}` on HomePage.
+- **Library:** driver.js (`driver-popover-theme` class).
+- **Single step:** targets `#add-project-button` (in `AppSidebar.tsx`).
+- **Popover:** side `right`, align `start`; title `onboardingTourTitle`, description `onboardingTourDesc`; buttons: close only.
+- **Dismiss:** clicking add-project button destroys tour.
+- **Delay:** 300ms before `drive()`.
+- **Renders:** `null` (no visible React output).
+
+### 2.5 Keyboard shortcuts
+
+None defined on HomePage.
+
+---
+
+## 3. Project Detail Page (`ProjectDetailPage.tsx`)
+
+### 3.1 Component tree (empty state path)
+
+```
+ProjectDetailPage
+└── [when !hasTabs && !hasFileTabs]
+    └── ProfileLayout
+        └── TerminalTabs
+            ├── Tab bar (empty)
+            └── emptyFallback → emptyTerminalState
+                └── Empty (centered)
+                    ├── EmptyHeader
+                    │   ├── EmptyMedia icon → TerminalWindowIcon
+                    │   ├── EmptyTitle → noTerminalsOpen
+                    │   └── EmptyDescription → noTerminalsOpenDescription
+                    └── EmptyContent
+                        └── div.flex
+                            ├── Button (New Terminal) [+ PlusIcon, newTerminal]
+                            └── [optional] DropdownMenu (template picker)
+                                ├── DropdownMenuTrigger → Button size="icon" [-ml-px rounded-l-none, aria-label="Choose template"]
+                                │   └── CaretDownIcon
+                                └── DropdownMenuContent (min-w-56 p-1)
+                                    └── TerminalTemplateDropdownContent
+```
+
+### 3.2 Redirect logic (no visible UI)
+
+- Missing project → `<Navigate to="/" replace />`
+- Missing profile → redirect to default profile or first profile, else `/`
+
+### 3.3 Empty terminal CTA buttons
+
+| Control | Label (i18n) | Classes / props | Disabled when |
+|---------|--------------|-----------------|---------------|
+| Primary | `newTerminal` ("New Terminal") | `Button`; if templates exist: `rounded-r-none` | `createTab.isPending` |
+| Template split | (icon only) | `Button` `size="icon"`, `-ml-px rounded-l-none`, `aria-label="Choose template"` | same |
+
+### 3.4 Keyboard shortcuts (via `TerminalLayer`, active profile)
+
+| Shortcut | Action |
+|----------|--------|
+| `Cmd/Ctrl+T` | Create new terminal tab |
+| `Cmd/Ctrl+W` | Close active terminal tab |
+
+---
+
+## 4. Profile Layout (`ProfileLayout.tsx`)
+
+### 4.1 Component tree
+
+```
+ProfileLayout (div.flex.h-full.flex-col)
+├── CommandPalette (modal, always mounted)
+├── div.border-b
+│   └── ProjectTopBar
+└── div.flex.min-h-0.min-w-0.flex-1
+    ├── ProfileSidebar
+    └── div.min-h-0.min-w-0.flex-1
+        └── {children}  → TerminalTabs
+```
+
+### 4.2 Local state
+
+| State | Default | Purpose |
+|-------|---------|---------|
+| `fileTreeOpen` | `true` | Sidebar panel visible |
+| `sidebarMode` | `"files"` | `"files" \| "git" \| "notes"` |
+
+### 4.3 Sidebar toggle behavior
+
+- **`onToggleFileTree`:** flips `fileTreeOpen`.
+- **`onSidebarModeChange(mode)`:**
+  - If sidebar open AND same mode clicked → close sidebar.
+  - Else set mode and open sidebar.
+
+### 4.4 File open handler
+
+`openFileTab(profile.id, filePath)` → `useFileViewerTabsStore.openFile`.
+
+---
+
+## 5. Profile Sidebar (`ProfileSidebar.tsx`)
+
+### 5.1 Component tree
+
+```
+ProfileSidebar (div.h-full.shrink-0)
+└── motion.div (animated width)
+    ├── [files mode, display block/none] FileTreePanel
+    ├── [mode === git] SidebarPanelContent → SidebarGitPanel
+    ├── [mode === notes] SidebarPanelContent
+    │   └── div → ProfileNotesEditor (lazy)
+    └── [isOpen] resize separator (role="separator")
+```
+
+### 5.2 Width & animation constants
+
+| Constant | Value |
+|----------|-------|
+| `SIDEBAR_PANEL_MIN_WIDTH` | 180px |
+| `SIDEBAR_PANEL_MAX_WIDTH` | 560px |
+| `DEFAULT_SIDEBAR_PANEL_WIDTH` | 208px |
+| `SIDEBAR_PANEL_STORAGE_KEY` | `"file-tree-panel"` (localStorage JSON `{ state: { panelWidth }, version: 2 }`) |
+| Spring transition | stiffness 320, damping 34, mass 0.9 |
+| Closed width | 0 (animate) |
+| Reduced motion | `{ duration: 0 }` |
+
+### 5.3 Resize handle
+
+| Property | Value |
+|----------|-------|
+| `aria-label` | `profileSidebarResizeSeparator` ("Resize sidebar") |
+| `aria-orientation` | `vertical` |
+| `aria-valuemin/max/now` | 180 / 560 / current width |
+| `tabIndex` | 0 |
+| Classes | `absolute top-0 -right-1 bottom-0 z-[1] w-2 cursor-col-resize focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-[var(--app-focus-ring)]` |
+| Pointer | `useHorizontalResize` drag |
+| Keyboard | ArrowLeft/Right ±16px; Home=min; End=max |
+
+### 5.4 Pointer events when closed
+
+- Container: `pointerEvents: none`, `aria-hidden={true}` when closed.
+
+### 5.5 SidebarPanelContent wrapper
+
+```
+div.flex.min-h-0.min-w-0.flex-1.flex-col.overflow-hidden.border-r
+└── AsyncBoundary
+    ├── fallback: LoadingSpinner
+    ├── error: LoadingError
+    └── children
+```
+
+### 5.6 Git mode panel (`SidebarGitPanel` — child, not in read list but mounted here)
+
+```
+div.flex.min-h-0.min-w-0.flex-1.flex-col.overflow-hidden
+├── ChangesFileList (scrollable file list + commit inclusion)
+└── CommitComposer (summary, body, commit/push)
+```
+
+**ChangesFileList header (sticky):**
+
+- Master checkbox (include all/none) → `gitCommitIncludeAll` aria-label
+- Text: `changedFiles({ count })`
+- Optional maximize button → `gitOpenDiffView`, `ArrowsOutSimpleIcon`, `size-6`
+- Empty: `noChangesDetected`
+
+**Keyboard:** none specific to sidebar git panel.
+
+---
+
+## 6. Sidebar Mode Switch (`SidebarModeSwitch.tsx`)
+
+### 6.1 Component tree
+
+```
+Tabs (value = isOpen ? mode : null)
+└── TabsList (h-7)
+    └── [for each mode: files, git, notes]
+        └── Tooltip
+            └── TooltipTrigger → TabsTrigger (px-2, aria-label=label)
+                ├── Icon (size-3.5): FolderSimpleIcon | GitBranchIcon | NoteIcon
+                └── [git only, if diffStats] +{additions} (text-green-500) -{deletions} (text-red-500)
+```
+
+### 6.2 Mode labels (i18n)
+
+| Mode | Key | English |
+|------|-----|---------|
+| files | `sidebarFilesTab` | Files |
+| git | `sidebarGitTab` | Git |
+| notes | `notes` | Notes |
+
+### 6.3 Interaction
+
+- Click tab → `onModeChange(value)` (also wired to Tabs `onValueChange`).
+- Git tab shows live diff stat badges when `useGitDiffStats(profileId, isActive)` returns data.
+- When sidebar closed, `Tabs` value is `null` (no tab appears selected).
+
+---
+
+## 7. File Tree Panel (`FileTreePanel.tsx`)
+
+### 7.1 Component tree
+
+```
+FileTreePanel (div.flex.h-full.min-h-0.min-w-0.overflow-hidden)
+└── motion.div (opacity/x slide when isOpen)
+    └── div.relative.min-h-0.min-w-0.flex-1.border-r.px-1.5.py-1
+        ├── FileTree (@pierre/trees)
+        │   └── renderContextMenu → FileTreeContextMenu
+        ├── [rootContextMenu] FileTreeRootContextMenu
+        └── [isTreePathsError] error overlay (absolute inset-0, pointer-events-none)
+            └── p.text-xs.text-muted-foreground (error message)
+```
+
+### 7.2 Pierre FileTree configuration
+
+| Option | Value |
+|--------|-------|
+| `density` | `"compact"` |
+| `flattenEmptyDirectories` | `false` |
+| `icons` | `"complete"` |
+| `initialExpansion` | `"closed"` |
+| `stickyFolders` | `true` |
+| Drag-and-drop | move within tree; also terminal drop payload |
+| Renaming | inline; draft create uses `startRenaming(..., { removeIfCanceled: true })` |
+
+### 7.3 CSS variables (`FILE_TREE_HOST_STYLE`)
+
+| Variable | Value |
+|----------|-------|
+| `--trees-font-size-override` | `13px` |
+| `--trees-level-gap-override` | `12px` |
+| `--trees-border-radius-override` | `4px` |
+| `--trees-item-margin-x-override` | `4px` |
+| `--trees-item-padding-x-override` | `4px` |
+| `--trees-padding-inline-override` | `4px` |
+| `--trees-bg-override` | `transparent` |
+| `--trees-selected-bg-override` | `var(--muted)` |
+| Host padding | `px-1.5 py-1` on wrapper |
+
+### 7.4 Animation
+
+| Property | Open | Closed |
+|----------|------|--------|
+| opacity | 1 | 0 |
+| x | 0 | -12 |
+| duration | 0.18s ease `[0.22, 1, 0.36, 1]` | same / 0 if reduced motion |
+
+### 7.5 Tree item interaction
+
+| Action | Behavior |
+|--------|----------|
+| Click file | Opens in file viewer tab (`onOpenFile`) |
+| Click directory | Expand/collapse |
+| Selection change (keyboard) | Opens single selected file unless suppressed |
+| MouseDown | Suppresses auto-open on selection (multi-select) |
+| Meta/Ctrl/Shift click | Does not auto-open on selection |
+| Drag start | Writes terminal drop payload; suppresses click-open 500ms |
+| KeyUp on focused dir | Sync expand/collapse state |
+
+**Draft create names:** `"New File"`, `"New Folder"` (English hardcoded in `FILE_TREE_CREATE_NAMES`).
+
+### 7.6 Context menu — item (`FileTreeContextMenu`)
+
+Rendered via `FileTreeMenu` → Base UI Menu portal.
+
+| Item | i18n key | Enabled when |
+|------|----------|--------------|
+| Open | `fileTreeContextMenuOpen` | file kind + in filePathSet |
+| Open in Default App | `fileTreeContextMenuOpenInDefaultApp` | path deletable/exists |
+| Reveal in Finder | `fileTreeContextMenuRevealInFileManager` | same |
+| — separator — | | |
+| Refresh | `fileTreeContextMenuRefresh` | !isRefreshing |
+| — separator — | | |
+| New File | `fileTreeContextMenuNewFile` | always |
+| New Folder | `fileTreeContextMenuNewFolder` | always |
+| Rename | `rename` | single path in tree |
+| — separator — | | |
+| Copy Relative Path | `fileTreeContextMenuCopyRelativePath` | always |
+| Copy Absolute Path | `fileTreeContextMenuCopyAbsolutePath` | always |
+| — separator — | | |
+| Delete | `delete` | all selected deletable; variant destructive |
+
+**Popup classes:** `z-50 max-h-[var(--available-height)] min-w-40 overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10`.
+
+### 7.7 Context menu — empty/root area (`FileTreeRootContextMenu`)
+
+| Item | i18n |
+|------|------|
+| New File | `fileTreeContextMenuNewFile` |
+| New Folder | `fileTreeContextMenuNewFolder` |
+| Refresh | `fileTreeContextMenuRefresh` |
+| Reveal in Finder | `fileTreeContextMenuRevealInFileManager` |
+| Copy Relative Path (`.`) | `fileTreeContextMenuCopyRelativePath` |
+| Copy Absolute Path (root) | `fileTreeContextMenuCopyAbsolutePath` |
+
+### 7.8 Loading / error states
+
+| State | UI |
+|-------|-----|
+| Tree paths loading | Pierre tree empty until data (no explicit spinner in panel) |
+| Tree paths error | Centered overlay text: error message, `text-xs text-muted-foreground` |
+| Create failure toast | `fileTreeCreateErrorTitle` + description |
+| Delete failure toast | `fileTreeDeleteErrorTitle` + description |
+| Refresh failure toast | `somethingWentWrong` |
+
+### 7.9 Git status integration
+
+- Status-only paths appear in tree (including deleted, ignored).
+- Deleted files: visible but not openable on click.
+- Status badges rendered by Pierre model via `setGitStatus`.
+
+### 7.10 Query gating
+
+When `!isOpen || !isActive`: file tree and git status queries disabled.
+
+---
+
+## 8. File Viewer (`FileViewerPane.tsx` + tab integration in `TerminalTabs.tsx`)
+
+### 8.1 Tab bar integration
+
+File tabs share the horizontal tab strip with terminal tabs.
+
+**File tab trigger (`TabsTrigger`):**
+
+```
+TabsTrigger (max-w-56 flex-none justify-start, nativeButton=false, render=<div/>)
+├── FileTreeFileIcon (size=14)
+├── span.truncate (filename title)
+├── [if dirty] span.size-2.rounded-full.bg-muted-foreground (unsaved dot)
+└── TabCloseButton (XIcon size-3, aria-label="Close {title}")
+```
+
+**Terminal tab trigger:** same layout class; terminal/agent icon; optional `AgentStatusDot`; close button.
+
+**Trailing control:** `TerminalTemplateMenu` (+ new terminal / templates dropdown).
+
+**Tab strip container:** `flex w-full min-w-0 items-center overflow-x-auto overflow-y-hidden border-b p-0`.
+
+### 8.2 FileViewerPane decision tree
+
+```
+FileViewerPane
+├── [previewableBinaryFile] → FilePreviewPane
+├── [loading && !hasLoadedFile] → Spinner in h-32 center
+├── [error && !hasLoadedFile] → error text h-32 center
+├── [!hasLoadedFile] → null
+├── [.md/.mdx] → MarkdownEditor
+└── else → Monaco Editor
+```
+
+### 8.3 Monaco editor pane
+
+| Property | Value |
+|----------|-------|
+| Container | `div.h-full.min-h-0.overflow-hidden` ref for save focus |
+| Height | `100%` |
+| Theme | `light` or `vs-dark` from terminal theme id |
+| Font | terminal settings `fontFamily`, `fontSize` |
+| Options | minimap off; padding top/bottom 12; ligatures; wordWrap off; no TS/JS validation |
+| Loading | centered Spinner |
+| Unsaved | tracked in `fileViewerDirtyStore`; 400ms draft debounce (`DRAFT_SYNC_DELAY_MS`) |
+
+### 8.4 Markdown file pane
+
+Uses `MarkdownEditor` with `editorKey={filePath}`, `saveStatus` from save mutation (`saving` \| `idle`).
+
+### 8.5 FilePreviewPane (binary/archive/image/pdf)
+
+**Header:** `min-h-9`, `border-b`, `bg-muted`, `px-3`
+
+| Element | Content |
+|---------|---------|
+| Left | filename, `truncate text-sm font-medium` |
+| Right | `"Office Preview"` if kind `office-pdf`, else hardcoded `"Preview"` (not i18n) |
+
+**Archive:** `ArchivePreviewTree` instead of generic preview.
+
+**Image:** checkerboard background grid, `object-fit: contain`, max dimensions 100%.
+
+**PDF:** full-size iframe, white background, border 0.
+
+**Loading:** Spinner centered.
+
+**Error:** `text-sm text-muted-foreground` centered, max-w-lg.
+
+**Unavailable:** hardcoded `"Preview unavailable"`.
+
+**Previewable extensions:** images (png, jpg, …), pdf, office docs, archives (.zip, .tar, .tar.gz, .tgz, .gz).
+
+### 8.6 ArchivePreviewTree
+
+```
+div.flex.h-full.min-h-0.flex-col.overflow-hidden
+├── header (min-h-9, border-b, bg-muted, px-3)
+│   ├── filename (truncate text-sm font-medium)
+│   └── "{fileCount} files / {directoryCount} folders" (hardcoded English)
+└── FileTree (read-only, initialExpansion open, same 13px tree styles)
+```
+
+### 8.7 Terminal vs file content visibility
+
+- File viewer: conditionally rendered when `fileTabActive && activeFilePath`.
+- Terminals: **never unmounted**; parent `display: none` when file tab active; each terminal `visibility hidden` except active tab.
+
+### 8.8 Unsaved close dialog (`UnsavedFileCloseDialog`)
+
+**Trigger:** closing file tab while path in `dirtyFilePathSet`.
+
+| Element | i18n |
+|---------|------|
+| Title | `closeUnsavedFileTitle` + WarningCircleIcon |
+| Body | `closeUnsavedFileDescription({ file })` |
+| Cancel | `cancel` |
+| Discard | `discardChanges` (destructive) |
+
+### 8.9 Keyboard shortcuts (file editor)
+
+| Shortcut | Action |
+|----------|--------|
+| `Cmd/Ctrl+S` | Save (window listener + Monaco command) |
+
+---
+
+## 9. Markdown Editor (`MarkdownEditor.tsx`)
+
+Used by profile notes and `.md`/`.mdx` file tabs.
+
+### 9.1 Component tree
+
+```
+MarkdownEditor (div.milkdown-wrapper.h-full.overflow-hidden)
+└── MilkdownProvider
+    └── MilkdownEditor (div.flex.h-full.min-h-0.flex-col)
+        ├── MarkdownToolbar
+        └── div.min-h-0.flex-1.overflow-y-auto.p-4
+            └── Milkdown (ProseMirror)
+```
+
+### 9.2 Toolbar layout (`MarkdownToolbar`)
+
+Container: `flex shrink-0 items-center gap-1 overflow-x-auto border-b bg-background px-2 py-1`.
+
+**Sections left → right:**
+
+1. **Command menu dropdown** (`notesCommandMenu`, ListIcon) — block types, quote, code block, table, divider.
+2. **Separator** vertical `h-5`.
+3. **Inline formatting buttons** (ghost icon-xs, active: `bg-muted text-foreground`):
+   - Bold (`notesFormatBold` + hint `⌘B`)
+   - Italic (`notesFormatItalic` + `⌘I`)
+   - Code (`notesFormatCode` + `⌘E`)
+   - Strike (`notesFormatStrike`, renders "S" with line-through)
+   - Link (`notesFormatLink`)
+4. **Separator**
+5. **List/quote buttons:** bullet list, ordered list (shows "1."), quote.
+6. **Separator**
+7. **Table menu** (`notesTableMenu`, TableIcon): insert table, add row/col, delete cells.
+8. **Link editor inline** (when open): Input placeholder `https://`, apply (CheckIcon), remove (XIcon).
+9. **SaveStatusIndicator** (flex-1 justify-end): Badge with Saving/Saved/Failed.
+
+### 9.3 Save status badge
+
+| Status | Icon | Label | Badge variant |
+|--------|------|-------|---------------|
+| saving | FloppyDiskIcon | `notesSaving` | secondary |
+| saved | CheckIcon | `notesSaved` | default |
+| failed | WarningCircleIcon | `notesSaveFailedShort` | destructive |
+| idle | (spacer flex-1) | — | — |
+
+### 9.4 Slash command menu (typing `/`)
+
+Floating menu class `markdown-editor-slash-menu` with items: Paragraph, H1–H3, bullet/ordered list, quote, code block, table (3×3), divider.
+
+### 9.5 Placeholder
+
+CSS `data-placeholder` on empty paragraph; default i18n `notesPlaceholder` ("Write notes for this profile…") or prop override.
+
+### 9.6 Auto-save timing
+
+- Markdown change debounce: **650ms** before `onMarkdownChange`.
+- Profile notes: saves via API on change (see ProfileNotesEditor).
+
+### 9.7 Keyboard
+
+| Shortcut | Action |
+|----------|--------|
+| `Cmd/Ctrl+S` | `onRequestSave` when pane focused (file tabs); notes editor omits handler unless passed |
+
+---
+
+## 10. Profile Notes (`ProfileNotesEditor.tsx`)
+
+### 10.1 Component tree
+
+```
+ProfileNotesEditor
+└── MarkdownEditor
+    editorKey={profile.id}
+    initialMarkdown={profile.notes}
+    placeholder={notesPlaceholder}
+    saveStatus={saveStatus from local state}
+```
+
+### 10.2 Save behavior
+
+- On markdown change (after editor debounce): calls `useUpdateProfileNotes` mutation.
+- Status flow: `idle` → `saving` → `saved` (1.6s) → `idle`, or `failed` on error toast `notesSaveFailedTitle`.
+- Skips save if markdown equals last saved.
+
+### 10.3 Layout
+
+Fills sidebar panel: `min-h-0 flex-1 overflow-hidden` inside `SidebarPanelContent`.
+
+---
+
+## 11. Command Palette (`CommandPalette.tsx`)
+
+### 11.1 Component tree
+
+```
+Command.Dialog (cmdk)
+├── [header] div.border-b.px-4.py-3
+│   └── Command.Input (placeholder, aria-label)
+├── Command.List (max-h-[60vh] overflow-y-auto p-1)
+│   ├── [error] CommandPaletteStatusMessage
+│   ├── [empty] CommandPaletteEmptyState
+│   └── CommandPaletteResultList
+│       └── CommandPaletteResultItem × N
+│           ├── FileTreeFileIcon (16)
+│           ├── name (truncate text-sm)
+│           └── parent path (truncate text-xs muted)
+```
+
+### 11.2 CSS (`app.css`)
+
+| Class | Styles |
+|-------|--------|
+| `project-command-palette__overlay` | fixed inset-0, z-index 1400, rgba(0,0,0,0.4) |
+| `project-command-palette__dialog` | fixed, top 72px, centered, padding-inline 12px, z-index 1401 |
+| `project-command-palette__root` | width min(100%, 40rem), max-height calc(100vh - 96px), border-radius 8px, popover background |
+
+### 11.3 Result item
+
+Classes: `flex min-w-0 select-none items-center gap-2 rounded px-3 py-2 data-[selected=true]:bg-muted`.
+
+### 11.4 Empty / error messages
+
+| Condition | Message |
+|-----------|---------|
+| No search, no results | `commandPaletteEmpty` |
+| Search, no results | `commandPaletteNoResults` |
+| API error, no cached results | error text via `getErrorMessage` |
+
+### 11.5 Keyboard
+
+| Shortcut | Action |
+|----------|--------|
+| `Cmd/Ctrl+K` | Open palette (capture phase, active profile only) |
+| Arrow keys | Navigate results (cmdk `loop`) |
+| Enter | Open selected file, close palette |
+| Escape | Close (via onOpenChange) |
+
+**Note:** i18n keys `commandPaletteHint`, `commandPaletteOpenHint`, `commandPaletteFooterHint`, `commandPaletteResultCount` exist in en.json but are **not rendered** in current CommandPalette UI.
+
+---
+
+## 12. Project Top Bar (`ProjectTopBar.tsx`)
+
+### 12.1 Component tree
+
+```
+ProjectTopBar
+├── div[data-tauri-drag-region] (relative flex min-h-[44px] items-end justify-between px-4 pt-1 pb-1.5)
+│   ├── leftContent
+│   ├── titleContent (absolute centered)
+│   └── controlsContent
+├── ProjectSettingsDialog
+├── SwitchBranchDialog
+└── GitDiffDialog (branch-aware for default profile)
+```
+
+### 12.2 Bar padding (platform)
+
+| Platform / state | Class |
+|------------------|-------|
+| Windows | `pr-[118px]` |
+| Default | `pr-5` |
+| macOS + collapsed app sidebar | `pl-[84px]` |
+
+### 12.3 Left region
+
+| Element | When | Details |
+|---------|------|---------|
+| Expand sidebar button | App sidebar collapsed | `SidebarSimpleIcon`, ghost icon button, `expandSidebar` |
+| SidebarModeSwitch | Always when props provided | see §6 |
+
+### 12.4 Center title region
+
+Classes: `pointer-events-none absolute inset-x-0 bottom-1.5 flex min-w-0 items-center justify-center gap-2 px-32`.
+
+| Element | Content |
+|---------|---------|
+| Project name button | `truncate font-semibold`; click → reveal worktree in file manager; tooltip shows `profile.worktree_path` |
+| Branch button | `switchBranchTitle` aria-label |
+
+**Branch display rules:**
+
+- **Default profile + active:** live `GitBranchLabel` (fetched branch name) with GitBranchIcon.
+- **Default profile + inactive:** no branch label shown.
+- **Non-default profile:** static `profile.branch_name` with GitBranchIcon.
+
+### 12.5 Right controls
+
+- Dynamic topbar controls from registry (`visibleActiveControls`).
+- Settings gear: `projectSettings`, secondary icon button.
+
+### 12.6 Topbar control components (`controls.tsx`)
+
+| Control ID | Button | Label pattern | Action |
+|------------|--------|---------------|--------|
+| github-desktop | icon-sm secondary | `topbarGithubDesktop` | Open GitHub Desktop at worktree |
+| editor | icon-sm secondary | `topbarEditor` · {app name} | Open configured editor app |
+| terminal | icon-sm secondary | `topbarTerminal` · {app name} | Open configured terminal app |
+| pr-status | xs secondary with text | `#N {state}` | Open PR URL; tooltip `topbarPrTooltip` |
+
+**PR states:** Draft, Open, Merged, Closed (`topbarPrDraft/Open/Merged/Closed`).
+
+### 12.7 Keyboard shortcuts (active profile)
+
+| Shortcut | Action |
+|----------|--------|
+| `Cmd/Ctrl+G` | Open Git diff dialog (changes tab) |
+| `Cmd/Ctrl+E` | Toggle file tree sidebar (`onToggleFileTree`) |
+
+---
+
+## 13. Top Bar Settings UI (`topbar/*.tsx`)
+
+Configured in app Settings page, not on project detail directly.
+
+### 13.1 TopBarSettings
+
+```
+div.flex.max-w-2xl.flex-col.gap-6
+├── hint text (topbarDragHint)
+├── DndContext
+│   ├── TopBarPreview
+│   ├── AvailableControls
+│   └── DragOverlay → DraggableControl
+├── Editor app NativeSelect (if apps detected)
+├── Terminal app NativeSelect
+└── Reset button (topbarResetDefaults)
+```
+
+**Loading:** `topbarDetectingApps`.
+
+### 13.2 TopBarPreview
+
+Mock bar: "My Project" + branch "main" + draggable active controls or `topbarNoControls`.
+
+### 13.3 AvailableControls
+
+Dashed border drop area; inactive controls or `topbarAllControlsActive`.
+
+### 13.4 DraggableControl
+
+`rounded-md border bg-muted p-2`; grab cursor; DotsSixVerticalIcon + control icon (16px); dragging opacity 0.4.
+
+---
+
+## 14. Dialogs — Projects
+
+### 14.1 CreateProjectDialog
+
+**Open triggers:** App sidebar "New Project" button (`#add-project-button`).
+
+| Element | Details |
+|---------|---------|
+| Title | FolderPlusIcon + `createProject` |
+| Empty folder state | Dashed border button, FolderIcon size-6, `chooseFolder` |
+| Selected folder | Label `folder`, outline xs button to re-pick, `code` block with path |
+| Field | `projectName` input, placeholder `projectNamePlaceholderFolder` |
+| Description | Dynamic hint from folder/name state |
+| Footer | Cancel + Create (Spinner when pending) |
+
+**Validation:** Create disabled until folder selected.
+
+**Success:** navigates to new project's first profile.
+
+**Enter key:** submits from name field.
+
+### 14.2 DeleteProjectDialog
+
+**Open trigger:** Project context menu in sidebar (`ProjectMenuItem`).
+
+| Element | i18n |
+|---------|------|
+| Title | TrashIcon + `deleteProject` |
+| Body | `confirmDeleteProject` |
+| Cancel | `cancel` |
+| Delete | `delete` (destructive, Spinner when pending) |
+
+### 14.3 RenameProjectDialog
+
+**Open trigger:** Project context menu → Rename.
+
+| Element | i18n |
+|---------|------|
+| Title | PencilSimpleIcon + `renameProject` |
+| Field | `newName` |
+| Submit disabled | empty or unchanged name |
+| Buttons | `cancel`, `rename` |
+
+**Focus:** `[data-rename-input]` on open.
+
+### 14.4 ProjectSettingsDialog
+
+**Open trigger:** Project context menu → Settings; also gear in ProjectTopBar.
+
+| Element | Details |
+|---------|---------|
+| Content width | `sm:max-w-lg` |
+| Title | GearSixIcon + `projectSettings` |
+| Loading | Spinner min-h-[200px] |
+| Error | DialogBodyError |
+
+**Tabs:**
+
+| Tab | Icon | Content |
+|-----|------|---------|
+| scripts (default) | CodeIcon | Worktree dir + init/setup/teardown script textareas |
+| templates | TerminalWindowIcon | ProjectTemplatesEditor |
+
+**Scripts tab fields:**
+
+| Field | Label | Description key |
+|-------|-------|-----------------|
+| worktreeDir | `projectWorktreeDir` | `projectWorktreeDirDesc`, placeholder `projectWorktreeDirPlaceholder` |
+| initScript | `initScript` | `initScriptDesc`, 4-row mono textarea |
+| setupScript | `setupScript` | `setupScriptDesc` |
+| teardownScript | `teardownScript` | `teardownScriptDesc` |
+
+**Footer:** Cancel + Save (Spinner when pending).
+
+### 14.5 ProjectTemplatesEditor (`components/ProjectTemplatesEditor.tsx`)
+
+| Element | i18n |
+|---------|------|
+| Section title | `projectTerminalTemplates` |
+| Description | `projectTerminalTemplatesDescription` |
+| Add button | `addTerminalTemplate` |
+| Empty | `noTerminalTemplates` |
+| Row actions | edit (`editTerminalTemplate`), delete (`deleteTerminalTemplate`) |
+| Row shows | name, command preview (mono), optional cwd |
+
+**Sub-dialog:** `TerminalTemplateDraftDialog` (from terminal feature) for create/edit.
+
+### 14.6 UnsavedFileCloseDialog
+
+See §8.8.
+
+---
+
+## 15. Dialogs — Profiles
+
+### 15.1 CreateProfileDialog
+
+**Open triggers:**
+
+- `ProfileList` "New Profile" control.
+- `ProjectMenuItem` when project has only default profile.
+
+| Element | i18n |
+|---------|------|
+| Title | GitBranchIcon + `createProfile` ("New Profile") |
+| Field | `branchName`, placeholder `branchNamePlaceholder` |
+| Footer | `cancel`, `create` |
+
+**Enter:** submits if not pending.
+
+**Success:** navigate to new profile route.
+
+### 15.2 DeleteProfileDialog
+
+**Open trigger:** Profile item context menu (`ProfileItem`).
+
+| Element | i18n |
+|---------|------|
+| Title | TrashIcon + `deleteProfile` |
+| Body | `confirmDeleteProfile` |
+| Checking state | Spinner + `deleteProfileCheckingGitStatus` |
+| Risk alert | `deleteProfileGitWarningTitle` + combined warnings |
+| Git check failed alert | `deleteProfileGitCheckFailedTitle/Description` |
+| Delete button | `deleteProfileAnyway` if risk, else `delete` |
+
+**Delete disabled while:** git check fetching or delete pending.
+
+---
+
+## 16. Shared components
+
+### 16.1 FileTreeFileIcon
+
+- SVG icon from `@pierre/trees` symbol set based on filename extension.
+- Default size **14px** (command palette uses **16**).
+- Props: `fileName`, optional `size`.
+- `aria-hidden="true"`, `data-icon-name`, `data-icon-token`.
+- Color via CSS var `--trees-file-icon-color-{token}`.
+
+### 16.2 OverflowTooltipText
+
+- Truncating span (`min-w-0 truncate`).
+- Tooltip only when text overflows (canvas measurement via `@chenglou/pretext`).
+- Tooltip: side top, align start, max-width `min(480px, calc(100vw - 32px))`, `break-all whitespace-normal`.
+- Prop `tooltipDisabled` suppresses tooltip.
+
+**Used in:** sidebar profile labels (not in scoped file list but referenced by layout).
+
+---
+
+## 17. Terminal tab strip extras (`TerminalTemplateMenu`)
+
+**New terminal tab trigger:** TabsTrigger value `__new-terminal__`, PlusIcon.
+
+**Dropdown sections:** Project templates, global templates, default terminal; empty hint `noTemplatesDropdownHint`.
+
+---
+
+## 18. Complete keyboard shortcut reference (scoped surfaces)
+
+| Shortcut | Surface | Action |
+|----------|---------|--------|
+| Cmd/Ctrl+K | Profile (active) | Open command palette |
+| Cmd/Ctrl+S | File editor / markdown file | Save file |
+| Cmd/Ctrl+G | Profile (active) | Open git diff dialog |
+| Cmd/Ctrl+E | Profile (active) | Toggle sidebar open/close |
+| Cmd/Ctrl+T | Profile (active) | New terminal |
+| Cmd/Ctrl+W | Profile (active) | Close terminal tab |
+| Arrow L/R, Home, End | Profile sidebar resize handle | Adjust width |
+| Enter | Command palette | Open file |
+| Escape | Command palette / dialogs | Close |
+| Enter | Rename/create dialogs | Submit where wired |
+
+---
+
+## 19. i18n key index (English) — scoped features
+
+Keys listed in `messages/en.json` directly referenced by inventoried components:
+
+**Home:** `home`, `emptyProjectsTitle`, `emptyProjectsDesc`, `onboardingTourTitle`, `onboardingTourDesc`
+
+**Project detail / terminal empty:** `noTerminalsOpen`, `noTerminalsOpenDescription`, `newTerminal`
+
+**Sidebar:** `sidebarFilesTab`, `sidebarGitTab`, `notes`, `profileSidebarResizeSeparator`, `expandSidebar`
+
+**File tree menus:** `fileTreeContextMenuOpen`, `fileTreeContextMenuOpenInDefaultApp`, `fileTreeContextMenuRevealInFileManager`, `fileTreeContextMenuRefresh`, `fileTreeContextMenuNewFile`, `fileTreeContextMenuNewFolder`, `fileTreeContextMenuCopyRelativePath`, `fileTreeContextMenuCopyAbsolutePath`, `rename`, `delete`, `fileTreeCreateErrorTitle`, `fileTreeDeleteErrorTitle`, `somethingWentWrong`
+
+**Command palette:** `commandPaletteTitle`, `commandPalettePlaceholder`, `commandPaletteEmpty`, `commandPaletteNoResults`, `commandPaletteRoot`
+
+**File close:** `closeUnsavedFileTitle`, `closeUnsavedFileDescription`, `cancel`, `discardChanges`
+
+**Notes / markdown:** `notes`, `notesPlaceholder`, `notesSaving`, `notesSaved`, `notesSaveFailedShort`, `notesSaveFailedTitle`, all `notesFormat*`, `notesInsert*`, `notesTable*`, `notesCodeBlock*`, `notesCommandMenu`, `notesApplyLink`, `notesRemoveLink`, `preview`
+
+**Project dialogs:** `createProject`, `chooseFolder`, `folder`, `projectName`, `projectNamePlaceholderFolder`, `createProjectChooseFolderHint`, `createProjectHintFolderEmpty`, `createProjectHintFolderNamed`, `create`, `cancel`, `deleteProject`, `confirmDeleteProject`, `renameProject`, `newName`, `rename`, `projectSettings`, `scripts`, `templates`, `projectWorktreeDir*`, `initScript*`, `setupScript*`, `teardownScript*`, `scriptPlaceholder`, `save`, `projectTerminalTemplates*`, `addTerminalTemplate`, `editTerminalTemplate`, `deleteTerminalTemplate`, `noTerminalTemplates`, `terminalTemplate`
+
+**Profile dialogs:** `createProfile`, `branchName`, `branchNamePlaceholder`, `deleteProfile`, `confirmDeleteProfile`, `deleteProfileCheckingGitStatus`, `deleteProfileGitWarningTitle`, `deleteProfileLocalChangesWarning`, `deleteProfileUnpushedCommitsWarning`, `deleteProfileTotalDiffWarning`, `deleteProfileGitCheckFailedTitle`, `deleteProfileGitCheckFailedDescription`, `deleteProfileAnyway`
+
+**Top bar:** `projectSettings`, `switchBranchTitle`, `topbarGithubDesktop`, `topbarEditor`, `topbarTerminal`, `topbarPrStatus`, `topbarPr*`, `topbarPreview`, `topbarAvailable`, `topbarDragHint`, `topbarResetDefaults`, `topbarDetectingApps`, `topbarNoControls`, `topbarAllControlsActive`, `topbarEditorApp`, `topbarTerminalApp`
+
+**Git sidebar:** `noChangesDetected`, `changedFiles`, `gitCommitIncludeAll`, `gitOpenDiffView`, (+ commit composer keys)
+
+---
+
+## 20. Dialog open trigger summary
+
+| Dialog | Trigger location |
+|--------|------------------|
+| CreateProjectDialog | AppSidebar new project button |
+| DeleteProjectDialog | ProjectMenuItem context menu |
+| RenameProjectDialog | ProjectMenuItem context menu |
+| ProjectSettingsDialog | ProjectMenuItem context menu; ProjectTopBar gear |
+| CreateProfileDialog | ProfileList; ProjectMenuItem (single-profile projects) |
+| DeleteProfileDialog | ProfileItem context menu |
+| UnsavedFileCloseDialog | Close dirty file tab in TerminalTabs |
+| CommandPalette | Cmd/Ctrl+K |
+| GitDiffDialog | Cmd/Ctrl+G; git sidebar maximize; double-click changed file |
+| SwitchBranchDialog | Click branch in ProjectTopBar |
+
+---
+
+*Generated from codebase exploration. Hardcoded English strings not in en.json are called out explicitly (e.g. "Preview unavailable", archive file counts, "Choose template", draft "New File"/"New Folder").*

--- a/docs/ui-inventory-settings-terminal-git-debug-updater.md
+++ b/docs/ui-inventory-settings-terminal-git-debug-updater.md
@@ -1,0 +1,1228 @@
+# 2code UI Inventory — Settings, Terminal, Git, Debug, Updater & Dialogs
+
+Framework-agnostic inventory derived from source code in `/workspace`. Intended for reimplementing the UI without the current frontend stack.
+
+**Scope:** Settings window, Terminal UI, Git UI, Debug UI, Updater UI, and all remaining modal dialogs/overlays.
+
+**Out of scope (referenced only where they attach):** Home page, sidebar, file tree, file viewer, command palette, notes editor, onboarding tour.
+
+---
+
+## Table of Contents
+
+1. [Window Architecture](#1-window-architecture)
+2. [Settings Window](#2-settings-window)
+3. [Terminal UI](#3-terminal-ui)
+4. [Git UI](#4-git-ui)
+5. [Debug UI](#5-debug-ui)
+6. [Updater UI](#6-updater-ui)
+7. [Remaining Dialogs & Overlays](#7-remaining-dialogs--overlays)
+8. [Global Toast System](#8-global-toast-system)
+9. [Cross-Cutting Platform Differences](#9-cross-cutting-platform-differences)
+10. [Keyboard Shortcuts Summary](#10-keyboard-shortcuts-summary)
+
+---
+
+## 1. Window Architecture
+
+### 1.1 Main Window (`tauri.conf.json`)
+
+| Property | Value |
+|----------|-------|
+| Title (internal) | `2code` |
+| Visible title bar text | Hidden (`hiddenTitle: true`) |
+| Decorations | Enabled |
+| Title bar style | **Overlay** (macOS-style integrated title bar) |
+| Traffic light position (macOS) | x=16, y=24 |
+| Default size | 1440 × 900 px, centered |
+| Maximizable | Yes |
+
+**Layout (main window root):**
+
+```
+MainWindow
+├── StartupUpdateCheck (invisible — side effect only)
+├── Horizontal split
+│   ├── AppSidebar (left, collapsible)
+│   └── Main content area (relative, scrollable card background)
+│       ├── Routes (Home / Project detail placeholder)
+│       └── TerminalLayer (absolute inset-0 overlay; shown on profile routes)
+├── DebugFloat (fixed bottom-right FAB, conditional)
+└── WindowControls (Windows only — custom min/max/close)
+```
+
+**Drag region:** Project top bar uses `data-tauri-drag-region` for window dragging on macOS overlay chrome.
+
+### 1.2 Settings Window (second webview)
+
+Created by Tauri command `open_settings_window` when not already open.
+
+| Property | Value |
+|----------|-------|
+| Label | `settings` |
+| Title | `Settings` |
+| URL | `index.html` (same SPA entry; frontend branches on window label) |
+| Size | 880 × 640 px (default), min 600 × 420 px |
+| Centered | Yes |
+| Decorations | System default (no overlay title bar config) |
+
+**Frontend branch (`main.tsx`):** If `getCurrentWebviewWindow().label === "settings"`, render `SettingsWindow` instead of `App`. Settings window does **not** mount: file watcher, terminal layer, sidebar, or startup profiling sync.
+
+**Settings URL tabs:** Query param `?tab=<tabId>` selects settings tab. `open_update_page` opens/reuses settings window with `?tab=about`.
+
+**Cross-window sync:** Settings edited in the settings window sync to the main window via broadcast store sync (`crossWindowSync.ts`).
+
+### 1.3 Global Providers (both windows)
+
+Outer → inner: QueryClient → ThemeProvider → TooltipProvider → BrowserRouter → content → **Toaster** (Sonner toast stack).
+
+---
+
+## 2. Settings Window
+
+### 2.1 Root: `SettingsWindow`
+
+```
+SettingsWindow
+└── div (full height, card background, foreground text)
+    └── SettingsPage
+```
+
+No sidebar, no terminal layer, no file watcher.
+
+### 2.2 `SettingsPage` — Tab Shell
+
+**Layout:** Full-height column.
+
+```
+SettingsPage
+├── Tabs (flex-1 column, min-height 0)
+│   ├── TabsList (horizontal, margin 20px top, scroll-x if overflow)
+│   │   └── 6 × TabsTrigger (icon + label each)
+│   └── Scrollable content area (padding 20px, flex-1 overflow auto)
+│       └── TabsContent (one visible at a time)
+```
+
+**Tabs (left → right):**
+
+| Tab ID | Icon | English label (`en.json`) |
+|--------|------|---------------------------|
+| `general` | Gear | General |
+| `terminal` | Terminal window | Terminal |
+| `template` | Code | Terminal Templates |
+| `notification` | Bell | Notification |
+| `topbar` | Monitor | Top Bar |
+| `about` | Info | About |
+
+**Tab state:** Persisted in URL search param `tab`. Default tab when absent: `general`. Changing to `general` clears the param.
+
+**Terminal tab split layout:** Two columns with 32px gap:
+- **Left column:** max-width ~28rem (`max-w-md`), vertical stack gap 24px — pickers
+- **Right column:** flex-1 — live `TerminalPreview`
+
+---
+
+### 2.3 General Tab
+
+**Container:** Vertical stack, max-width ~28rem, gap 24px.
+
+#### 2.3.1 Language
+
+| Element | Type | Content |
+|---------|------|---------|
+| Label | Field label | `Language` |
+| Control | Native select (small) | Options: `English` (value `en`), `中文` (value `zh`) |
+
+Changing value calls `setAppLocale`.
+
+#### 2.3.2 Theme (app light/dark)
+
+| Element | Type | Content |
+|---------|------|---------|
+| Label | Field label | `Theme` |
+| Control | Native select (small) | `System`, `Light`, `Dark` |
+
+Stored in `ThemeContext` preference (separate from terminal theme).
+
+#### 2.3.3 BorderRadiusPicker
+
+| Element | Type | Content |
+|---------|------|---------|
+| Label | Field label | `Border Radius` |
+| Control | Toggle group (small, single-select) | `None`, `Small`, `Medium`, `Large`, `Extra Large` |
+
+**Store default:** `sm` (Small).
+
+**Effect:** Sets CSS custom properties `--radius`, `--radius-sm/md/lg/xl` on document root.
+
+#### 2.3.4 WorktreeSettings
+
+| Element | Type | Content |
+|---------|------|---------|
+| Label | Field label | `Default Worktree Directory` |
+| Description | Field description | `Used for new profiles when a project does not set worktree_dir. Relative paths are resolved from the project folder.` |
+| Row | Horizontal flex | Text input (editable path) + Outline button with folder icon (`Choose Folder`) + Ghost icon button (X, clear) |
+
+**Placeholder:** `Default: ~/.2code/workspace`
+
+**Clear button:** Disabled when path empty. Aria-label: `Clear default worktree directory`.
+
+**Choose Folder:** Opens native directory picker dialog (Tauri).
+
+**Store default:** empty string.
+
+#### 2.3.5 Debug Mode
+
+| Element | Type | Content |
+|---------|------|---------|
+| Label | Field label | `Debug Mode` |
+| Description | `Show backend log events in a floating panel.` |
+| Control | Switch (right-aligned horizontal field) |
+
+**Store default:** `enabled: false`. Persisted. Toggling on starts backend debug log channel.
+
+#### 2.3.6 Performance Profiling
+
+| Element | Type | Content |
+|---------|------|---------|
+| Label | Field label | `Performance Profiling` |
+| Description | `Write frontend and backend performance traces until this is turned off or the app exits.` |
+| Control | Switch |
+
+**Store default:** `enabled: false`. Not persisted across restarts (in-memory Zustand only).
+
+#### 2.3.7 SidebarAppearanceSettings
+
+| Element | Type | Content |
+|---------|------|---------|
+| Label | Field label | `Show Project Avatars` |
+| Description | `Display project avatars in the left sidebar.` |
+| Control | Switch |
+
+**Store default:** `showProjectAvatars: true`.
+
+---
+
+### 2.4 Terminal Tab
+
+**Left column (top → bottom):**
+
+#### TerminalThemePicker
+
+**When "sync theme" checked:**
+- One theme select labeled `Terminal Theme`
+- Preview eye button (ghost icon-xs, right of label)
+
+**When sync unchecked:**
+- `Dark Mode Theme` select + preview button
+- `Light Mode Theme` select + preview button
+
+**Theme select options** (display names from `themes.ts`):
+
+| ID | Display name |
+|----|--------------|
+| github-dark | GitHub Dark |
+| github-light | GitHub Light |
+| dracula | Dracula |
+| ayu-dark | Ayu Dark |
+| ayu-light | Ayu Light |
+| solarized-dark | Solarized Dark |
+| solarized-light | Solarized Light |
+| one-dark | One Dark |
+| one-light | One Light |
+
+**Preview button:** Aria-label `Preview`. Sets parent preview theme override.
+
+**Sync checkbox row:** Checkbox + label `Use same theme for both modes`
+
+**Store defaults:**
+- `darkTerminalTheme`: `github-dark`
+- `lightTerminalTheme`: `github-light`
+- `syncTerminalTheme`: `false`
+
+#### ShellPicker (async — skeleton 70px while loading)
+
+| Element | Content |
+|---------|---------|
+| Label | `Default Shell` |
+| Select | List of detected shells; default shell marked `(default)`; last option `Custom` |
+| Conditional input | Shown when Custom selected — monospace input, placeholder `e.g. /usr/bin/fish` |
+| Description | `Used for newly opened terminal tabs.` |
+
+Shell list from backend `listAvailableShells`.
+
+#### FontPicker (async — skeleton 70px)
+
+| Element | Content |
+|---------|---------|
+| Label | `Terminal Font` |
+| Select | Mono fonts by default; each option shows font family name |
+| Empty state | Select shows `Unavailable` + description `No system fonts were found on this machine.` |
+| Checkbox below | `Show all fonts` (includes non-monospace when checked) |
+
+**Store defaults:** `fontFamily: "JetBrains Mono"`, `showAllFonts: false`
+
+**Platform:** `listSystemFonts` — macOS Core Text, Linux/Windows fontdb.
+
+#### FontSizePicker
+
+| Element | Content |
+|---------|---------|
+| Label | `Font Size` |
+| Control | Number input |
+
+**Constraints:** min 10, max 20. **Default:** 13.
+
+**Right column: TerminalPreview**
+
+Read-only faux terminal block:
+- Background/foreground from selected or auto terminal theme
+- Font family/size from terminal settings store
+- Padding 12px 16px, 8px border radius, 0.5px border
+- Fixed sample lines: `whoami`, `ls`, `echo "Hello, 2code!"` with green `$` prompts
+- Blinking block cursor on last empty prompt line
+
+Preview updates live when font/size/theme eye-preview changes.
+
+---
+
+### 2.5 Template Tab (Global Terminal Templates)
+
+**Container:** max-width ~42rem (`max-w-2xl`).
+
+```
+GlobalTerminalTemplatesSettings
+├── Header row
+│   ├── Title: "Global Templates" (semibold)
+│   ├── Description: "These templates are available in every project."
+│   └── Button (outline, sm): "Add Template"
+├── Empty state OR template list
+└── TerminalTemplateDraftDialog (modal)
+```
+
+**Empty state:** Bordered rounded box, muted text: `No templates yet.`
+
+**Template list item (each):**
+- Bordered rounded row, horizontal flex
+- Left: template name (truncate, medium weight) + command preview (monospace, muted, truncate)
+- Right: Ghost icon buttons — Edit (pencil), Delete (trash, destructive color)
+- Disabled while save pending
+
+**Store default:** empty templates array (persisted via Tauri storage).
+
+---
+
+### 2.6 Notification Tab
+
+**Container:** max-width ~28rem, gap 24px.
+
+#### Enable toggle
+
+| Label | `Enable Notifications` |
+| Description | `Allow this app to send system notifications.` |
+| Control | Switch |
+
+On enable: requests OS notification permission; if denied, toggle reverts.
+
+**Store default:** `enabled: false`
+
+#### SoundPicker (async)
+
+| Label | `Sound` |
+| Preview button | Speaker icon, aria-label `Preview` — disabled if notifications off, no sound, or no sounds |
+| Select | `None` + system sound names; disabled when notifications off or no sounds |
+| Empty | Shows `No system sounds` + description |
+
+**Store default:** `sound: "Ping"`
+
+**Platform:** `listSystemSounds` / `playSystemSound` — macOS `/System/Library/Sounds`, Windows `C:\Windows\Media`, Linux XDG dirs.
+
+---
+
+### 2.7 Top Bar Tab (`TopBarSettings`)
+
+**Container:** max-width ~42rem, gap 24px.
+
+```
+TopBarSettings
+├── Hint text: "Drag controls to reorder or move between areas."
+├── DndContext
+│   ├── TopBarPreview ("Current Controls")
+│   ├── AvailableControls ("Available Controls")
+│   └── DragOverlay (floating copy while dragging)
+├── Optional app selects (if apps detected)
+│   ├── Editor Application → native select
+│   └── Terminal Application → native select
+└── Button (outline, sm): "Reset to Defaults"
+```
+
+**Loading:** `Detecting installed apps...`
+
+**Error:** Shows error message text.
+
+**TopBarPreview:** Mock bar showing "My Project" + branch icon "main" + draggable active controls area.
+
+**AvailableControls:** Dashed border drop zone for inactive controls.
+
+**Drag behavior:**
+- Reorder within preview
+- Drag from preview to available → remove from bar
+- Drag from available to preview → add to bar
+
+---
+
+### 2.8 About Tab (`AboutSettings`)
+
+**Container:** max-width ~42rem, vertical gap 32px.
+
+#### App identity section
+
+| Element | Content |
+|---------|---------|
+| App icon | 80×80 px, drop shadow, alt "2code" |
+| Title | `2code` (2xl semibold) |
+| Version badge | `Version {version}` — clickable copies to clipboard; skeleton while loading |
+| Tagline | `The Vibe Coding Workstation — A desktop workspace where terminal, AI agents, and Git live together for uninterrupted flow state.` |
+
+Non-Tauri (web dev): version shows `dev`.
+
+#### External links row
+
+Two outline small buttons:
+- GitHub icon + `Repository` + external arrow → `https://github.com/AkaraChen/2code`
+- Tag icon + `Releases` + external arrow → releases URL
+
+#### Update section (bordered card)
+
+**Header bar:** Title `Update` + optional badge:
+- If update available: `Update {version} is available`
+- If checked and up to date: `Already up to date` (outline muted badge)
+
+**Body:**
+- Switch: `Accept Beta Updates` / `Check prerelease builds from the beta channel.`
+- Status text (one of):
+  - Update available description with current/latest versions
+  - Release date line: `Released {date}` (locale-formatted)
+  - Not available / idle descriptions
+  - Error text (destructive color) if update error
+- Buttons:
+  - `Check for Updates` (outline) — shows spinner while checking
+  - `Install {version}` (primary) — shown when update available; spinner while downloading
+
+**Updater settings default:** `acceptBetaUpdates: false`
+
+#### Contributors
+
+Heading `Contributors` + clickable card:
+- Avatar 36px round
+- Name `AkaraChen`
+- Subtitle `Project maintainer and primary contributor.`
+- Hover: external arrow icon
+
+#### Footer
+
+`© {currentYear} AkaraChen` (xs muted)
+
+---
+
+### 2.9 TerminalTemplateDraftDialog (shared modal)
+
+Used from Global Templates settings (and project templates elsewhere).
+
+| Property | Value |
+|----------|-------|
+| Max width | ~32rem (`sm:max-w-lg`) |
+| Title icon | Terminal window |
+| Title | `Add Template` or `Edit Template` |
+
+**Fields:**
+1. **Template Name** — text input, placeholder `e.g. Dev Server`
+2. **Working Directory** — optional (`showCwd` prop); only in project context
+3. **Commands** — textarea 8 rows, monospace, placeholder `One command per line…`; description `Runs after the terminal starts. One command per line.`
+
+**Footer (space-between):**
+- Left: `Cancel` (outline) + `Delete` (destructive, edit mode only, spinner if pending)
+- Right: `Save` (disabled if name empty or pending)
+
+---
+
+## 3. Terminal UI
+
+### 3.1 Layer Architecture
+
+```
+TerminalLayer (absolute inset-0, one visible profile at a time)
+├── For each active profile ID:
+│   └── div (absolute inset-0; display flex/none)
+│       └── ProfileLayout
+│           ├── CommandPalette
+│           ├── ProjectTopBar (see Git section)
+│           ├── ProfileSidebar (files/git/notes — out of scope)
+│           └── TerminalTabs
+└── TerminalFileLinkPickerDialog (global, one instance)
+```
+
+**Persistence rule:** Terminals never unmount. Inactive profiles/tabs use CSS `display: none` or `visibility: hidden`.
+
+**Global shortcuts (TerminalLayer, active profile only):**
+- **⌘T** (metaKey + t): Create new terminal tab in active profile
+- **⌘W** (metaKey + w): Close active terminal tab
+
+Note: These check `e.metaKey` only (macOS-oriented).
+
+---
+
+### 3.2 ProfileLayout → Terminal Area
+
+Below top bar + optional sidebar:
+
+```
+TerminalTabs (full width/height column)
+├── Tab bar row (border-bottom, horizontal scroll)
+│   └── TabsList (line variant)
+│       ├── Terminal tab triggers (one per session)
+│       ├── File tab triggers (one per open file)
+│       └── TerminalTemplateMenu ("+ New Terminal")
+├── File viewer pane (flex-1, conditional — only when file tab active)
+└── Terminal area (flex-1, relative)
+    ├── Per-tab absolute layers (visibility hidden when inactive)
+    └── emptyFallback when no tabs
+```
+
+When file tab active: terminal area `display: none` (but terminals stay mounted).
+
+---
+
+### 3.3 Tab Bar
+
+**Tab trigger layout class:** max-width 14rem (`max-w-56`), flex-none, left-aligned content.
+
+#### Terminal tab trigger (each)
+
+Left → right:
+1. **Icon** — 14×14 px:
+   - Default: terminal window icon
+   - Agent keyword match (case-insensitive in title): claude, codex, gemini, kimi, cline, openclaw, opencode, qoder → respective brand SVG
+2. **Title** — truncated text (from PTY OSC title or default)
+3. **AgentStatusDot** (optional) — see §3.8
+4. **Close button** — 16×16 hit target, X icon, aria-label `Close {title}`
+
+**Drop target:** Terminal tabs accept file-tree drag-drop of paths (writes formatted paths to PTY).
+
+#### File tab trigger (each)
+
+1. File type icon (14px)
+2. Truncated filename
+3. Dirty indicator — 8px filled circle (muted) if unsaved
+4. Close button
+
+Closing dirty file → `UnsavedFileCloseDialog`.
+
+#### TerminalTemplateMenu (trailing)
+
+Rendered as last item in tab list.
+
+**Primary click / Enter / Space on trigger:** Creates default empty terminal (does not open dropdown).
+
+**Hover-open dropdown** (120ms close delay, non-modal):
+- Empty: message `No templates yet.` + hint `Add project templates in Project Settings, or global templates in Settings.`
+- **Project Templates** group (if any) — name + optional cwd subtitle
+- Separator (if both groups)
+- **Global Templates** group (if any)
+
+Selecting template creates terminal running template commands.
+
+**Button label:** `New Terminal`
+
+---
+
+### 3.4 Terminal Component (xterm.js host)
+
+**Outer shell:**
+- Flex column, relative, 100% size
+- Padding: 8px top, 0 right/bottom, 8px left
+- Background: terminal theme background color
+- Overflow hidden
+
+**Inner:** Flex-1 min-size-0 div — xterm mounts here in a 100% wrapper div.
+
+**Search overlay (when open):** `TerminalSearchBar` positioned absolute top-right inside shell.
+
+#### xterm visual configuration
+
+| Setting | Value |
+|---------|-------|
+| Cursor | Bar, width 4px, blinking |
+| Cursor inactive | Outline style |
+| Scrollback | 5000 lines |
+| Scrollbar | Hidden |
+| macOptionIsMeta | false |
+
+#### TerminalSearchBar
+
+Fixed overlay: top-right (12px inset), z-index 20.
+
+| Element | Details |
+|---------|---------|
+| Search input | width ~14rem, height 28px, autofocus; placeholder `Search terminal` |
+| Result count | `No results` or `{current}/{total}` |
+| Previous button | Caret up, aria `Previous match` |
+| Next button | Caret down, aria `Next match` |
+| Close button | X, aria `Close search` |
+
+**Match highlight colors:** gold/brown inactive, blue active (hardcoded hex).
+
+**Keyboard in search:**
+- Escape → close, refocus terminal
+- Enter → next match (Shift+Enter → previous)
+- Typing → incremental search
+
+#### Link handling
+
+- Web links and file links open confirmation unless Ctrl/Cmd+click bypass
+- **TerminalLinkConfirmDialog** for external URLs
+- Ambiguous file paths → **TerminalFileLinkPickerDialog**
+
+#### Agent detection
+
+Polls every 250ms (2s when tab hidden). Publishes `running` | `waiting` | `idle` to store. Waiting triggers notification sound + optional system notification.
+
+#### Process exit
+
+Appends gray line: `[Process exited]`
+
+---
+
+### 3.5 Terminal Keyboard Shortcuts (in-terminal focus)
+
+| Shortcut | Platform | Action |
+|----------|----------|--------|
+| ⌘F | macOS | Open search |
+| Ctrl+Shift+F | Windows/Linux | Open search |
+| ⌘= / ⌘+ | macOS | Increase font size |
+| ⌘- | macOS | Decrease font size |
+| Ctrl+L | All | Clear screen (+ PTY clear) |
+| Ctrl+C | Windows/Linux | Copy selection, or SIGINT if no selection |
+| Ctrl+V | Windows/Linux | Paste clipboard to PTY |
+| ⌘← / ⌘→ | macOS | Send Home / End |
+| Alt+← / Alt+→ | All | Word left / word right |
+| Shift+Enter | All | Send newline |
+
+Selection auto-copies to clipboard with toast **"Text copied"** (hardcoded English, not i18n).
+
+Font size changes persist to terminal settings store (clamped 10–20).
+
+---
+
+### 3.6 TerminalLinkConfirmDialog
+
+| Title | `Open Link` (link icon) |
+| Description | `Choose where to open this link. Hold Ctrl and click to open directly in the default browser next time.` |
+| URL label | `Link` |
+| URL value | Monospace, break-all |
+| Cancel | `Cancel` |
+| Primary split button | `Open in Default Browser` + dropdown caret |
+| Dropdown | List installed browsers (`listInstalledBrowsers`); disabled if empty; aria `Open With` |
+
+---
+
+### 3.7 TerminalFileLinkPickerDialog
+
+| Max width | ~36rem |
+| Title | `Choose File` (file icon) |
+| Description | `The exact file path was not found. Select one of the matching files to open.` |
+| List | Scrollable max 50vh, bordered |
+
+**Each candidate row (min-height 44px):**
+- File icon 16px
+- Name (truncate, medium) + relative path (monospace xs muted)
+- FileText icon trailing
+- Click → opens file in file viewer tab, closes dialog
+
+---
+
+### 3.8 AgentStatusDot
+
+8px circle (`size-2`), rounded full:
+
+| Status | Appearance |
+|--------|------------|
+| `running` | Emerald green + pulsing shadow animation |
+| `waiting` | Yellow (`yellow-400`) |
+| `completed` | Green (`green-500`) — shown as dismissible notification dot on tab when no active status |
+
+Dismiss completion: click dot, aria-label `Dismiss completion notification`.
+
+---
+
+### 3.9 TerminalPreview (settings only)
+
+Static HTML/CSS mock terminal — not a live PTY. See §2.4.
+
+---
+
+## 4. Git UI
+
+### 4.1 ProjectTopBar
+
+**Height:** min 44px. **Padding:** platform-dependent right padding (Windows: extra 118px for system buttons).
+
+**Three zones (horizontal):**
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ [Left controls]     [Center title - absolute centered]  [Right controls] │
+└─────────────────────────────────────────────────────────────┘
+```
+
+#### Left zone
+
+- **Expand sidebar** button (only when app sidebar collapsed) — ghost icon, tooltip `Expand sidebar`
+- **SidebarModeSwitch** (when sidebar mode props provided) — toggles Files / Git / Notes sidebar
+
+#### Center zone (pointer-events split)
+
+- **Project name** — semibold truncate, clickable → reveals worktree path in Finder/file manager (tooltip shows full path)
+- **Branch control** — git branch icon + branch name, clickable → opens SwitchBranchDialog
+  - Default profile + active: live git branch from repo
+  - Non-default profile: shows `profile.branch_name` static
+
+#### Right zone
+
+- Dynamic **top bar controls** from registry (GitHub Desktop, editor launcher, terminal launcher, PR status, etc.)
+- **Project settings** gear button (secondary icon) — tooltip `Project Settings` → ProjectSettingsDialog
+
+**Keyboard shortcuts (active profile):**
+- **⌘G / Ctrl+G:** Open Git diff dialog (Changes tab)
+- **⌘E / Ctrl+E:** Toggle file tree sidebar
+
+**Mounted dialogs from top bar:**
+- `ProjectSettingsDialog`
+- `SwitchBranchDialog`
+- `GitDiffDialog` (branch name from live git or profile)
+
+---
+
+### 4.2 SwitchBranchDialog
+
+| Max width | ~28rem |
+| Padding | Header/content split, no outer padding on content wrapper |
+
+```
+SwitchBranchDialog
+├── Header (border-bottom, px-16 py-12)
+│   └── Title: "Switch branch" + branch icon
+├── Search input (px-12 py-8, h-32, autofocus)
+│   └── placeholder: "Search branches…"
+└── Scrollable list (max-height min(60dvh, 384px))
+    └── BranchRow × N
+```
+
+**BranchRow contents:**
+- Branch icon (muted)
+- Branch name (truncate; bold if current)
+- Badges (optional):
+  - `current` (secondary) — current branch, row disabled/selected bg
+  - `trunk` (outline)
+  - `used` (amber outline) — branch in use by another profile, disabled
+- Ahead/behind counts: green `↑N`, red `↓N` ( monospace 11px)
+
+**Empty search:** `No branches found`
+
+**Loading:** Centered spinner
+
+**Checkout success toast:** `Switched to {branch}`
+
+---
+
+### 4.3 GitDiffDialog (full-screen modal)
+
+| Size | width `min(88rem, 100vw - 2rem)`, height `min(82dvh, 56rem)` |
+| Close button | Hidden in dialog chrome — custom close in header |
+| Padding | 0 (full bleed) |
+
+```
+GitDiffDialog
+├── GitDiffHeader
+└── GitDiffContent (flex-1 min-height 0)
+```
+
+#### GitDiffHeader
+
+Horizontal bar, border-bottom, padding 16×8:
+
+| Zone | Content |
+|------|---------|
+| Title | Branch icon + truncated branch name (fallback "main") |
+| Center-right | Toggle group `Preview`: `Unified` / `Split` |
+| Far right | Ghost icon close button (aria "Close") |
+
+#### GitDiffContent — Master Layout
+
+```
+┌──────────────────┬─────────────────────────────────────┐
+│ Sidebar 360px    │ Diff pane (flex-1)                   │
+│ border-right     │                                      │
+│                  │                                      │
+│ [Changes|History]  │  File diff viewer OR empty state     │
+│                  │                                      │
+│ File/commit list │                                      │
+│ + commit form    │                                      │
+└──────────────────┴─────────────────────────────────────┘
+     [Review Queue FAB if comments exist]
+```
+
+**Sidebar:** Fixed width 360px, focusable (`tabIndex=0`) for keyboard nav.
+
+**Sidebar tabs:**
+- `Changes` (git diff icon)
+- `History` (commit icon)
+
+---
+
+### 4.4 Changes Tab (Sidebar)
+
+#### Empty state
+Centered: `No changes detected`
+
+#### ChangesFileList
+
+**Sticky header:**
+- Tri-state checkbox (include all/none) — aria `All`
+- Text: `{count} changed file(s)`
+- Optional maximize button (sidebar mode only) — aria `Open diff view`
+
+**File rows (`FileListItem`):**
+- Optional checkbox (include in commit)
+- Basename (truncate) + parent path (xs muted)
+- Change badge (letter in colored square):
+  - `A` green — added
+  - `D` red — deleted
+  - `M` blue — modified
+  - `R` amber — rename
+- Active row: muted background
+- Double-click → open file in editor tab, close diff dialog
+- Right-click → context menu portal (fixed 200px):
+  - Destructive button: `Discard changes to this file`
+
+**Keyboard (sidebar focused):**
+- ↑/↓ — move selection
+- Space — toggle include checkbox (changes tab)
+- Enter — drill into commit (history tab)
+- Backspace/Escape — back from commit file list (history)
+
+#### CommitComposer (bottom, border-top)
+
+| Field | Label | Placeholder |
+|-------|-------|-------------|
+| Summary | `Summary` | `Describe the changes you're committing` |
+| Body | `Description` | `Add an optional extended description` |
+
+Section title: `Commit` (uppercase xs muted)
+
+**Buttons (right-aligned):**
+- If no changed files but commits ahead: **Push** button with ahead count + upload icon
+- Else: **Commit** button (disabled unless ≥1 file included + non-empty summary)
+
+**Shortcut:** ⌘/Ctrl+Enter in summary/body → commit (if valid)
+
+**Global shortcut:** ⌘/Ctrl+Enter when no local changes but ahead commits → push
+
+---
+
+### 4.5 Changes Tab (Diff Pane)
+
+**Component:** `GitDiffPane` with `@pierre/diffs` FileDiff renderer.
+
+**Font:** Uses terminal font family + size from settings.
+
+**Empty states:**
+- No changes: `No changes detected`
+- No selection: `Select a file to view changes`
+
+**File header bar:**
+- Change badge + truncated path (rename shows `old → new`)
+- Green `+N` / red `-N` line counts
+
+**Special views:**
+1. **Large diff guardrail** (≥ threshold changed lines, default threshold in utils):
+   - Title: `Large diff hidden by default`
+   - Description with counts
+   - Button: `Load diff anyway`
+2. **Rename-only:** Previous path / Current path rows
+3. **Binary image:** Side-by-side Before/After preview panes with checkerboard background
+4. **Normal diff:** Unified or split per header toggle
+
+**Review comments (changes pane only):**
+- Line click/drag selection opens floating composer anchored to selection
+- Composer: "Comment on {range}", textarea, "Add to queue" button
+- Hardcoded English strings in composer UI
+
+**Review Queue FAB:** Bottom-right when comments exist — button `Review Queue` + count badge (hardcoded English label on FAB).
+
+---
+
+### 4.6 History Tab
+
+#### Commit list (initial)
+
+Scrollable rows:
+- Commit message (1 line clamp)
+- Hash (mono) + author + relative time (`just now`, `Nm ago`, etc. — hardcoded English)
+- Stats: N file(s), +insertions, -deletions
+
+Empty: `No commits found`
+
+#### Commit drill-in
+
+**Header:** Back arrow (aria `Back to commit list`) + message + hash
+
+**File list:** Same `FileListItem` without checkboxes + `{count} changed file(s)`
+
+Empty files: `No file changes`
+
+**Diff pane:** Shows selected commit file diff (no review comments).
+
+---
+
+### 4.7 GitReviewQueueDialog
+
+| Size | width `min(56rem, 100vw-2rem)`, max-height 80vh |
+
+**Header:** `Review Queue` (chat icon)
+
+**Body:** Scrollable list of comment cards, each:
+- File path (mono semibold)
+- Range badge + "Selected diff" (hardcoded)
+- Mini diff preview (max-height 128px)
+- "Comment" label + editable textarea
+- Delete button (destructive icon)
+
+**Footer:**
+- `Copy` (outline) — hardcoded English
+- `Copy and clear all` (destructive) — hardcoded English
+
+Success toasts: `Review comments copied` / `Review comments copied and cleared`
+
+---
+
+### 4.8 SidebarGitPanel (compact git in profile sidebar)
+
+Same as Changes sidebar subset:
+- `ChangesFileList` with maximize button → opens full GitDiffDialog
+- `CommitComposer` below
+- No history tab in sidebar mode
+
+Tooltips on file paths disabled in compact mode.
+
+---
+
+## 5. Debug UI
+
+### 5.1 Enabling
+
+**Settings → General → Debug Mode** switch.
+
+When enabled:
+- Backend debug log channel starts
+- `DebugFloat` FAB appears
+
+### 5.2 DebugFloat
+
+| Property | Value |
+|----------|-------|
+| Visibility | Only when debug mode enabled |
+| Position | Fixed, right 64px, bottom 16px, z-index 50 |
+| Shape | Circular icon button |
+| Icon | Wrench |
+| Aria-label | `Debug Log` |
+
+Click → opens DebugLogDialog.
+
+### 5.3 DebugLogDialog
+
+| Max width | ~32rem (`sm:max-w-lg`) |
+| Max height | 70vh |
+| Title | `Debug Log` |
+
+```
+DebugLogDialog
+├── Search input (flex-1) — placeholder "Search logs..."
+├── Clear button (trash icon, aria "Clear")
+├── Log list (scrollable, flex-1)
+│   └── LogRow × N
+└── Footer count: "{filtered} / {total}" (xs muted, right)
+```
+
+**LogRow columns:**
+1. Timestamp `HH:MM:SS.mmm`
+2. Level badge: ERROR (destructive), WARN (secondary), INFO (default)
+3. Source (muted)
+4. Message (break-all)
+
+**Auto-scroll:** Sticks to bottom unless user scrolls up (>40px from bottom).
+
+**Empty filtered:** `No log entries yet`
+
+**Search:** Filters message, source, level (case-insensitive).
+
+### 5.4 Debug Keyboard Shortcut
+
+**⌘⇧D** (macOS) / **Ctrl+Shift+D** (others): Toggle debug panel open/closed (only if debug mode enabled; otherwise no-op).
+
+---
+
+## 6. Updater UI
+
+### 6.1 StartupUpdateCheck
+
+Invisible component mounted in main `App`. On mount:
+1. Silent `checkForUpdate`
+2. If update available (once per app session): Sonner **info** toast
+
+**Toast contents:**
+- Title: `Update {version} is available`
+- Description: `Current version {currentVersion}; latest version {version}.`
+- Duration: 12 seconds
+- Action button: `Open Update Page` → opens settings window on About tab
+
+Toast id: `update-available` (deduped).
+
+### 6.2 About Tab Update Section
+
+See §2.8. Full manual check/install flow with beta toggle.
+
+**Toasts from About actions:**
+| Action | Toast |
+|--------|-------|
+| Copy version | `Version copied to clipboard` |
+| Check — update found | info: update available title + description |
+| Check — up to date | info: already up to date |
+| Check — error | error: update check failed + message |
+| Install — error | error: update failed + message |
+
+### 6.3 Updater Backend Config
+
+- Endpoint: GitHub releases `latest.json`
+- Beta channel controlled by `acceptBetaUpdates` setting
+
+---
+
+## 7. Remaining Dialogs & Overlays
+
+### 7.1 CreateProjectDialog
+
+| Title | `Create Project` (folder-plus icon) |
+
+**Flow:**
+1. Initial: dashed bordered drop zone — folder icon + `Choose Folder`
+2. After folder selected: folder path in monospace box + small `Choose Folder` edit button
+3. Project name field — label `Project Name`, placeholder `Optional. Leave empty to use folder name`
+4. Dynamic hint text (one of three i18n hints based on state)
+
+**Footer:** `Cancel` | `Create` (disabled without folder or while pending)
+
+Enter in name field submits.
+
+---
+
+### 7.2 DeleteProjectDialog
+
+| Title | `Delete Project` (trash icon) |
+| Body | `Are you sure you want to delete this project? This action cannot be undone.` |
+| Footer | `Cancel` | `Delete` (destructive) |
+
+---
+
+### 7.3 RenameProjectDialog
+
+| Title | `Rename` (pencil icon) |
+| Field | `New Name` |
+| Footer | `Cancel` | `Rename` (disabled if empty or unchanged) |
+
+Autofocuses rename input on open.
+
+---
+
+### 7.4 ProjectSettingsDialog
+
+| Max width | ~32rem |
+| Title | `Project Settings` (gear icon) |
+
+**Tabs:**
+1. **Scripts** (code icon)
+2. **Templates** (terminal icon)
+
+**Scripts tab fields:**
+| Field | Label | Description |
+|-------|-------|-------------|
+| Worktree dir | `Worktree Directory` | Overrides global default… |
+| Init script | `Init Script` | Injected into every new terminal session |
+| Setup script | `Setup Script` | Runs when creating profile |
+| Teardown script | `Teardown Script` | Runs when deleting profile |
+
+All script fields: monospace textarea 4 rows, placeholder `One command per line…`
+
+**Templates tab:** `ProjectTemplatesEditor` — same list/edit pattern as global templates but with cwd field in draft dialog (`showCwd=true`).
+
+**Footer:** `Cancel` | `Save`
+
+Loading: centered spinner min-height 200px.
+
+---
+
+### 7.5 CreateProfileDialog
+
+| Title | `New Profile` (branch icon) |
+| Field | `Branch Name`, placeholder `Optional. Leave empty to auto-generate…` |
+| Footer | `Cancel` | `Create` |
+
+---
+
+### 7.6 DeleteProfileDialog
+
+| Title | `Delete Profile` (trash icon) |
+| Body | `Are you sure you want to delete this profile? The git worktree will be removed.` |
+
+**Conditional blocks while checking git:**
+- Spinner + `Checking this profile's Git status…`
+- Warning alert with aggregated diff/commit warnings
+- Error alert if git check failed
+
+**Footer:** `Cancel` | `Delete` or `Delete Anyway` (if risky)
+
+---
+
+### 7.7 UnsavedFileCloseDialog
+
+| Title | `Close Unsaved File?` (warning icon) |
+| Body | `{file} has unsaved changes. Closing it will discard those changes.` |
+| Footer | `Cancel` | `Discard Changes` (destructive) |
+
+Triggered from terminal tab bar when closing dirty file tab.
+
+---
+
+### 7.8 Context Menu Overlay (ChangesFileList)
+
+Not a dialog — fixed portal at cursor:
+- 200px wide popover
+- Single destructive action: `Discard changes to this file`
+- Closes on outside click, Escape, blur, resize
+
+---
+
+### 7.9 Floating Review Comment Composer (GitDiffPane)
+
+Fixed-position popover (not modal) anchored to selected diff lines:
+- Header: comment range + cancel
+- Textarea
+- "Add to queue" button
+
+---
+
+### 7.10 Command Palette (attached to profile)
+
+Overlay search for files — triggered **⌘K / Ctrl+K**. Out of detailed scope but exists in `ProfileLayout`.
+
+---
+
+## 8. Global Toast System
+
+**Component:** Sonner `Toaster` in both windows.
+
+**Used for:** Update notifications, git operations, clipboard confirmations, review queue copy, agent-adjacent feedback, file tree errors, etc.
+
+Standard patterns:
+- `toast.success(title, { description })`
+- `toast.error(title, { description })`
+- `toast.info(title, { description, action: { label, onClick } })`
+
+---
+
+## 9. Cross-Cutting Platform Differences
+
+| Feature | macOS | Windows | Linux |
+|---------|-------|---------|-------|
+| Main window title bar | Overlay + traffic lights at (16,24) | Standard decorations; extra topbar right padding 118px for window controls | Standard decorations |
+| Custom window controls | No (traffic lights in overlay) | Yes (`WindowControls` component) | No |
+| Settings shortcut | ⌘, | Ctrl+, | Ctrl+, |
+| Debug toggle | ⌘⇧D | Ctrl+Shift+D | Ctrl+Shift+D |
+| Terminal new/close tab | ⌘T / ⌘W (metaKey only in code) | Same binding checks metaKey | Same |
+| Terminal search | ⌘F | Ctrl+Shift+F | Ctrl+Shift+F |
+| Font listing | Core Text | fontdb | fontdb |
+| Sound listing | `/System/Library/Sounds` | `C:\Windows\Media` | XDG sound dirs |
+| Notification permission | Tauri notification plugin prompt on enable | Same | Same |
+| File reveal | "Reveal in Finder" tooltip on project name | Platform file manager via backend | Platform file manager |
+
+**Settings window:** Uses standard system title bar with title text "Settings" (not overlay style).
+
+**Browser list for links:** From `listInstalledBrowsers` when link confirm opens.
+
+---
+
+## 10. Keyboard Shortcuts Summary
+
+| Shortcut | Context | Action |
+|----------|---------|--------|
+| ⌘, / Ctrl+, | Global (main window) | Open settings window |
+| ⌘⇧D / Ctrl+⇧D | Global | Toggle debug log dialog |
+| ⌘T | Active profile | New terminal tab |
+| ⌘W | Active profile | Close active terminal tab |
+| ⌘G / Ctrl+G | Active profile top bar | Open git diff dialog |
+| ⌘E / Ctrl+E | Active profile top bar | Toggle sidebar |
+| ⌘K / Ctrl+K | Active profile | Command palette |
+| ⌘F | Terminal focus (macOS) | Terminal search |
+| Ctrl+Shift+F | Terminal focus (Win/Linux) | Terminal search |
+| ⌘=/⌘+ / ⌘- | Terminal (macOS) | Font size |
+| Ctrl+L | Terminal | Clear screen |
+| ⌘←/→ | Terminal (macOS) | Home/End to PTY |
+| Alt+←/→ | Terminal | Word motion |
+| Shift+Enter | Terminal | Newline to PTY |
+| ↑/↓/Space/Enter | Git diff sidebar | Navigate/toggle/select |
+| ⌘/Ctrl+Enter | Git commit form | Commit |
+| ⌘/Ctrl+Enter | Git diff (no changes, ahead) | Push |
+| Escape | Terminal search / git contexts | Close/back |
+
+---
+
+## Appendix A — Persisted Settings Defaults
+
+| Store | Key | Default |
+|-------|-----|---------|
+| terminalSettings | fontFamily | JetBrains Mono |
+| terminalSettings | fontSize | 13 |
+| terminalSettings | darkTerminalTheme | github-dark |
+| terminalSettings | lightTerminalTheme | github-light |
+| terminalSettings | syncTerminalTheme | false |
+| terminalSettings | showAllFonts | false |
+| terminalSettings | defaultShell | from `DEFAULT_TERMINAL_SHELL` |
+| themeStore | borderRadius | sm |
+| notificationStore | enabled | false |
+| notificationStore | sound | Ping |
+| sidebarSettings | showProjectAvatars | true |
+| worktreeSettings | defaultWorktreeDir | "" (empty → ~/.2code/workspace) |
+| updaterSettings | acceptBetaUpdates | false |
+| debugStore | enabled | false |
+| terminalTemplates | templates | [] |
+
+---
+
+## Appendix B — Hardcoded Non-i18n Strings
+
+These appear in UI without `en.json` entries:
+
+| Location | String |
+|----------|--------|
+| Terminal.tsx | Toast: "Text copied" |
+| GitDiffContent.tsx | FAB: "Review Queue" |
+| GitReviewQueueDialog | "Copy", "Copy and clear all", "Selected diff", "Comment", "Comment on …", "Add to queue" |
+| GitDiffPane comment composer | "Add to queue", "Cancel review comment" |
+| GitDiffHeader | Close aria-label: "Close" |
+| CommitList | Relative time: "just now", "Nm ago", "file/files" |
+| TerminalTabs | "Dismiss completion notification", "Close {title}" |
+| TopBarPreview | Mock text: "My Project", "main" |
+
+---
+
+*Document generated from codebase inspection. Branch: settings/terminal/git/debug/updater components as specified in exploration task.*

--- a/docs/ui-inventory.md
+++ b/docs/ui-inventory.md
@@ -1,0 +1,977 @@
+# 2code UI 完整清单（换框架重写规格）
+
+这份文档是 2code 桌面端 **全部可见 UI 的框架无关规格**。目标：之后用任何 UI 技术栈重写时，不必再读 React / Tailwind / shadcn 源码，也能按相同产品形态还原窗口、页面、组件树、排布、尺寸、交互、空态、错误态和文案。
+
+**审计日期：** 2026-09-03  
+**对照代码：** 主窗口 `src/App.tsx`、`src/layout/*`、`src/features/*`、`src/components/ui/*`、`src/app.css`、`src-tauri/tauri.conf.json`、`src-tauri/src/handler/window.rs`、`messages/en.json`
+
+**更细的 className / 像素对照（英文附录）：**
+
+| 附录 | 覆盖面 |
+|------|--------|
+| [sidebar-ui-inventory.md](./sidebar-ui-inventory.md) | 应用侧栏、项目分组、头像、Profile 次级侧栏原语 |
+| [ui-inventory-home-project.md](./ui-inventory-home-project.md) | 首页、Profile 布局、文件树、文件查看器、命令面板、项目/Profile 对话框 |
+| [ui-inventory-settings-terminal-git-debug-updater.md](./ui-inventory-settings-terminal-git-debug-updater.md) | 设置窗、终端、Git 大对话框、调试、更新器 |
+
+本文是 **主规格**：先读本文，再按需要查附录。文中尺寸、文案、树结构均来自源码，不 invent。
+
+---
+
+## 0. 怎么用这份文档重写
+
+重写时按「窗口 → 区域 → 组件 → 状态」还原，不要按当前 React 组件名还原。
+
+1. **先还原窗口壳**：两个 Webview、原生标题栏、拖拽区、Windows 自定义按钮。
+2. **再还原主窗三分区**：应用侧栏 | 主内容 | 持久终端层。
+3. **再还原 Profile 工作区**：顶栏 + 次级侧栏（Files/Git/Notes）+ 统一标签栏 + 终端/文件查看器。
+4. **最后还原叠加层**：对话框、命令面板、右键菜单、Toast、调试 FAB、新手引导。
+
+**不可破坏的产品不变量：**
+
+- 终端实例 **不能因切标签/切路由而销毁**。隐藏用 CSS `display:none` / `visibility:hidden`，不要条件卸载。
+- 文件树在 Files/Git/Notes 切换时也 **保持挂载**（`display:none`），以免丢失展开/选中状态。
+- 设置是 **独立窗口**，不是主窗内路由页。
+- `Cmd+,` 开设置；`Cmd+Shift+D` 开调试面板；`Cmd+K` 开文件搜索；`Cmd+T`/`Cmd+W` 开/关终端标签。
+- 文案走 i18n（英/中）。品牌字 `"2Code"` 硬编码，不要翻译。
+
+---
+
+## 1. 产品表面总图
+
+2code 是本地优先的「项目 + Profile（git worktree）+ 持久 PTY 终端」工作站。用户看到的全部表面：
+
+```
+操作系统
+├── 主窗口 "2code"  1440×900  叠加标题栏
+│   ├── 应用侧栏（项目列表）
+│   ├── 主内容
+│   │   ├── 首页（仅无项目时停留）
+│   │   └── Profile 工作区（有项目后的主界面）
+│   │       ├── 顶栏
+│   │       ├── 次级侧栏：Files | Git | Notes
+│   │       └── 统一标签栏 + 终端 / 文件查看器
+│   ├── 叠加层：对话框、命令面板、右键菜单、Toast
+│   ├── 调试扳手按钮（可选）
+│   └── Windows 右上角 min/max/close
+│
+└── 设置窗口 "Settings"  880×640
+    └── 六个标签：General / Terminal / Templates / Notification / Top Bar / About
+```
+
+**没有的表面：** 登录、账号、云同步、独立「项目列表页」（有项目会立刻跳进第一个默认 Profile）、移动端布局、汉堡菜单。
+
+---
+
+## 2. 窗口与原生铬
+
+### 2.1 主窗口
+
+| 项 | 值 |
+|----|----|
+| 内部 title | `2code` |
+| 可见标题文字 | 隐藏（`hiddenTitle: true`） |
+| 装饰 | 系统 decorations 开 |
+| 标题栏样式 | **Overlay**（内容顶到标题栏下） |
+| macOS 红绿灯 | 左上，坐标 **x=16, y=24** |
+| 默认尺寸 | **1440 × 900**，居中 |
+| 可最大化 | 是 |
+
+因为 overlay 标题栏，应用必须自己留出红绿灯和拖拽区：
+
+- 应用侧栏 **header** 标 `data-tauri-drag-region`。macOS 上 `padding-top: 32px`（`pt-8`），其它平台 `8px`（`pt-2`）。
+- 首页 header、Profile 顶栏也是拖拽区。
+- 拖拽区内的按钮/链接必须 `no-drag`，否则点不到。
+- 应用侧栏折叠后，macOS 顶栏左侧再加 `padding-left: 84px`，避开红绿灯。
+- Windows 顶栏右侧 `padding-right: 118px`，避开自定义窗口按钮。
+
+### 2.2 设置窗口
+
+| 项 | 值 |
+|----|----|
+| Webview label | `settings` |
+| 标题 | `Settings` |
+| URL | 同一个 `index.html`；前端看 label 决定渲染 `SettingsWindow` 而不是 `App` |
+| 默认尺寸 | **880 × 640** |
+| 最小尺寸 | **600 × 420** |
+| 居中 | 是 |
+| 装饰 | 系统默认（**不是** overlay） |
+
+打开方式：
+
+- 侧栏底部 Settings
+- `Cmd+,` / `Ctrl+,`
+- 更新 Toast 的 “Open Update Page” → 复用同一窗口并切到 About（`?tab=about`）
+
+已存在则 `show()` + `focus()`，不新建。设置窗 **不** 挂文件监视、终端层、应用侧栏、启动性能同步。设置项通过跨窗口 broadcast 同步回主窗。
+
+### 2.3 Windows 自定义窗口按钮
+
+仅 Windows 渲染。`fixed top-0 right-0`，高 **28px**（`h-7`），从左到右：
+
+1. Minimize — 减号，12px，hover 灰底
+2. Maximize / Restore — 未最大化是方框，最大化是「两份重叠」图标
+3. Close — X，hover **#c42b1c** 白字，active **#b32717**
+
+每个按钮 **28×36**（`h-7 w-9`），`no-drag`。
+
+### 2.4 根布局（主窗）
+
+```
+html/body/#root = 100% × 100%，overflow:hidden
+App
+├── StartupUpdateCheck          （无 DOM，启动时可能弹 Toast）
+├── 横向 flex，flex-1，min-height:0
+│   ├── AppSidebar 或 SidebarSkeleton / SidebarError
+│   └── main（relative, flex-1, overflow-y:auto, 背景 --card）
+│       ├── Routes
+│       │   ├── /        HomePage
+│       │   ├── /projects/:id/profiles/:profileId   ProjectDetailPage
+│       │   └── *        重定向 /
+│       └── TerminalLayer（absolute inset 0 覆盖层）
+├── DebugFloat（条件）
+└── WindowControls（仅 Windows）
+```
+
+整窗背景 `--background`，文字 `--foreground`。侧栏背景 `--sidebar`，主区 `--card`。
+
+**全局交互基调：** `body` 禁止文本选择、默认箭头光标。只有 `input` / `textarea` / `contenteditable` / `.xterm` / Markdown 编辑器允许选字。按钮、链接、`[data-sidebar-item]` 也是默认光标（不是 pointer），只有少数明确写了 `cursor-pointer` 的标题/分支例外。
+
+---
+
+## 3. 设计系统（视觉合同）
+
+### 3.1 字体
+
+| 用途 | 字体 |
+|------|------|
+| UI 正文 | Inter Variable → 系统栈（-apple-system, Segoe UI, Roboto…） |
+| 标题 token | Geist Variable（`--font-heading`） |
+| 等宽 / 终端 / 代码 / Markdown | 设置里的终端字体，CSS 变量 `--font-mono`，默认 JetBrains Mono 栈 |
+| 抗锯齿 | `-webkit-font-smoothing: antialiased`，`text-rendering: optimizeLegibility` |
+
+Phosphor 图标默认 **1em、duotone**。少数地方改 `weight="regular"`。
+
+### 3.2 颜色 token（oklch）
+
+亮色 `:root`：
+
+| Token | 值 | 用途 |
+|-------|-----|------|
+| `--background` | `oklch(1 0 0)` | 窗体底 |
+| `--foreground` | `oklch(0.145 0 0)` | 主文字 |
+| `--card` | `oklch(1 0 0)` | 主内容区 |
+| `--popover` | `oklch(1 0 0)` | 菜单/对话框/Toast |
+| `--primary` | `oklch(0.205 0 0)` | 主按钮（近黑） |
+| `--muted` | `oklch(0.97 0 0)` | 浅底、hover |
+| `--muted-foreground` | `oklch(0.556 0 0)` | 次要文字 |
+| `--destructive` | `oklch(0.577 0.245 27.325)` | 危险操作 |
+| `--border` / `--input` | `oklch(0.922 0 0)` | 边框 |
+| `--ring` | `oklch(0.708 0 0)` | 焦点环 |
+| `--radius` | `0.625rem`（10px） | 基础圆角 |
+| `--sidebar` | `oklch(0.985 0 0)` | 侧栏底（比主区略灰） |
+| `--sidebar-accent` | `oklch(0.97 0 0)` | 侧栏 hover/选中 |
+| `--app-focus-ring` | 系统 `Highlight` | 自定义焦点 |
+
+暗色 `.dark`：背景 `oklch(0.145)`，卡片/弹出层 `oklch(0.205)`，主色反转成浅色，边框半透明白。侧栏暗色底与卡片同级。
+
+**语义色（不走 token）：**
+
+- Git 增加：`text-green-500` / `text-green-600`
+- Git 删除：`text-red-500` / `text-red-600`
+- Agent waiting：`bg-yellow-400`
+- Agent completed：`bg-green-500`
+- Agent running：`bg-emerald-400` + 1.4s 脉冲光晕
+- 分支 “used” 徽章：琥珀底/字
+- Windows 关闭按钮：`#c42b1c`
+
+焦点环优先用系统 `Highlight` / `HighlightText`（选择色也是）。
+
+### 3.3 圆角档位
+
+设置里的 Border Radius 改 `--radius`。派生：
+
+| 档 | 显示名 | 相对 `--radius` |
+|----|--------|-----------------|
+| none | None | 0 |
+| small | Small | ×0.6 |
+| medium | Medium | 默认 0.625rem |
+| large | Large | ×1.4 |
+| extra large | Extra Large | ×1.8 |
+
+常用：按钮 `rounded-lg`，对话框 `rounded-xl`，头像 `rounded-md`，菜单 `rounded-lg`。
+
+### 3.4 按钮规格
+
+| size | 高 | 用途 |
+|------|----|------|
+| default | 32px（`h-8`） | 对话框主操作 |
+| xs | 24px | 紧凑（改文件夹、重试） |
+| sm | 28px | 次要 |
+| lg | 36px | 少用 |
+| icon | 32×32 | 顶栏齿轮、调试 FAB |
+| icon-xs | 24×24 | 搜索条箭头 |
+| icon-sm | 28×28 | 对话框关闭 |
+
+| variant | 外观 |
+|---------|------|
+| default | 实心 primary |
+| outline | 边框 + 白底，hover muted |
+| secondary | 浅底 |
+| ghost | 无底，hover muted |
+| destructive | 浅红底 + 红字（不是大红实心） |
+| link | 下划线链接 |
+
+禁用：`opacity: 50%`，不可点。激活时轻微下移 1px。
+
+### 3.5 标准对话框壳
+
+默认对话框：
+
+- 遮罩：全屏 `bg-black/10`，支持 backdrop 时轻微模糊，z-index 50
+- 面板：水平垂直居中，默认 `max-w-sm`，内边距 16px，`rounded-xl`，`bg-popover`，细环 `ring-foreground/10`
+- 打开：淡入 + 缩放到 95%
+- 右上角默认有 ghost 关闭按钮（Git 大对话框关掉这个默认按钮，自己画关闭）
+- 结构：Title（常带 16px 图标）→ 正文 gap 12–20px → Footer 右对齐（Cancel outline + 主按钮）
+
+标准小对话框（创建/删除/重命名/未保存关闭）都用这套壳。Git Diff 是例外：`min(88rem, 100vw-2rem)` × `min(82dvh, 56rem)`，无内边距。
+
+### 3.6 Toast
+
+Sonner，跟主题走。图标 16px Phosphor regular：成功勾、信息 i、警告三角、错误叉、加载转圈。背景 `--popover`。启动更新 Toast 持续 **12 秒**，带 “Open Update Page” 动作。
+
+### 3.7 空状态
+
+居中 `Empty`：上方圆形图标容器 → 标题 → 灰色说明 → 可选操作按钮。用于：无项目、无终端、设置/模板空列表。
+
+### 3.8 加载 / 错误
+
+| 表面 | 加载 | 错误 |
+|------|------|------|
+| 应用侧栏 | 250px 宽骨架：一条标题 + 半宽标签 + 三条缩进行 | 同宽栏，红标题 “Something went wrong” + 消息 + Try again |
+| 主页面 | 左上骨架：48×192 标题 + 两行 | 同样错误栈，padding 32px |
+| 面板内部 | 居中 Spinner 16px | 居中错误栈 |
+| 行内 | — | 左红标题+截断消息，右 xs Try again |
+| 对话框体 | Spinner | 最小高 200px 居中错误栈 |
+
+### 3.9 Agent 状态点
+
+**8×8** 圆点，不可聚焦。
+
+| 状态 | 颜色 | 动画 |
+|------|------|------|
+| waiting | 黄 `#facc15` | 无 |
+| running | 翠绿 | 1.4s 脉冲光晕（`prefers-reduced-motion` 时关掉） |
+| completed | 绿 `#22c55e` | 无 |
+
+出现位置：侧栏默认 Profile / 非默认 Profile、终端标签。完成点可点消失（仅标签栏）。
+
+---
+
+## 4. 应用侧栏（左列）
+
+### 4.1 尺寸与折叠
+
+| 常量 | 值 |
+|------|-----|
+| 默认宽 | **250px** |
+| 最小 / 最大 | **220 / 420** |
+| 键盘步进 | 16px |
+| 持久化 | localStorage `app-sidebar-width`（宽、是否折叠、折叠的分组 id） |
+
+折叠时侧栏 **整棵不渲染**。展开按钮只出现在 Profile 顶栏左侧（首页折叠后没有展开钮）。
+
+右缘有 **8px** 宽竖直 resize 热区，中线 1px。拖时中线变 `foreground/30`，hover/焦点时显示 border 色。
+
+### 4.2 结构（上 → 下）
+
+```
+Sidebar（role=navigation, aria-label="Side navigation"）
+├── Header（拖拽区）
+│   ├── 左：不可点品牌 "2Code"（semibold）
+│   └── 右：折叠按钮 SidebarSimple 图标
+├── Content（竖向滚动，stable scrollbar gutter）
+│   ├── [无项目] Home 行（房子图标 + "Home"）
+│   ├── [有置顶] 分组 "Pinned"
+│   │   └── 项目行…
+│   └── 分组 "Projects"
+│       ├── 标签右侧：铅笔（排序）+ 加号（新建项目）#add-project-button
+│       └── 顶层条目：项目 或 分组
+└── Footer
+    └── Settings 行（齿轮 + "Settings"）
+```
+
+无项目时 Content 里只有 Home。有项目时 Home 不出现（首页会立刻跳走）。
+
+键盘：在侧栏内 ↑/↓ 在所有 `[data-sidebar-item]` 间循环。
+
+### 4.3 普通模式：项目行
+
+一行从左到右：
+
+1. **头像 16×16**（可在设置关掉）
+   - 有 GitHub avatar URL：封面图
+   - 失败/无图：侧栏 accent 底 + 项目名第一个大写字母，10px
+   - 空名：`?`
+2. **项目名** medium、截断
+3. 右侧动作：
+   - **只有默认 Profile：** hover/焦点时显示 `+`（新建 Profile）；平时若有 agent 状态则显示状态点（hover 时点隐藏、`+` 出现）
+   - **有额外 Profile：** 展开/折叠 caret（默认展开）
+
+点击项目名 → 进默认 Profile。
+
+**右键菜单：**
+
+1. Add to Project Group ▸
+   - 已有分组列表（当前分组打勾、禁用）
+   - 若已在分组：Remove from Project Group
+   - Create Project Group，或直接出现输入框（无分组时）
+   - 输入占位 `e.g. Work`，Enter 创建并加入，Esc 取消
+2. Project Settings
+3. Rename
+4. — 分隔 —
+5. Delete Project（destructive）
+
+### 4.4 展开后的 Profile 子列表
+
+缩进子菜单：
+
+1. 第一行永远是 **Default**（终端窗图标 + 文案 “Default” + 可选状态点）
+2. 其余 Profile：Git 分支图标 + `branch_name`（溢出出 tooltip）+ 状态点
+3. 最后一行：`+` + “New Profile”
+
+非默认 Profile 右键只有 **Delete Profile**（destructive）。
+
+### 4.5 项目分组
+
+分组行：caret + 分组名 + 右侧数字徽章（项目数）。点击折叠。展开用 180ms 高度/透明度动画（`[0.22,1,0.36,1]`），尊重 reduced motion。
+
+分组内项目与顶层项目同一套行/菜单。
+
+### 4.6 排序模式
+
+点铅笔进入。项目/分组变成可拖行：
+
+- 左：六点拖手（`cursor-grab`）
+- 中：头像或文件夹图标 + 名
+- 右：星标钉/取消钉
+
+分区：
+
+1. **Pinned** — 已钉项目 + 虚线投放区 “Drop here to pin”
+2. **Projects** — 顶层项目与分组交错；分组下再嵌套项目 + “Drop project into folder”；底部 “Drop here to unpin or move out”
+
+保存中禁用拖拽。标签右侧铅笔换成 **勾**（完成）+ 加号。拖拽中行透明度 0.45，背景 sidebar-accent。
+
+### 4.7 侧栏骨架 / 错误
+
+宽固定 250px，右边框，`bg-muted/40`，内边距 16px。错误时居中错误栈。
+
+---
+
+## 5. 首页
+
+有项目时 **立刻 replace 导航** 到第一个项目的默认 Profile，用户几乎看不到首页内容。
+
+无项目时：
+
+```
+HomePage（满高）
+├── header 高 52px，底边框，左右 padding 20px，拖拽区
+│   ├── Folder 图标 16px muted
+│   └── "Home" semibold 14px
+├── 剩余高度居中 Empty
+│   ├── FolderPlus 图标
+│   ├── "No projects yet"
+│   └── "Create your first project from the sidebar to get started."
+└── TourOnboarding（无 React DOM）
+```
+
+新手引导：300ms 后用 driver.js 指向侧栏 `#add-project-button`。气泡在右侧、上对齐。标题 “Create your first project”，说明 “Click here to add a project folder and get started.” 只有关闭按钮。点加号会销毁引导。
+
+---
+
+## 6. Profile 工作区（主界面）
+
+### 6.1 谁在画这块 UI
+
+两条路径，外观必须一致：
+
+| 条件 | 谁渲染 ProfileLayout |
+|------|----------------------|
+| 该 Profile **没有任何** 终端标签和文件标签 | `ProjectDetailPage` 画空态 CTA |
+| 该 Profile **至少有一个** 标签 | `TerminalLayer` 用 absolute overlay 画完整工作区；`ProjectDetailPage` 返回 null |
+
+`TerminalLayer` 为 **每一个曾经开过标签的 Profile** 各挂一份 `ProfileLayout`，非当前路由的用 `display:none`。切项目/Profile 不卸载终端。
+
+无效 project/profile → 回默认 Profile 或 `/`。
+
+### 6.2 布局
+
+```
+ProfileLayout  竖向满高
+├── CommandPalette（始终挂着，关时不可见）
+├── 底边框
+│   └── ProjectTopBar  最小高 44px
+└── 横向 flex-1，min-width/height 0
+    ├── ProfileSidebar  默认 208px，可 180–560
+    └── 主列 flex-1
+        └── TerminalTabs
+            ├── 标签栏（终端标签 + 文件标签 + 新建）
+            ├── 文件查看器（仅文件标签激活时）
+            └── 终端层（永不卸载，文件标签激活时 display:none）
+```
+
+次级侧栏关时宽度动画到 0，`pointer-events:none`，`aria-hidden`。弹簧：stiffness 320, damping 34, mass 0.9。宽度存在 localStorage `file-tree-panel`。
+
+---
+
+## 7. 顶栏（ProjectTopBar）
+
+三区叠在同一条 **最小 44px** 高的条上，底对齐，左右 padding 16px，上 4px 下 6px，整条拖拽区。
+
+```
+[ 左：展开侧栏? + Files/Git/Notes ]     [ 绝对居中：项目名 + 分支 ]     [ 右：可配置控件 + 齿轮 ]
+```
+
+居中块 `pointer-events:none`，内部按钮再打开；左右各留 128px（`px-32`）以免和两侧重叠。
+
+### 7.1 左
+
+1. 应用侧栏折叠时：ghost icon 按钮，SidebarSimple，tooltip “Expand sidebar”
+2. **SidebarModeSwitch** — 高 28px 的三段 tab
+   - Files：FolderSimple 14px
+   - Git：GitBranch 14px + 可选 `+N` 绿 / `-M` 红
+   - Notes：Note 14px
+   - 只有图标，文字在 tooltip
+   - 侧栏关闭时三段都未选中
+   - **再点当前模式 = 关闭侧栏**；点其它模式 = 切模式并打开
+
+快捷键（仅当前 Profile）：`Cmd/Ctrl+E` 开关侧栏，`Cmd/Ctrl+G` 开 Git Diff 大对话框。
+
+### 7.2 中
+
+- **项目名** semibold，可点，tooltip 显示 worktree 绝对路径；点击在系统文件管理器中显示该目录
+- **分支**：Git 图标 + 名
+  - 默认 Profile：拉当前 git 分支；非活动 overlay 不拉
+  - 非默认 Profile：显示 `profile.branch_name`
+  - 点击打开 Switch Branch 对话框
+  - muted，hover 变主色
+
+### 7.3 右
+
+用户在设置 Top Bar 里配置的控件（只显示本机已安装的）：
+
+| id | 外观 | 行为 |
+|----|------|------|
+| `github-desktop` | GitHub 标 | 用 GitHub Desktop 打开当前 worktree |
+| `editor` | Code 标 | 用所选编辑器打开（VS Code / Cursor / Windsurf / Zed / Sublime） |
+| `terminal` | 终端窗标 | 用所选终端打开（Ghostty / iTerm2 / kitty / Warp） |
+| `pr-status` | PR 标 + 状态 | Checking / No PR / Open / Draft / Merged / Closed；tooltip 带号和标题 |
+
+最右固定 **齿轮** secondary icon，开 **项目设置对话框**（不是应用设置窗）。
+
+---
+
+## 8. 次级侧栏三模式
+
+右缘 8px resize，aria “Resize sidebar”，键盘 ±16 / Home / End。
+
+### 8.1 Files — 文件树
+
+Pierre FileTree，compact，完整图标，粘性文件夹，默认全收起。
+
+| 视觉 | 值 |
+|------|-----|
+| 字号 | 13px |
+| 缩进 | 12px / 级 |
+| 行左右 padding/margin | 4px |
+| 选中底 | `--muted` |
+| 外包 | `px-1.5 py-1` + 右边框 |
+| 打开动画 | 18ms，opacity + 左移 12px |
+
+**交互：**
+
+- 单击文件 → 在统一标签栏开文件标签
+- 单击目录 → 展开/折叠
+- 多选 / Cmd / Shift 点击不自动打开
+- 树内拖拽移动；拖到终端标签或终端区域会把路径写进 PTY
+- 内联重命名；新建草稿名硬编码 `"New File"` / `"New Folder"`（重名加数字）
+- Git 状态混进路径列表（未跟踪/改动的文件即使目录未扫到也会出现）
+
+**条目右键：** Open · Open in Default App · Reveal in Finder · Refresh · New File · New Folder · Rename · Copy Relative Path · Copy Absolute Path · Delete（红）
+
+**空白/根右键：** New File · New Folder · Refresh · Reveal in Finder · Copy Relative / Absolute Path（根）
+
+加载中树自身处理；路径错误时半透明错误字叠在树上（不挡操作）。
+
+### 8.2 Git — 紧凑变更面板
+
+```
+竖向满高
+├── ChangesFileList（可滚）
+│   └── sticky 头：全选 checkbox + "{n} changed file(s)" + 放大开 Diff 对话框
+│   └── 文件行：checkbox + 图标 + 名 + A/D/M/R 徽章 + discard
+└── CommitComposer（底，上边框，padding 10×8）
+    ├── 小写标题 COMMIT
+    ├── Summary 单行（高 28px）
+    ├── Description 多行（最小 4.5rem）
+    ├── "{included} of {total} files included" + All / None
+    ├── Commit 按钮（需有摘要且至少勾一个文件）
+    └── 若 ahead>0：Push 按钮 + 上传图标
+```
+
+空列表： “No changes detected”。双击文件打开大 Diff 并选中该文件。`Cmd/Ctrl+Enter` 提交。
+
+### 8.3 Notes
+
+懒加载 Markdown 编辑器，占满侧栏。占位 “Write notes for this profile…”。自动保存。状态徽章：Saving / Saved / Failed。失败 Toast “Notes save failed”。
+
+---
+
+## 9. 统一标签栏 + 终端 + 文件查看器
+
+### 9.1 标签栏
+
+一条横滚、底边框的 line tabs。每个 trigger `max-width: 14rem`（`max-w-56`），左对齐。
+
+**终端标签（左起）：**
+
+1. 图标 14px：标题含 claude/codex/gemini/kimi/cline/openclaw/opencode/qoder 则用对应彩色 SVG，否则 TerminalWindow
+2. 标题截断
+3. 运行/等待状态点；若只有 completed，点可点掉
+4. 关闭 X（16px 热区，12px 图标），`aria-label="Close {title}"`
+
+终端标签是文件树路径的 drop target。
+
+**文件标签（接在终端后面）：**
+
+1. 文件类型图标 14px
+2. 文件名截断
+3. 未保存：8px muted 圆点
+4. 关闭（脏则先弹确认）
+
+**最右：New Terminal**
+
+- 无模板：一个 `+ New Terminal` tab-looking 控件
+- 有模板：主按钮 + 右侧 caret 分裂按钮，菜单分 **Project Templates** / **Global Templates**
+  - 项目模板可显示相对 cwd 副文案
+  - 空提示去项目设置或应用设置加模板
+
+### 9.2 空终端 CTA（无任何标签时）
+
+居中 Empty：终端窗图标 + “No terminals open” + “Open a terminal to start working in this project.” + 同上的 New Terminal（可分裂）。分裂按钮 `aria-label` 硬编码 `"Choose template"`。
+
+### 9.3 终端本体
+
+每个会话一个 xterm.js，绝对铺满标签下区域。非活动：`visibility:hidden` + `pointer-events:none`。恢复中居中 Spinner。
+
+**必须遵守：** 不要因切标签卸载 xterm。WebKit 下字体测量必须用挂在 document 里的 canvas，否则半角字宽测错、右侧空一截。
+
+终端内：
+
+- 搜索条：右上绝对定位（`top/right: 12px`），半透明底、边框、阴影。输入宽 224px 高 28px + `n/m` 或 “No results” + 上/下/关。Esc 关，Enter 下一个，Shift+Enter 上一个。高亮：普通匹配褐底 `#5f4b16`，当前蓝 `#1f6feb`。
+- 点链接：确认框，说明可 Ctrl+点击跳过；显示 URL；Default Browser / Open With。
+- 点文件路径：在工作区内则开文件标签；歧义则选择列表；工作区外提示不能打开。
+- 主题 10 套：GitHub Dark/Light、Dracula、Ayu Dark/Light、Solarized Dark/Light、One Dark/Light。暗/亮模式可各选一套，或同步。
+
+全局（当前 Profile）：`Cmd+T` 新终端，`Cmd+W` 关当前终端。
+
+### 9.4 文件查看器
+
+按扩展名三条路：
+
+**A. 文本（非 md）— Monaco**
+
+- 满高，无 minimap，无 word wrap，padding 上下 12px
+- 字体 = 终端字体 + ligatures，字号 = 终端字号
+- 主题：终端主题名含 `light` 用 `light`，否则 `vs-dark`
+- TS/JS 诊断关闭
+- `Cmd/Ctrl+S` 保存（窗口级 + 编辑器命令）
+- 草稿 400ms 防抖；脏点在标签上
+
+**B. Markdown / MDX — Milkdown**
+
+顶工具条（`px-2 py-1`，xs 图标按钮）+ 编辑区。工具：段落/H1–H3、粗斜代码删、链接、列表、引用、代码块、表、分割线、保存。`/` 斜杠菜单（最小宽 180、最高 280）。代码块深色 `#282c34`，语言选择器 240px，预览最高 420px。保存徽章与 Notes 相同。
+
+**C. 二进制预览**
+
+顶条高 ≥36px，muted 底：文件名 + 右侧 “Preview” 或 “Office Preview”。
+
+- 图：棋盘透明底，contain
+- PDF / Office→PDF：白底 iframe
+- 压缩包：`ArchivePreviewTree`，统计硬编码 `"{n} files / {m} folders"`
+- 其它：“Preview unavailable”（硬编码）
+
+加载：高 128px 居中 Spinner。错误：居中 muted 消息。
+
+关脏文件：对话框 “Close Unsaved File?” + “{file} has unsaved changes…” + Cancel / Discard Changes（红）。
+
+---
+
+## 10. 命令面板（Cmd/Ctrl+K）
+
+仅当前活动 Profile。
+
+| 项 | 值 |
+|----|-----|
+| 遮罩 | 全屏 40% 黑，z 1400 |
+| 面板 | 顶距 72px，水平居中，宽 `min(100%, 40rem)`，最高 `100vh-96px` |
+| 圆角 | 8px |
+| 边框 | `--border` |
+| 背景 | `--popover` |
+
+结构：
+
+1. 底边框搜索行，`px-4 py-3`，无边框输入，16px，占位 “Search files by name…”
+2. 列表最高 60vh：每项 图标16 + 文件名 14px + 父路径 12px muted；选中 `bg-muted`
+3. 空：未输入 “Start typing…”；无结果 “No matching files found.”；错误显示消息
+
+打开后 focus + 全选。选中 Enter → 开文件标签并关面板。自管过滤关（`shouldFilter=false`），结果来自后端搜索。
+
+---
+
+## 11. Git 大对话框
+
+`Cmd+G` 或侧栏 Git 放大、或顶栏逻辑打开。
+
+```
+DialogContent  宽 min(88rem, 100vw-2rem)  高 min(82dvh, 56rem)  无默认关闭钮
+├── Header（底边框，px-4 py-2）
+│   ├── 左：Git 图标 + 分支名（缺省显示硬编码 "main"）
+│   ├── 中右：Unified / Split toggle
+│   └── 关 X
+└── 横向 flex-1
+    ├── 左栏约 360px
+    │   └── Tabs: Changes | History
+    │       ├── Changes：文件列表 + CommitComposer（与侧栏同构，更宽）
+    │       └── History：提交列表 → 点进后变该提交的文件列表 + Back
+    └── 右：Diff pane（Pierre diffs + Shiki，主题跟终端主题映射）
+```
+
+文件徽章：A / D / M / R。大 diff（超过阈值的行数）默认折叠，说明 “Large diff hidden by default”，按钮 “Load diff anyway”。重命名显示 Previous/Current path。图片 Before/After。二进制不可预览走 “Preview unavailable”。
+
+Review Queue：浮动按钮，收集 diff 评论，可复制/复制并清空。
+
+History 空：“No commits found”。无文件变更：“No file changes”。未选文件：“Select a file to view changes”。
+
+---
+
+## 12. 设置窗口（六个标签）
+
+顶：横向 TabsList，`margin: 20px 20px 0`，溢出横滚。每项 图标 + 字。默认 General（URL 无 `tab`）；其它写入 `?tab=`。
+
+内容区 `padding: 20px`，可滚。
+
+### 12.1 General
+
+单列 `max-w-md`，项间距 24px。
+
+1. **Language** — native select：English / 中文
+2. **Theme** — System / Light / Dark（应用 chrome，不是终端）
+3. **Border Radius** — 五档
+4. **Default Worktree Directory** — 输入，占位 `Default: ~/.2code/workspace`，可清空。说明：项目没设 `worktree_dir` 时新 Profile 用它；相对路径相对项目根
+5. **Debug Mode** — 横排：标题+说明 / Switch。说明 “Show backend log events in a floating panel.”
+6. **Performance Profiling** — 同上，写前后端 trace
+7. **Show Project Avatars** — 控制侧栏 16px 头像
+
+### 12.2 Terminal
+
+左列（`max-w-md`）+ 右列实时 `TerminalPreview`，间距 32px。
+
+左：终端主题（可预览 hover）、Default Shell（系统列表 + Custom 路径）、Font（系统字体，可 “Show all fonts”）、Font Size stepper。Shell/Font 加载失败：70px 高骨架或 InlineError。
+
+### 12.3 Terminal Templates
+
+`max-w-2xl`。全局模板列表：名、shell、cwd、命令（一行一条）。增删改。空：“No templates yet.”
+
+### 12.4 Notification
+
+总开关 “Enable Notifications” + 说明。Sound：系统音列表或 None；不可用时 “No system sounds”。Agent 等待会弹系统通知并按配置播放声音。
+
+### 12.5 Top Bar
+
+预览当前控件 + 可拖 “Available Controls”。提示 “Drag controls to reorder or move between areas.” Reset to Defaults。Editor / Terminal 应用下拉。检测中 “Detecting installed apps...”。空槽 “No controls in the top bar…”
+
+控件显示名：GitHub Desktop、Editor、Terminal、Pull Request。编辑器/终端选项见 `messages/en.json` 的 `topbar*`。
+
+### 12.6 About
+
+应用图标、描述 “The Vibe Coding Workstation — …”、可点复制的 Version 徽章、维护者 AkaraChen（头像+主维护说明）、Repository / Releases / Website 外链。更新卡片：Check for Updates、Accept Beta Updates 开关、有更新则 Install {version}。状态文案见 i18n `update*`。
+
+---
+
+## 13. 全部对话框目录
+
+凡未写尺寸的，都用 §3.5 标准小对话框。
+
+### 13.1 Create Project
+
+触发：侧栏 `+`。
+
+- 标题：FolderPlus + “Create Project”
+- **未选文件夹：** 虚线大按钮，Folder 24px + “Choose Folder”，hover muted
+- **已选：** 上 “Folder” + xs “Choose Folder” 铅笔；下 code 块显示路径
+- Project Name 输入，占位 “Optional. Leave empty to use folder name”
+- 说明随状态变三条 hint（先选文件夹 / 只用文件夹名 / 自定义名）
+- Footer：Cancel / Create（无文件夹或进行中禁用；进行中出 Spinner）
+- 选文件夹用系统目录对话框；若名为空则填 basename
+- 成功关窗并导航到新项目第一个 Profile
+- Enter 在名称框提交
+
+### 13.2 Delete Project
+
+触发：项目右键。
+
+- Trash + “Delete Project”
+- “Are you sure you want to delete this project? This action cannot be undone.”
+- Cancel / Delete（红，进行中 Spinner）
+- 若删的是当前项目：跳到列表里相邻项目的默认 Profile，否则回 `/`
+
+### 13.3 Rename Project
+
+触发：项目右键。打开时 focus 输入。
+
+- Pencil + “Rename”
+- “New Name”
+- Cancel / Rename（空或未改禁用）
+
+### 13.4 Project Settings
+
+触发：项目右键或顶栏齿轮。
+
+- Gear + “Project Settings”
+- 内 Tabs：**Scripts**（Code 图标）/ **Templates**（终端窗图标）
+- Scripts：Worktree Directory + Init / Setup / Teardown 三个等宽 textarea（4 行，占位 “One command per line…”）
+- Templates：项目级终端模板编辑器（与全局同构）
+- Cancel / Save（进行中 Spinner）
+- 加载失败：DialogBodyError
+
+### 13.5 Create Profile
+
+触发：项目行 `+` 或子列表 “New Profile”。
+
+- GitBranch + “New Profile”
+- Branch Name，占位说明可留空自动生成 `pr/tokyo-a1b2c3d4` 这类名
+- Cancel / Create → 导航到新 Profile
+
+### 13.6 Delete Profile
+
+触发：非默认 Profile 右键。
+
+- Trash + “Delete Profile”
+- 确认 worktree 会删
+- 检查中：Spinner + “Checking this profile's Git status…”
+- 有风险：Alert “Check Git changes before deleting” + 未提交/未推送/合计 diff 数字
+- 检查失败：另一 Alert，请手动确认
+- 主按钮在有风险时改成 “Delete Anyway”
+- 删当前 Profile 则回默认/其它 Profile 或 `/`
+
+### 13.7 Close Unsaved File
+
+- Warning + “Close Unsaved File?”
+- “{file} has unsaved changes. Closing it will discard those changes.”
+- Cancel / Discard Changes（红）
+
+### 13.8 Switch Branch
+
+- GitBranch + “Switch branch”
+- 搜索框 “Search branches…”
+- 列表行：图标 + 名 + 徽章 current/trunk/used + ↑ahead ↓behind
+- current / used 禁用；used 琥珀徽章（已被其它 Profile 占用）
+- 当前行 muted 底；其它 hover
+- 空：“No branches found”
+- 成功 Toast “Switched to {branch}”；失败 “Checkout failed”
+
+### 13.9 终端相关
+
+- Open Link 确认
+- Choose File（歧义路径）
+- 模板草稿编辑（名、shell、cwd、命令）
+
+### 13.10 Git Review Queue
+
+从 Diff 对话框打开。标题 “Review Queue”。复制 / 复制并清空。Toast “Review comments copied”。
+
+### 13.11 Debug Log
+
+设置里打开 Debug Mode 后，主窗右下 **扳手圆钮**（`fixed right-16 bottom-4 z-50`）。点开日志对话框：搜索 “Search logs...”、Clear、自动滚、空 “No log entries yet”。`Cmd/Ctrl+Shift+D` 切换面板。
+
+---
+
+## 14. 叠加层与全局反馈
+
+| 层 | z / 位置 | 内容 |
+|----|----------|------|
+| 命令面板遮罩 | 1400 | 40% 黑 |
+| 命令面板 | 1401 | 见 §10 |
+| 对话框 | 50 | 见 §3.5 |
+| 菜单/tooltip | popover | 圆角 8、阴影、细环 |
+| Toast | Sonner 默认 | 见 §3.6 |
+| 调试 FAB | 50，右下偏左 | 仅 debug 开 |
+| 新手引导 | driver.js | 见 §5 |
+| 启动更新 | Toast 12s | 见 §2.4 |
+
+侧栏 Home 的 onboarding 锚在 `#add-project-button`，不在 Home DOM 里。
+
+---
+
+## 15. 键盘一览
+
+| 快捷键 | 范围 | 动作 |
+|--------|------|------|
+| `Cmd/Ctrl+,` | 全局 | 开设置窗 |
+| `Cmd/Ctrl+Shift+D` | 全局 | 开/关调试面板 |
+| `Cmd/Ctrl+K` | 活动 Profile | 命令面板 |
+| `Cmd/Ctrl+T` | 活动 Profile | 新终端 |
+| `Cmd/Ctrl+W` | 活动 Profile | 关当前终端 |
+| `Cmd/Ctrl+E` | 活动 Profile | 开关次级侧栏 |
+| `Cmd/Ctrl+G` | 活动 Profile | 开 Git Diff |
+| `Cmd/Ctrl+S` | 文件查看器可见 | 保存 |
+| `Cmd/Ctrl+Enter` | Commit 摘要/正文 | 提交 |
+| `Enter` / `Shift+Enter` | 终端搜索 | 下/上一个匹配 |
+| `Esc` | 搜索/多数对话框 | 关闭 |
+| `↑` `↓` | 应用侧栏 | 项目/Profile 间移动焦点 |
+| `←` `→` / Home / End | resize 热区 | 调宽度 |
+| `Enter` / `Space` | 分组/部分动作 | 切换 |
+
+macOS 用 Meta，其它用 Ctrl。TerminalLayer 的 T/W 当前实现检查 `metaKey`（macOS 路径）。
+
+---
+
+## 16. 平台差异（必须实现）
+
+| | macOS | Windows | Linux |
+|--|-------|---------|-------|
+| 标题栏 | Overlay + 红绿灯 (16,24) | Overlay + 自定义 min/max/close | Overlay，无自定义按钮 |
+| 侧栏 header padding-top | 32px | 8px | 8px |
+| 侧栏折叠后顶栏 padding-left | 84px | 正常 | 正常 |
+| 顶栏 padding-right | 20px | 118px | 20px |
+| Reveal 文案 | “Reveal in Finder” | 同一 i18n key，实现应走系统文件管理器 | 同左 |
+| 字体列表 | core-text | fontdb | fontdb |
+| 系统音 | /System/Library/Sounds + afplay | C:\Windows\Media + PowerShell | XDG + 桌面播放器 |
+| 顶栏外开 App | 探测本机已装的编辑器/终端/GitHub Desktop | 同 | 同 |
+
+---
+
+## 17. 持久化（影响 UI 还原）
+
+| Store / key | 影响的 UI |
+|-------------|-----------|
+| `app-sidebar-width` | 侧栏宽、折叠、分组折叠 |
+| `file-tree-panel` | 次级侧栏宽 |
+| themeStore | 亮/暗/系统 |
+| terminalSettingsStore | 字体、字号、主题、shell |
+| notificationStore | 通知开关、声音 |
+| sidebarSettingsStore | 是否显示项目头像 |
+| topbar store | 控件顺序、编辑器/终端选择 |
+| updater settings | 是否收 beta |
+| debugStore | 调试是否启用（FAB 显隐） |
+| locale | en / zh |
+
+设置窗与主窗必须共用这些值（跨窗 sync）。
+
+---
+
+## 18. 硬编码、未走 i18n 的字（重写时建议补）
+
+| 位置 | 字符串 |
+|------|--------|
+| 侧栏品牌 | `2Code` |
+| 应用侧栏 resize aria | `Resize sidebar`（次级侧栏已 i18n） |
+| 模板分裂按钮 | `Choose template` |
+| Git Diff 关 | `Close` |
+| Git 无分支时 | `main` |
+| 文件树草稿名 | `New File` / `New Folder` |
+| 预览失败 | `Preview unavailable` |
+| 预览条 | `Preview` / `Office Preview` |
+| 压缩包统计 | `{n} files / {m} folders` |
+| 完成点 | `Dismiss completion notification` |
+| 关标签 | `Close {title}` |
+| Windows 按钮 | Minimize / Restore / Maximize / Close |
+| 设置窗 title | `Settings` |
+| 链接占位 | `https://` |
+| About 作者 | `AkaraChen`、仓库 URL |
+
+中文包在 `messages/zh.json`，key 与 `en.json` 对齐。重写时不要把英文写死进布局，除上表。
+
+---
+
+## 19. 完整组件树（实现对照）
+
+```
+[主窗口]
+App
+├── StartupUpdateCheck
+├── AppSidebar
+│   ├── Header: "2Code" + collapse
+│   ├── Home? | Pinned[] | Projects[ Group | Project ]
+│   │   └── Project
+│   │       ├── Avatar + name + (+|caret|agent-dot)
+│   │       ├── context: group / settings / rename / delete
+│   │       └── sub: Default, Profile…, New Profile
+│   ├── Footer: Settings
+│   ├── resize
+│   └── CreateProjectDialog
+├── main
+│   ├── HomePage | (empty ProjectDetailPage)
+│   └── TerminalLayer
+│       └── per profile (display none unless active)
+│           └── ProfileLayout
+│               ├── CommandPalette
+│               ├── ProjectTopBar
+│               │   ├── expand sidebar?
+│               │   ├── Files | Git+stats | Notes
+│               │   ├── project name + branch → SwitchBranchDialog
+│               │   ├── topbar controls + project settings
+│               │   └── GitDiffDialog
+│               ├── ProfileSidebar
+│               │   ├── FileTreePanel
+│               │   ├── SidebarGitPanel → CommitComposer + ChangesFileList
+│               │   └── ProfileNotesEditor → MarkdownEditor
+│               └── TerminalTabs
+│                   ├── terminal tabs + file tabs + New Terminal menu
+│                   ├── FileViewerPane (Monaco | Markdown | preview)
+│                   ├── Terminal… (xterm, search, link dialogs)
+│                   └── UnsavedFileCloseDialog
+├── DebugFloat → DebugLogDialog
+└── WindowControls?
+
+[设置窗口]
+SettingsWindow → SettingsPage
+├── General | Terminal+Preview | Templates | Notification | Top Bar | About
+```
+
+---
+
+## 20. 重写验收清单
+
+做完新 UI 后，对照下列是否 **看起来和用起来** 一样（不必同技术栈）：
+
+1. 冷启动无项目：左栏只有 Home + Settings，右栏 Home 空态，引导指向 `+`。
+2. 建项目：虚线选文件夹 → 命名 → 进入默认 Profile 空终端 CTA。
+3. 开终端：标签出现，xterm 铺满；再开一个；切换不丢滚动/进程。
+4. 切到另一 Profile 再切回：终端还在。
+5. 文件树开文件：标签出现；md 走工具条编辑器；图走棋盘预览；脏点；关时确认。
+6. Cmd+K 搜文件打开。
+7. 次级侧栏 Files/Git/Notes 切换，Git 显示 +/-，Notes 能写能存。
+8. Cmd+G 大 Diff：Changes 提交/推送，History 看提交，Unified/Split。
+9. 顶栏点项目名开 Finder；点分支切换；齿轮开项目脚本/模板。
+10. 侧栏钉选、分组、拖拽排序、折叠整栏、拖宽。
+11. Cmd+, 独立设置窗；改主题/字体/圆角/头像，主窗立刻变。
+12. Debug 开后右下扳手出日志。
+13. 有更新时 Toast 12s，动作进 About。
+14. Windows 右上三按钮可用；macOS 红绿灯不被标题挡住。
+15. 中英切换，布局不碎。
+
+---
+
+## 21. 附录索引
+
+需要像素级 className、token 表、完整 i18n key 列表时打开：
+
+1. [sidebar-ui-inventory.md](./sidebar-ui-inventory.md)
+2. [ui-inventory-home-project.md](./ui-inventory-home-project.md)
+3. [ui-inventory-settings-terminal-git-debug-updater.md](./ui-inventory-settings-terminal-git-debug-updater.md)
+4. 文案源：[`messages/en.json`](../messages/en.json) / [`messages/zh.json`](../messages/zh.json)
+5. 颜色与全局 CSS：[`src/app.css`](../src/app.css)
+6. 窗口配置：[`src-tauri/tauri.conf.json`](../src-tauri/tauri.conf.json)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this is

A framework-agnostic inventory of **every visible 2code UI surface**, written so a later rewrite can rebuild the same product without the current React / Tailwind / shadcn stack.

## Documents

| File | Role |
|------|------|
| [`docs/ui-inventory.md`](docs/ui-inventory.md) | **Master rewrite spec** (Chinese): windows, chrome, design tokens, every screen tree, dialogs, shortcuts, platform diffs, acceptance checklist |
| [`docs/sidebar-ui-inventory.md`](docs/sidebar-ui-inventory.md) | Pixel-level appendix: app sidebar + profile sidebar |
| [`docs/ui-inventory-home-project.md`](docs/ui-inventory-home-project.md) | Pixel-level appendix: home, file tree, viewer, command palette, project/profile dialogs |
| [`docs/ui-inventory-settings-terminal-git-debug-updater.md`](docs/ui-inventory-settings-terminal-git-debug-updater.md) | Pixel-level appendix: settings window, terminal, git, debug, updater |
| [`docs/README.md`](docs/README.md) | Index updated |

## Coverage

- Two windows (main overlay chrome + Settings 880×640)
- App sidebar (pin, groups, reorder DnD, avatars, agent dots)
- Home empty state + onboarding tour
- Profile workspace: top bar, Files/Git/Notes sidebar, unified tabs
- Terminal (never-unmount contract), file viewer (Monaco / Markdown / binary)
- Git compact panel + large diff dialog
- All dialogs, command palette, toasts, debug FAB, updater toast
- Keyboard, platform chrome (macOS traffic lights / Windows custom buttons)
- Hardcoded non-i18n strings and rewrite invariants

No application code changed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1b936e8b-f2ad-4650-a132-63ddb856ee3c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1b936e8b-f2ad-4650-a132-63ddb856ee3c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

